### PR TITLE
Hotfix 0.6.18: revert Health AI to 2.23.0 + accumulated develop work

### DIFF
--- a/Quilt4Net.Toolkit.Health/Quilt4Net.Toolkit.Health.csproj
+++ b/Quilt4Net.Toolkit.Health/Quilt4Net.Toolkit.Health.csproj
@@ -40,7 +40,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-	  <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="3.1.0" />
+	  <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.23.0" />
 	  <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.202">
 		  <PrivateAssets>all</PrivateAssets>
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Quilt4Net.Toolkit.Tests/AssemblyScanTests.cs
+++ b/Quilt4Net.Toolkit.Tests/AssemblyScanTests.cs
@@ -1,0 +1,17 @@
+using FluentAssertions;
+using Xunit;
+
+namespace Quilt4Net.Toolkit.Tests;
+
+public class AssemblyScanTests
+{
+    // Guardrail: reproduces what any assembly-scanner (e.g. Tharga.Cache) does.
+    // Regressed in 0.6.17 when Quilt4Net.Toolkit.Health bumped AI to 3.x and the
+    // unified resolve removed ITelemetryInitializer from under Quilt4NetTelemetryInitializer.
+    [Fact]
+    public void Quilt4NetToolkit_CanEnumerateTypes()
+    {
+        var types = typeof(Quilt4Net.Toolkit.LoggingRegistration).Assembly.GetTypes();
+        types.Should().NotBeEmpty();
+    }
+}

--- a/Quilt4Net.Toolkit/Features/ApplicationInsights/ApplicationInsightsService.cs
+++ b/Quilt4Net.Toolkit/Features/ApplicationInsights/ApplicationInsightsService.cs
@@ -631,7 +631,7 @@ AppRequests
         var binary = (BinaryData)row[rawIndex]!;
         var json = binary.ToString();
 
-        var rawNullable = JsonSerializer.Deserialize<Dictionary<string, object?>>(
+        var rawNullable = JsonSerializer.Deserialize<Dictionary<string, object>>(
             json,
             new JsonSerializerOptions
             {

--- a/Quilt4Net.Toolkit/Features/Health/Metrics/Storage/StorageMetricsService.cs
+++ b/Quilt4Net.Toolkit/Features/Health/Metrics/Storage/StorageMetricsService.cs
@@ -72,8 +72,7 @@ internal class StorageMetricsService : IStorageMetricsService
 
     static StorageDeviceType GetWindowsStorageType(DriveInfo drive)
     {
-        using var searcher = new ManagementObjectSearcher(
-            $"SELECT * FROM Win32_LogicalDisk WHERE DeviceID = '{drive.Name.TrimEnd('\\')}'");
+        using var searcher = new ManagementObjectSearcher($"SELECT * FROM Win32_LogicalDisk WHERE DeviceID = '{drive.Name.TrimEnd('\\')}'");
 
         foreach (var disk in searcher.Get())
         {


### PR DESCRIPTION
## Summary

**Headline fix (0.6.18 hotfix):**
- Revert `Microsoft.ApplicationInsights.AspNetCore` in `Quilt4Net.Toolkit.Health` from 3.1.0 → 2.23.0. In 0.6.17 the AI bump caused NuGet to unify AI up to 3.x in consumers, where the classic extensibility model (`ITelemetryInitializer`, `ITelemetryProcessor`) is gone — `Quilt4NetTelemetryInitializer` failed to load and any consumer calling `Assembly.GetTypes()` (e.g. Tharga.Cache) crashed on startup.
- New guardrail test `AssemblyScanTests.Quilt4NetToolkit_CanEnumerateTypes` reproduces the assembly-scan that regressed and would have caught this before 0.6.17 shipped.
- Proper AI 3.x port tracked separately for 0.7.0 (OpenTelemetry processor, breaking change).

**Also bundles accumulated develop work since the last merge to master:**
- CI/CD: GitHub Actions workflow (build + security + release + prerelease) with warning ratchet
- CI: drop auto-commit of lowered warning baseline (branch protection incompatibility)
- fix: `Certificatehelper` skips non-HTTPS URIs instead of throwing
- feat: `RemoteConfigurationService` — new `GetAsync` / `SetAsync` surface (old methods obsoleted, kept working)
- chore: move sample ApiKey + AppInsights connection strings to user-secrets
- chore: various nuget package updates, warning cleanup, sample appsettings improvements

## Test plan
- [x] `Quilt4Net.Toolkit.Tests` — 34 pass (includes new `Quilt4NetToolkit_CanEnumerateTypes`)
- [x] `Quilt4Net.Toolkit.Health.Tests` — 48 pass
- [x] Local build: 79 warnings, 0 errors (well under baseline 248)
- [ ] CI green on this PR
- [ ] After merge: verify 0.6.18 publishes to NuGet; smoke-test Tharga.Cache + Quilt4Net.Toolkit integration