### PR TITLE
feat: friendly fallback for Application Insights query failures

### DIFF
--- a/Quilt4Net.Toolkit.Blazor/Features/Log/ApplicationInsightsErrorMessage.cs
+++ b/Quilt4Net.Toolkit.Blazor/Features/Log/ApplicationInsightsErrorMessage.cs
@@ -1,0 +1,25 @@
+namespace Quilt4Net.Toolkit.Blazor.Features.Log;
+
+internal static class ApplicationInsightsErrorMessage
+{
+    public static string Format(string prefix, Exception ex)
+    {
+        if (IsAuthenticationFailure(ex))
+        {
+            return $"{prefix} Application Insights authentication failed — the configured TenantId, WorkspaceId, ClientId or ClientSecret may be incorrect, the secret may have expired, or the service principal may not have access to the workspace. Verify the Application Insights settings.";
+        }
+
+        return $"{prefix} {ex.Message}";
+    }
+
+    private static bool IsAuthenticationFailure(Exception ex)
+    {
+        for (var current = ex; current != null; current = current.InnerException)
+        {
+            if (current.GetType().FullName == "Azure.Identity.AuthenticationFailedException") return true;
+            if (current.Message?.Contains("AADSTS", StringComparison.Ordinal) == true) return true;
+            if (current.Message?.Contains("ClientSecretCredential", StringComparison.Ordinal) == true) return true;
+        }
+        return false;
+    }
+}

--- a/Quilt4Net.Toolkit.Blazor/Features/Log/LogEnvironmentSelector.razor
+++ b/Quilt4Net.Toolkit.Blazor/Features/Log/LogEnvironmentSelector.razor
@@ -3,7 +3,11 @@
 @inject IHostEnvironment HostEnvironment
 @inject IApplicationInsightsService ApplicationInsightsService
 
-@if (_environments == null)
+@if (_loadError != null)
+{
+    <RadzenAlert AlertStyle="AlertStyle.Warning" Shade="Shade.Lighter" AllowClose="false">@_loadError</RadzenAlert>
+}
+else if (_environments == null)
 {
     <Loading Size="ProgressBarCircularSize.Small" />
 }
@@ -24,6 +28,7 @@ else
     private EnvironmentOption[] _environments;
     private IApplicationInsightsContext _loadedContext;
     private EnvironmentOption _firedContext;
+    private string _loadError;
 
     [Parameter]
     public EventCallback<EnvironmentOption> OnSelected { get; set; }
@@ -36,17 +41,26 @@ else
         if (_environments == null || !Equals(_loadedContext, Context))
         {
             _loadedContext = Context;
+            _loadError = null;
 
-            var environments = await ApplicationInsightsService.GetEnvironments(_loadedContext).ToArrayAsync();
+            try
+            {
+                var environments = await ApplicationInsightsService.GetEnvironments(_loadedContext).ToArrayAsync();
 
-            _environments = environments.Select(x => new EnvironmentOption(x)).ToArray();
+                _environments = environments.Select(x => new EnvironmentOption(x)).ToArray();
 
-            var current = _environments.FirstOrDefault(x => x.Value == HostEnvironment.EnvironmentName)
-                          ?? _environments.FirstOrDefault()
-                          ?? new EnvironmentOption(null, "Any!");
-            _selectedEnvironment = current;
+                var current = _environments.FirstOrDefault(x => x.Value == HostEnvironment.EnvironmentName)
+                              ?? _environments.FirstOrDefault()
+                              ?? new EnvironmentOption(null, "Any!");
+                _selectedEnvironment = current;
 
-            await OnChange(current);
+                await OnChange(current);
+            }
+            catch (Exception ex)
+            {
+                _loadError = ApplicationInsightsErrorMessage.Format("Could not load Application Insights environments.", ex);
+                _environments = Array.Empty<EnvironmentOption>();
+            }
         }
 
         await base.OnParametersSetAsync();

--- a/Quilt4Net.Toolkit.Blazor/Features/Log/LogView.razor
+++ b/Quilt4Net.Toolkit.Blazor/Features/Log/LogView.razor
@@ -1,3 +1,4 @@
+@using Microsoft.AspNetCore.Components.Web
 @using Microsoft.Extensions.DependencyInjection
 @using Microsoft.Extensions.Options
 @using Quilt4Net.Toolkit.Features.ApplicationInsights
@@ -29,25 +30,34 @@
         </RadzenColumn>
     </RadzenRow>
 
