### PR TITLE
feat: allow HealthAddress to be set via options callback

### DIFF
--- a/Quilt4Net.Toolkit.Tests/HealthRegistrationTests.cs
+++ b/Quilt4Net.Toolkit.Tests/HealthRegistrationTests.cs
@@ -1,0 +1,72 @@
+using FluentAssertions;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Quilt4Net.Toolkit.Features.Health;
+using Xunit;
+
+namespace Quilt4Net.Toolkit.Tests;
+
+public class HealthRegistrationTests
+{
+    [Fact]
+    public void Callback_can_set_HealthAddress_when_config_is_missing()
+    {
+        var services = new ServiceCollection();
+        var configuration = new ConfigurationBuilder().Build();
+
+        services.AddQuilt4NetHealthClient(configuration, o => o.HealthAddress = "https://example.com/health");
+
+        var provider = services.BuildServiceProvider();
+        var options = provider.GetRequiredService<IOptions<HealthClientOptions>>();
+        options.Value.HealthAddress.Should().Be("https://example.com/health");
+    }
+
+    [Fact]
+    public void Callback_can_override_HealthAddress_from_config()
+    {
+        var services = new ServiceCollection();
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string>
+            {
+                ["Quilt4Net:HealthClient:HealthAddress"] = "https://from-config.com/health"
+            })
+            .Build();
+
+        services.AddQuilt4NetHealthClient(configuration, o => o.HealthAddress = "https://from-callback.com/health");
+
+        var provider = services.BuildServiceProvider();
+        var options = provider.GetRequiredService<IOptions<HealthClientOptions>>();
+        options.Value.HealthAddress.Should().Be("https://from-callback.com/health");
+    }
+
+    [Fact]
+    public void Throws_when_neither_config_nor_callback_provides_address()
+    {
+        var services = new ServiceCollection();
+        var configuration = new ConfigurationBuilder().Build();
+
+        var act = () => services.AddQuilt4NetHealthClient(configuration);
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*HealthClient*");
+    }
+
+    [Fact]
+    public void Uses_config_value_when_no_callback_is_provided()
+    {
+        var services = new ServiceCollection();
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string>
+            {
+                ["Quilt4Net:HealthClient:HealthAddress"] = "https://from-config.com/health"
+            })
+            .Build();
+
+        services.AddQuilt4NetHealthClient(configuration);
+
+        var provider = services.BuildServiceProvider();
+        var options = provider.GetRequiredService<IOptions<HealthClientOptions>>();
+        options.Value.HealthAddress.Should().Be("https://from-config.com/health");
+    }
+}

--- a/Quilt4Net.Toolkit/HealthRegistration.cs
+++ b/Quilt4Net.Toolkit/HealthRegistration.cs
@@ -30,10 +30,16 @@ public static class HealthRegistration
         var config = configuration?.GetSection("Quilt4Net:HealthClient").Get<HealthClientOptions>();
         var o = new HealthClientOptions
         {
-            HealthAddress = config?.HealthAddress.NullIfEmpty() ?? throw new InvalidOperationException($"No address for {nameof(HealthClient)} has been configured.")
+            HealthAddress = config?.HealthAddress.NullIfEmpty()
         };
 
         options?.Invoke(o);
+
+        if (string.IsNullOrEmpty(o.HealthAddress))
+        {
+            throw new InvalidOperationException($"No address for {nameof(HealthClient)} has been configured.");
+        }
+
         services.AddSingleton(Options.Create(o));
 
         services.AddTransient<IHealthClient, HealthClient>();


### PR DESCRIPTION
Move the options callback invocation before the null check in AddQuilt4NetHealthClient so consumers can set HealthAddress programmatically when the config section is missing.