-    <RadzenTabs SelectedIndex="@_tabIndex" Change="@OnTabChange">
-        <Tabs>
-            <RadzenTabsItem Text="Search">
-                <LogSearchView Range="@RangeToUse" Environment="@EnvironmentToUse" Context="Context" />
-            </RadzenTabsItem>
-            <RadzenTabsItem Text="Summary">
-                <LogSummaryListView Range="@RangeToUse" Environment="@EnvironmentToUse" Context="Context" />
-            </RadzenTabsItem>
-            <RadzenTabsItem Text="Measure">
-                <LogMeasureView Range="@RangeToUse" Environment="@EnvironmentToUse" Context="Context" />
-            </RadzenTabsItem>
-            <RadzenTabsItem Text="Count">
-                <LogCountView Range="@RangeToUse" Environment="@EnvironmentToUse" Context="Context" />
-            </RadzenTabsItem>
-            <RadzenTabsItem Text="Trigger" Visible="@(Context == null)">
-                <LogTriggerView Context="Context" />
-            </RadzenTabsItem>
-        </Tabs>
-    </RadzenTabs>
+    <ErrorBoundary @ref="_errorBoundary">
+        <ChildContent>
+            <RadzenTabs SelectedIndex="@_tabIndex" Change="@OnTabChange">
+                <Tabs>
+                    <RadzenTabsItem Text="Search">
+                        <LogSearchView Range="@RangeToUse" Environment="@EnvironmentToUse" Context="Context" />
+                    </RadzenTabsItem>
+                    <RadzenTabsItem Text="Summary">
+                        <LogSummaryListView Range="@RangeToUse" Environment="@EnvironmentToUse" Context="Context" />
+                    </RadzenTabsItem>
+                    <RadzenTabsItem Text="Measure">
+                        <LogMeasureView Range="@RangeToUse" Environment="@EnvironmentToUse" Context="Context" />
+                    </RadzenTabsItem>
+                    <RadzenTabsItem Text="Count">
+                        <LogCountView Range="@RangeToUse" Environment="@EnvironmentToUse" Context="Context" />
+                    </RadzenTabsItem>
+                    <RadzenTabsItem Text="Trigger" Visible="@(Context == null)">
+                        <LogTriggerView Context="Context" />
+                    </RadzenTabsItem>
+                </Tabs>
+            </RadzenTabs>
+        </ChildContent>
+        <ErrorContent Context="ex">
+            <RadzenAlert AlertStyle="AlertStyle.Warning" Shade="Shade.Lighter" AllowClose="false">
+                @ApplicationInsightsErrorMessage.Format("Could not query Application Insights.", ex)
+            </RadzenAlert>
+        </ErrorContent>
+    </ErrorBoundary>
 </CascadingValue>
 
 @code {
@@ -58,6 +68,7 @@
     private LogNavigationOptions _navOptions;
     private int _tabIndex;
     private string _configError;
+    private ErrorBoundary _errorBoundary;
 
     [Parameter]
     public bool ShowRangeSelector { get; set; } = true;
@@ -138,6 +149,8 @@
 
         var idx = Array.IndexOf(TabNames, Tab?.ToLower() ?? string.Empty);
         _tabIndex = idx >= 0 ? idx : 0;
+
+        _errorBoundary?.Recover();
     }
 
     private async Task OnTabChange(int index)


### PR DESCRIPTION
## Summary

When `LogView` or `LogEnvironmentSelector` hits a runtime error from Application Insights — most often an expired/rotated client secret (AADSTS7000215) — the unhandled exception used to crash the Blazor circuit. Now show a `RadzenAlert` with guidance instead.

Reproduces the situation seen on prod 2026-04-20 (CorrelationId `9cad001b-d3be-47bf-aa07-5a1c50346efe`) where the AppInsights service principal secret was rejected and crashed `/monitor/log`.

### Changes
- **`LogEnvironmentSelector`** — wraps `GetEnvironments(...)` in try/catch and renders an inline `RadzenAlert` on failure.
- **`LogView`** — wraps the tab content in `<ErrorBoundary>` with custom `<ErrorContent>` to catch failures from any sub-view (`LogSearchView`, `LogSummaryListView`, `LogMeasureView`, `LogCountView`, `LogTriggerView`). `_errorBoundary?.Recover()` on parameter changes so a fresh `Context` retries.
- **`ApplicationInsightsErrorMessage`** (new internal helper) — detects authentication failures by walking the inner exception chain for `Azure.Identity.AuthenticationFailedException`, `AADSTS`, or `ClientSecretCredential`, and produces tailored vs. generic guidance.

### User-facing messages
- **Auth failure:** *"Could not query Application Insights. Application Insights authentication failed — the configured TenantId, WorkspaceId, ClientId or ClientSecret may be incorrect, the secret may have expired, or the service principal may not have access to the workspace. Verify the Application Insights settings."*
- **Other errors:** *"Could not query Application Insights. {ex.Message}"*

Generic guidance — no consumer-specific links — so the same component works for Quilt4Net.Server, Florida, and any other Toolkit consumer regardless of where they keep config.

## Test plan
- [x] `Quilt4Net.Toolkit.Blazor` build clean (10 pre-existing warnings, 0 errors)
- [x] `Quilt4Net.Toolkit.Blazor.Tests` — 36/36 pass
- [ ] CI green on this PR
- [ ] After merge: smoke-test `/monitor/log` with a deliberately bad ClientSecret — should show the alert instead of crashing the circuit