### PR TITLE
feat: effective-application cache key for toggles + content, expose application on IQuilt4ContentService

### DIFF
--- a/Quilt4Net.Toolkit.Blazor/IQuilt4ContentService.cs
+++ b/Quilt4Net.Toolkit.Blazor/IQuilt4ContentService.cs
@@ -8,5 +8,15 @@ public interface IQuilt4ContentService
     /// <summary>
     /// Get content by key using the currently selected language.
     /// </summary>
-    Task<string> GetAsync(string key, string defaultValue);
+    /// <param name="key">Content key.</param>
+    /// <param name="defaultValue">Value to return if the server is unreachable or the key is unknown.</param>
+    /// <param name="application">
+    /// Application scope. Convention:
+    /// <list type="bullet">
+    /// <item><c>null</c> — default: resolve the current application name (ContentOptions.Application or the entry assembly name).</item>
+    /// <item><c>""</c> — shared (cross-application).</item>
+    /// <item>any other value — that exact application.</item>
+    /// </list>
+    /// </param>
+    Task<string> GetAsync(string key, string defaultValue, string application = null);
 }

--- a/Quilt4Net.Toolkit.Blazor/Quilt4ContentService.cs
+++ b/Quilt4Net.Toolkit.Blazor/Quilt4ContentService.cs
@@ -14,9 +14,9 @@ internal class Quilt4ContentService : IQuilt4ContentService
         _languageStateService = languageStateService;
     }
 
-    public async Task<string> GetAsync(string key, string defaultValue)
+    public async Task<string> GetAsync(string key, string defaultValue, string application = null)
     {
-        var result = await _contentService.GetContentAsync(key, defaultValue, _languageStateService.Selected.Key, ContentFormat.String);
+        var result = await _contentService.GetContentAsync(key, defaultValue, _languageStateService.Selected.Key, ContentFormat.String, application);
         return result.Value;
     }
 }

--- a/Quilt4Net.Toolkit.Tests/ContentTests.cs
+++ b/Quilt4Net.Toolkit.Tests/ContentTests.cs
@@ -1,0 +1,145 @@
+using System.Net;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Quilt4Net.Toolkit.Features.Content;
+using Quilt4Net.Toolkit.Features.FeatureToggle;
+using Quilt4Net.Toolkit.Framework;
+using Xunit;
+
+namespace Quilt4Net.Toolkit.Tests;
+
+public class ContentTests
+{
+    [Fact]
+    public async Task GetContentAsync_With_Explicit_Application_Sends_That_Value()
+    {
+        using var listener = StartListener(out var prefix, out var captured);
+
+        var service = BuildContentService(prefix);
+
+        await service.GetContentAsync("my-key", "default", Guid.NewGuid(), ContentFormat.String, application: "Yee");
+
+        captured.Should().ContainSingle();
+        captured[0].Should().Be("Yee");
+    }
+
+    [Fact]
+    public async Task GetContentAsync_With_Empty_Application_Sends_Empty_For_Shared()
+    {
+        using var listener = StartListener(out var prefix, out var captured);
+
+        var service = BuildContentService(prefix);
+
+        await service.GetContentAsync("my-key", "default", Guid.NewGuid(), ContentFormat.String, application: "");
+
+        captured.Should().ContainSingle();
+        captured[0].Should().Be("",
+            "empty string is the explicit 'shared' sentinel and must be forwarded as-is — the toolkit must not substitute a default");
+    }
+
+    [Fact]
+    public async Task GetContentAsync_With_Null_Application_Resolves_To_Non_Null_Value()
+    {
+        using var listener = StartListener(out var prefix, out var captured);
+
+        var service = BuildContentService(prefix);
+
+        await service.GetContentAsync("my-key", "default", Guid.NewGuid(), ContentFormat.String, application: null);
+
+        captured.Should().ContainSingle();
+        captured[0].Should().NotBeNullOrEmpty(
+            "null is 'default — toolkit resolves the current application name'. It must never be sent as null/empty; that would mean shared.");
+    }
+
+    [Fact]
+    public async Task GetContentAsync_Same_Key_Different_Application_Are_Separate_Cache_Entries()
+    {
+        using var listener = StartListener(out var prefix, out var captured);
+
+        var service = BuildContentService(prefix);
+        var languageKey = Guid.NewGuid();
+
+        await service.GetContentAsync("my-key", "default", languageKey, ContentFormat.String, application: "App1");
+        await service.GetContentAsync("my-key", "default", languageKey, ContentFormat.String, application: "App2");
+
+        captured.Should().BeEquivalentTo(["App1", "App2"],
+            "same key + language + different application must be separate cache entries — otherwise the second call silently returns the first call's value");
+    }
+
+    private static IContentService BuildContentService(string baseAddress)
+    {
+        var host = Host.CreateDefaultBuilder()
+            .ConfigureServices(services =>
+            {
+                services.AddQuilt4NetContent(null, o =>
+                {
+                    o.Quilt4NetAddress = baseAddress;
+                    o.ApiKey = "test-key";
+                });
+            })
+            .Build();
+
+        return host.Services.GetRequiredService<IContentService>();
+    }
+
+    private static HttpListener StartListener(out string prefix, out List<string> capturedApplications)
+    {
+        var port = GetFreePort();
+        prefix = $"http://127.0.0.1:{port}/";
+        var listener = new HttpListener();
+        listener.Prefixes.Add(prefix);
+        listener.Start();
+
+        var captured = new List<string>();
+        var captureLock = new object();
+        capturedApplications = captured;
+
+        _ = Task.Run(async () =>
+        {
+            while (listener.IsListening)
+            {
+                HttpListenerContext ctx;
+                try { ctx = await listener.GetContextAsync(); }
+                catch { return; }
+
+                // URL is /Api/Content/{base64(GetContentRequest)} — decode to capture the Application field.
+                var segments = ctx.Request.Url!.AbsolutePath.Split('/', StringSplitOptions.RemoveEmptyEntries);
+                if (segments.Length >= 3 && string.Equals(segments[0], "Api", StringComparison.OrdinalIgnoreCase)
+                    && string.Equals(segments[1], "Content", StringComparison.OrdinalIgnoreCase))
+                {
+                    var encoded = WebUtility.UrlDecode(segments[2]);
+                    var json = System.Text.Encoding.UTF8.GetString(Convert.FromBase64String(encoded));
+                    using var doc = System.Text.Json.JsonDocument.Parse(json);
+                    if (doc.RootElement.TryGetProperty("Application", out var appProp))
+                    {
+                        lock (captureLock)
+                        {
+                            captured.Add(appProp.ValueKind == System.Text.Json.JsonValueKind.Null
+                                ? null
+                                : appProp.GetString());
+                        }
+                    }
+                }
+
+                ctx.Response.StatusCode = 200;
+                ctx.Response.ContentType = "application/json";
+                var body = $$"""{"value":"server-value","validTo":"{{DateTime.UtcNow.AddHours(1):o}}"}""";
+                var buf = System.Text.Encoding.UTF8.GetBytes(body);
+                await ctx.Response.OutputStream.WriteAsync(buf);
+                ctx.Response.Close();
+            }
+        });
+
+        return listener;
+    }
+
+    private static int GetFreePort()
+    {
+        using var l = new System.Net.Sockets.TcpListener(IPAddress.Loopback, 0);
+        l.Start();
+        var port = ((IPEndPoint)l.LocalEndpoint).Port;
+        l.Stop();
+        return port;
+    }
+}

--- a/Quilt4Net.Toolkit.Tests/FeatureToggleTests.cs
+++ b/Quilt4Net.Toolkit.Tests/FeatureToggleTests.cs
@@ -2,6 +2,7 @@ using System.Net;
 using FluentAssertions;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Quilt4Net.Toolkit.Features.FeatureToggle;
 using Quilt4Net.Toolkit.Framework;
 using Xunit;
 
@@ -112,6 +113,81 @@ public class FeatureToggleTests
             var result = await service.GetToggleAsync("my-toggle", fallback: false);
 
             result.Should().BeFalse("fallback value should be returned when server returns 500");
+        }
+        finally
+        {
+            listener.Stop();
+        }
+    }
+
+    [Fact]
+    public async Task GetToggleAsync_Same_Key_Different_Application_Are_Separate_Cache_Entries()
+    {
+        // Arrange — local listener that counts requests and returns the request's
+        // base64-encoded complex key in the body so we can verify the second call
+        // actually hit the server (different application = different cache entry).
+        var port = GetFreePort();
+        var prefix = $"http://127.0.0.1:{port}/";
+        using var listener = new HttpListener();
+        listener.Prefixes.Add(prefix);
+        listener.Start();
+
+        var hits = 0;
+        var receivedApplications = new System.Collections.Concurrent.ConcurrentBag<string>();
+        var listenerTask = Task.Run(async () =>
+        {
+            while (listener.IsListening)
+            {
+                HttpListenerContext ctx;
+                try { ctx = await listener.GetContextAsync(); }
+                catch { return; }
+                Interlocked.Increment(ref hits);
+
+                // URL is /Api/Configuration/{base64(complexKey)} — decode the request to capture which Application was sent.
+                var segments = ctx.Request.Url!.AbsolutePath.Split('/', StringSplitOptions.RemoveEmptyEntries);
+                if (segments.Length >= 3)
+                {
+                    var encoded = WebUtility.UrlDecode(segments[2]);
+                    var json = System.Text.Encoding.UTF8.GetString(Convert.FromBase64String(encoded));
+                    using var doc = System.Text.Json.JsonDocument.Parse(json);
+                    if (doc.RootElement.TryGetProperty("Application", out var appProp))
+                        receivedApplications.Add(appProp.GetString());
+                }
+
+                ctx.Response.StatusCode = 200;
+                ctx.Response.ContentType = "application/json";
+                var body = $$"""{"value":"True","validTo":"{{DateTime.UtcNow.AddHours(1):o}}"}""";
+                var buf = System.Text.Encoding.UTF8.GetBytes(body);
+                await ctx.Response.OutputStream.WriteAsync(buf);
+                ctx.Response.Close();
+            }
+        });
+
+        try
+        {
+            var host = Host.CreateDefaultBuilder()
+                .ConfigureServices(services =>
+                {
+                    services.AddQuilt4NetRemoteConfiguration(null, o =>
+                    {
+                        o.Quilt4NetAddress = prefix;
+                        o.ApiKey = "test-key";
+                    });
+                })
+                .Build();
+
+            var service = host.Services.GetRequiredService<IRemoteConfigurationService>();
+
+            // Act — same key, two different applications
+            await service.GetAsync("my-toggle", false, application: "App1");
+            await service.GetAsync("my-toggle", false, application: "App2");
+
+            // Assert — both calls must hit the server because the cache key
+            // includes the effective application. With a key-only cache, the
+            // second call would silently return the first call's cached value.
+            hits.Should().Be(2,
+                "same toggle key with different application is a different cache entry — neither call may use the other's cached value");
+            receivedApplications.Should().BeEquivalentTo(["App1", "App2"]);
         }
         finally
         {

--- a/Quilt4Net.Toolkit/Features/Content/RemoteContentCallService.cs
+++ b/Quilt4Net.Toolkit/Features/Content/RemoteContentCallService.cs
@@ -40,7 +40,11 @@ internal class RemoteContentCallService : IRemoteContentCallService
         if (languageKey == Language.NoApiKeyLanguageKey || string.IsNullOrEmpty(_contentOptions.ApiKey)) return (defaultValue, false);
 
         var sw = Stopwatch.StartNew();
-        var cacheKey = $"{key}_{languageKey}";
+        // Resolve effective application up front so cache key + request share the same value.
+        // Convention: null -> lookup (options.Application or entry assembly name);
+        // "" stays as "" (shared); value forwarded as-is.
+        var effectiveApplication = ResolveApplication(application);
+        var cacheKey = BuildCacheKey(key, languageKey, effectiveApplication);
 
         try
         {
@@ -57,21 +61,21 @@ internal class RemoteContentCallService : IRemoteContentCallService
             // Stale-while-revalidate: return stale value immediately, refresh in background.
             if (cached != null)
             {
-                StartBackgroundRefresh(key, defaultValue, languageKey, contentType, application);
+                StartBackgroundRefresh(key, cacheKey, defaultValue, languageKey, contentType, effectiveApplication);
                 _logger.LogInformation("Content '{Key}' resolved in {Elapsed}ms. Source: StaleCache, Stale: true.",
                     key, sw.ElapsedMilliseconds);
                 return (cached.Value ?? defaultValue, true);
             }
 
             // No cache — must fetch with timeout.
-            return await FetchContentWithTimeout(key, defaultValue, languageKey, contentType, sw, application);
+            return await FetchContentWithTimeout(key, cacheKey, defaultValue, languageKey, contentType, sw, effectiveApplication);
         }
         catch (Exception e)
         {
             _localCache.TryGetValue(cacheKey, out var stale);
             var staleValue = stale?.Value ?? defaultValue;
             _logger.LogError(e, "{Message} Using stale cache or fallback for key {Key}.", e.Message, key);
-            CacheFailure(key, languageKey, staleValue);
+            CacheFailure(cacheKey, staleValue);
             _logger.LogInformation("Content '{Key}' resolved in {Elapsed}ms. Source: {Source}, Stale: true.",
                 key, sw.ElapsedMilliseconds, stale != null ? "StaleCache" : "Default");
             return (staleValue, false);
@@ -84,12 +88,12 @@ internal class RemoteContentCallService : IRemoteContentCallService
 
         try
         {
-            var assemblyName = application ?? _contentOptions.Application ?? Assembly.GetEntryAssembly()?.GetName()?.Name;
+            var effectiveApplication = ResolveApplication(application);
             var setContentRequest = new SetContentRequest
             {
                 Key = key,
                 LanguageKey = languageKey,
-                Application = assemblyName,
+                Application = effectiveApplication,
                 Environment = _environmentName.Name,
                 Instance = null, //_options.InstanceLoader?.Invoke(_serviceProvider),
                 Value = $"{value}",
@@ -101,7 +105,7 @@ internal class RemoteContentCallService : IRemoteContentCallService
             var response = await client.PostAsJsonAsync(address, setContentRequest);
             response.EnsureSuccessStatusCode();
 
-            _localCache.TryRemove($"{key}_{languageKey}", out _);
+            _localCache.TryRemove(BuildCacheKey(key, languageKey, effectiveApplication), out _);
 
             //TODO: Notify the user that this content will be updated after this long time on all clients, because of cache.
         }
@@ -157,16 +161,15 @@ internal class RemoteContentCallService : IRemoteContentCallService
         _localCache.Clear();
     }
 
-    private async Task<(string Value, bool Success)> FetchContentWithTimeout(string key, string defaultValue, Guid languageKey, ContentFormat? contentType, Stopwatch sw, string application = null)
+    private async Task<(string Value, bool Success)> FetchContentWithTimeout(string key, string cacheKey, string defaultValue, Guid languageKey, ContentFormat? contentType, Stopwatch sw, string effectiveApplication)
     {
         try
         {
-            var assemblyName = application ?? _contentOptions.Application ?? Assembly.GetEntryAssembly()?.GetName()?.Name;
             var request = new GetContentRequest
             {
                 Key = key,
                 LanguageKey = languageKey,
-                Application = assemblyName,
+                Application = effectiveApplication,
                 Environment = _environmentName.Name,
                 Instance = null,
                 DefaultValue = contentType == null ? null : $"{defaultValue}",
@@ -183,7 +186,7 @@ internal class RemoteContentCallService : IRemoteContentCallService
             {
                 _logger.LogError("Unable to get content for key '{Key}'. Response was {StatusCode} {ReasonPhrase}.",
                     key, response.StatusCode, response.ReasonPhrase);
-                CacheFailure(key, languageKey, defaultValue);
+                CacheFailure(cacheKey, defaultValue);
                 _logger.LogInformation("Content '{Key}' resolved in {Elapsed}ms. Source: Default, Stale: true.",
                     key, sw.ElapsedMilliseconds);
                 return (defaultValue, false);
@@ -191,7 +194,6 @@ internal class RemoteContentCallService : IRemoteContentCallService
 
             var result = await response.Content.ReadFromJsonAsync<GetContentResponse>(cancellationToken: cts.Token);
 
-            var cacheKey = $"{key}_{languageKey}";
             var interval = result.ValidTo - DateTime.UtcNow;
             if (interval > TimeSpan.Zero)
                 _lastKnownTtl[cacheKey] = interval;
@@ -206,7 +208,7 @@ internal class RemoteContentCallService : IRemoteContentCallService
         {
             _logger.LogWarning("HTTP request timed out for content '{Key}' after {Timeout}ms. Using default value.",
                 key, _contentOptions.HttpTimeout.TotalMilliseconds);
-            CacheFailure(key, languageKey, defaultValue);
+            CacheFailure(cacheKey, defaultValue);
             _logger.LogInformation("Content '{Key}' resolved in {Elapsed}ms. Source: Default, Stale: true.",
                 key, sw.ElapsedMilliseconds);
             return (defaultValue, false);
@@ -214,28 +216,26 @@ internal class RemoteContentCallService : IRemoteContentCallService
         catch (Exception e)
         {
             _logger.LogError(e, "{Message} Using default for content key {Key}.", e.Message, key);
-            CacheFailure(key, languageKey, defaultValue);
+            CacheFailure(cacheKey, defaultValue);
             _logger.LogInformation("Content '{Key}' resolved in {Elapsed}ms. Source: Default, Stale: true.",
                 key, sw.ElapsedMilliseconds);
             return (defaultValue, false);
         }
     }
 
-    private void StartBackgroundRefresh(string key, string defaultValue, Guid languageKey, ContentFormat? contentType, string application = null)
+    private void StartBackgroundRefresh(string key, string cacheKey, string defaultValue, Guid languageKey, ContentFormat? contentType, string effectiveApplication)
     {
-        var cacheKey = $"{key}_{languageKey}";
         if (!_refreshInProgress.TryAdd(cacheKey, true)) return;
 
         _ = Task.Run(async () =>
         {
             try
             {
-                var assemblyName = application ?? _contentOptions.Application ?? Assembly.GetEntryAssembly()?.GetName()?.Name;
                 var request = new GetContentRequest
                 {
                     Key = key,
                     LanguageKey = languageKey,
-                    Application = assemblyName,
+                    Application = effectiveApplication,
                     Environment = _environmentName.Name,
                     Instance = null,
                     DefaultValue = contentType == null ? null : $"{defaultValue}",
@@ -253,7 +253,7 @@ internal class RemoteContentCallService : IRemoteContentCallService
                     _logger.LogError("Background refresh for content '{Key}' failed. Response was {StatusCode} {ReasonPhrase}.",
                         key, response.StatusCode, response.ReasonPhrase);
                     var staleValue = _localCache.TryGetValue(cacheKey, out var s) ? s.Value : defaultValue;
-                    CacheFailure(key, languageKey, staleValue);
+                    CacheFailure(cacheKey, staleValue);
                     return;
                 }
 
@@ -272,13 +272,13 @@ internal class RemoteContentCallService : IRemoteContentCallService
                 _logger.LogWarning("Background refresh for content '{Key}' timed out after {Timeout}ms.",
                     key, _contentOptions.HttpTimeout.TotalMilliseconds);
                 var staleValue = _localCache.TryGetValue(cacheKey, out var s) ? s.Value : defaultValue;
-                CacheFailure(key, languageKey, staleValue);
+                CacheFailure(cacheKey, staleValue);
             }
             catch (Exception e)
             {
                 _logger.LogError(e, "Background refresh for content '{Key}' failed: {Message}.", key, e.Message);
                 var staleValue = _localCache.TryGetValue(cacheKey, out var s) ? s.Value : defaultValue;
-                CacheFailure(key, languageKey, staleValue);
+                CacheFailure(cacheKey, staleValue);
             }
             finally
             {
@@ -287,9 +287,8 @@ internal class RemoteContentCallService : IRemoteContentCallService
         });
     }
 
-    private void CacheFailure(string key, Guid languageKey, string value)
+    private void CacheFailure(string cacheKey, string value)
     {
-        var cacheKey = $"{key}_{languageKey}";
         var duration = _lastKnownTtl.GetValueOrDefault(cacheKey, _contentOptions.FailureCacheDuration);
         var failureResponse = new GetContentResponse
         {
@@ -297,6 +296,20 @@ internal class RemoteContentCallService : IRemoteContentCallService
             ValidTo = DateTime.UtcNow.Add(duration)
         };
         _localCache.AddOrUpdate(cacheKey, failureResponse, (_, _) => failureResponse);
+    }
+
+    private string ResolveApplication(string application)
+    {
+        // The convention: null is the "default" sentinel — toolkit looks up the application.
+        // "" is forwarded as-is (= shared). A non-empty value is forwarded as-is.
+        if (application != null) return application;
+        return _contentOptions.Application ?? Assembly.GetEntryAssembly()?.GetName()?.Name;
+    }
+
+    private static string BuildCacheKey(string key, Guid languageKey, string effectiveApplication)
+    {
+        // "" and null both mean "shared" so they collapse to the same cache slot.
+        return $"{key}_{languageKey}|{effectiveApplication ?? ""}";
     }
 
     private static string BuildKey(GetContentRequest request)

--- a/Quilt4Net.Toolkit/Features/FeatureToggle/RemoteConfigCallService.cs
+++ b/Quilt4Net.Toolkit/Features/FeatureToggle/RemoteConfigCallService.cs
@@ -34,12 +34,19 @@ internal class RemoteConfigCallService : IRemoteConfigCallService
         ttl ??= _options.Ttl;
         var sw = Stopwatch.StartNew();
 
+        // Resolve the effective application up front so the cache key, the
+        // outbound request and the background refresh all use the same value.
+        // Same toggle key with different applications is a different cache entry —
+        // otherwise the second call returns the first call's value silently.
+        var effectiveApplication = ResolveApplication(application);
+        var cacheKey = BuildCacheKey(key, effectiveApplication);
+
         try
         {
             var changeType = ((T)Convert.ChangeType($"{defaultValue}", typeof(T)));
             if (!$"{changeType}".Equals($"{defaultValue}")) throw new NotSupportedException($"Value of type {typeof(T).Name} is not supported.");
 
-            _localCache.TryGetValue(key, out var cached);
+            _localCache.TryGetValue(cacheKey, out var cached);
             var needRefresh = cached == null || DateTime.UtcNow > cached.ValidTo;
 
             if (!needRefresh)
@@ -54,7 +61,7 @@ internal class RemoteConfigCallService : IRemoteConfigCallService
             // and refresh in the background.
             if (cached != null)
             {
-                StartBackgroundRefresh(key, defaultValue, ttl, application);
+                StartBackgroundRefresh(key, cacheKey, defaultValue, ttl, effectiveApplication);
                 var staleValue = GetCachedOrDefault(cached, defaultValue);
                 _logger.LogInformation("Configuration '{Key}' resolved in {Elapsed}ms. Source: StaleCache, Stale: true, Value: '{Value}'.",
                     key, sw.ElapsedMilliseconds, staleValue);
@@ -62,14 +69,14 @@ internal class RemoteConfigCallService : IRemoteConfigCallService
             }
 
             // No cache at all — must fetch with timeout.
-            return await FetchWithTimeout(key, defaultValue, ttl, sw, application);
+            return await FetchWithTimeout(key, cacheKey, defaultValue, ttl, sw, effectiveApplication);
         }
         catch (Exception e)
         {
             _logger.LogError(e, "{Message} Using stale cache or fallback for key {Key}.", e.Message, key);
-            if (_localCache.TryGetValue(key, out var stale))
+            if (_localCache.TryGetValue(cacheKey, out var stale))
             {
-                CacheFailure(key, stale);
+                CacheFailure(cacheKey, stale);
                 var staleValue = GetCachedOrDefault(stale, defaultValue);
                 _logger.LogInformation("Configuration '{Key}' resolved in {Elapsed}ms. Source: StaleCache, Stale: true, Value: '{Value}'.",
                     key, sw.ElapsedMilliseconds, staleValue);
@@ -81,7 +88,7 @@ internal class RemoteConfigCallService : IRemoteConfigCallService
         }
     }
 
-    private async Task<T> FetchWithTimeout<T>(string key, T defaultValue, TimeSpan? ttl, Stopwatch sw, string application = null)
+    private async Task<T> FetchWithTimeout<T>(string key, string cacheKey, T defaultValue, TimeSpan? ttl, Stopwatch sw, string effectiveApplication)
     {
         try
         {
@@ -89,7 +96,7 @@ internal class RemoteConfigCallService : IRemoteConfigCallService
             var request = new FeatureToggleRequest
             {
                 Key = key,
-                Application = application ?? _options.Application ?? assemblyName?.Name,
+                Application = effectiveApplication,
                 Environment = _environmentName.Name,
                 Instance = null,
                 Version = $"{assemblyName?.Version}",
@@ -108,7 +115,7 @@ internal class RemoteConfigCallService : IRemoteConfigCallService
             {
                 _logger.LogError("Unable to get feature toggle for key '{Key}'. Response was {StatusCode} {ReasonPhrase}.",
                     key, response.StatusCode, response.ReasonPhrase);
-                CacheFailure(key, null);
+                CacheFailure(cacheKey, null);
                 _logger.LogInformation("Configuration '{Key}' resolved in {Elapsed}ms. Source: Default, Stale: true, Value: '{Value}'.",
                     key, sw.ElapsedMilliseconds, defaultValue);
                 return defaultValue;
@@ -118,9 +125,9 @@ internal class RemoteConfigCallService : IRemoteConfigCallService
 
             var interval = result.ValidTo - DateTime.UtcNow;
             if (interval > TimeSpan.Zero)
-                _lastKnownTtl[key] = interval;
+                _lastKnownTtl[cacheKey] = interval;
 
-            _localCache.AddOrUpdate(key, result, (_, _) => result);
+            _localCache.AddOrUpdate(cacheKey, result, (_, _) => result);
 
             var serverValue = GetCachedOrDefault(result, defaultValue);
             _logger.LogInformation("Configuration '{Key}' resolved in {Elapsed}ms. Source: Server, Stale: false, Value: '{Value}'.",
@@ -131,7 +138,7 @@ internal class RemoteConfigCallService : IRemoteConfigCallService
         {
             _logger.LogWarning("HTTP request timed out for configuration '{Key}' after {Timeout}ms. Using default value.",
                 key, _options.HttpTimeout.TotalMilliseconds);
-            CacheFailure(key, null);
+            CacheFailure(cacheKey, null);
             _logger.LogInformation("Configuration '{Key}' resolved in {Elapsed}ms. Source: Default, Stale: true, Value: '{Value}'.",
                 key, sw.ElapsedMilliseconds, defaultValue);
             return defaultValue;
@@ -139,16 +146,16 @@ internal class RemoteConfigCallService : IRemoteConfigCallService
         catch (Exception e)
         {
             _logger.LogError(e, "{Message} Using default for key {Key}.", e.Message, key);
-            CacheFailure(key, null);
+            CacheFailure(cacheKey, null);
             _logger.LogInformation("Configuration '{Key}' resolved in {Elapsed}ms. Source: Default, Stale: true, Value: '{Value}'.",
                 key, sw.ElapsedMilliseconds, defaultValue);
             return defaultValue;
         }
     }
 
-    private void StartBackgroundRefresh<T>(string key, T defaultValue, TimeSpan? ttl, string application = null)
+    private void StartBackgroundRefresh<T>(string key, string cacheKey, T defaultValue, TimeSpan? ttl, string effectiveApplication)
     {
-        if (!_refreshInProgress.TryAdd(key, true)) return;
+        if (!_refreshInProgress.TryAdd(cacheKey, true)) return;
 
         _ = Task.Run(async () =>
         {
@@ -158,7 +165,7 @@ internal class RemoteConfigCallService : IRemoteConfigCallService
                 var request = new FeatureToggleRequest
                 {
                     Key = key,
-                    Application = application ?? _options.Application ?? assemblyName?.Name,
+                    Application = effectiveApplication,
                     Environment = _environmentName.Name,
                     Instance = null,
                     Version = $"{assemblyName?.Version}",
@@ -177,7 +184,7 @@ internal class RemoteConfigCallService : IRemoteConfigCallService
                 {
                     _logger.LogError("Background refresh for '{Key}' failed. Response was {StatusCode} {ReasonPhrase}.",
                         key, response.StatusCode, response.ReasonPhrase);
-                    CacheFailure(key, _localCache.GetValueOrDefault(key));
+                    CacheFailure(cacheKey, _localCache.GetValueOrDefault(cacheKey));
                     return;
                 }
 
@@ -185,9 +192,9 @@ internal class RemoteConfigCallService : IRemoteConfigCallService
 
                 var interval = result.ValidTo - DateTime.UtcNow;
                 if (interval > TimeSpan.Zero)
-                    _lastKnownTtl[key] = interval;
+                    _lastKnownTtl[cacheKey] = interval;
 
-                _localCache.AddOrUpdate(key, result, (_, _) => result);
+                _localCache.AddOrUpdate(cacheKey, result, (_, _) => result);
                 _logger.LogInformation("Background refresh for '{Key}' completed. New value: '{Value}', ValidTo: {ValidTo}.",
                     key, result.Value, result.ValidTo);
             }
@@ -195,18 +202,32 @@ internal class RemoteConfigCallService : IRemoteConfigCallService
             {
                 _logger.LogWarning("Background refresh for '{Key}' timed out after {Timeout}ms.",
                     key, _options.HttpTimeout.TotalMilliseconds);
-                CacheFailure(key, _localCache.GetValueOrDefault(key));
+                CacheFailure(cacheKey, _localCache.GetValueOrDefault(cacheKey));
             }
             catch (Exception e)
             {
                 _logger.LogError(e, "Background refresh for '{Key}' failed: {Message}.", key, e.Message);
-                CacheFailure(key, _localCache.GetValueOrDefault(key));
+                CacheFailure(cacheKey, _localCache.GetValueOrDefault(cacheKey));
             }
             finally
             {
-                _refreshInProgress.TryRemove(key, out _);
+                _refreshInProgress.TryRemove(cacheKey, out _);
             }
         });
+    }
+
+    private string ResolveApplication(string application)
+    {
+        // The convention: only null means "default — toolkit looks it up". Empty string is
+        // an explicit "shared" and is forwarded as-is. A non-empty value is forwarded as-is.
+        if (application != null) return application;
+        return _options.Application ?? Assembly.GetEntryAssembly()?.GetName().Name;
+    }
+
+    private static string BuildCacheKey(string toggleKey, string effectiveApplication)
+    {
+        // "" and null both mean shared so they collapse to the same cache slot.
+        return $"{toggleKey}|{effectiveApplication ?? ""}";
     }
 
     public async Task<ConfigurationResponse[]> GetAllAsync()
@@ -287,15 +308,15 @@ internal class RemoteConfigCallService : IRemoteConfigCallService
         }
     }
 
-    private void CacheFailure(string key, FeatureToggleResponse stale)
+    private void CacheFailure(string cacheKey, FeatureToggleResponse stale)
     {
-        var duration = _lastKnownTtl.GetValueOrDefault(key, FallbackFailureCacheDuration);
+        var duration = _lastKnownTtl.GetValueOrDefault(cacheKey, FallbackFailureCacheDuration);
         var failureResponse = new FeatureToggleResponse
         {
             Value = stale?.Value,
             ValidTo = DateTime.UtcNow.Add(duration)
         };
-        _localCache.AddOrUpdate(key, failureResponse, (_, _) => failureResponse);
+        _localCache.AddOrUpdate(cacheKey, failureResponse, (_, _) => failureResponse);
     }
 
     private static string BuildKey(FeatureToggleRequest request)


### PR DESCRIPTION
## Summary

Two related fixes on the same branch.

### Toggles / Remote Configuration (`ce784e3`)
`RemoteConfigCallService`'s local cache keyed entries by toggle key alone. Two calls with the same key but different applications (`GetToggleAsync("A", application: "App1")` vs `GetToggleAsync("A", application: "App2")`) silently returned the first call's value from cache.

- Resolve effective application once at the top of `MakeCallAsync`.
- Cache key becomes `$"{toggleKey}|{effectiveApplication ?? \"\"}"` across `_localCache`, `_lastKnownTtl`, `_refreshInProgress`, `FetchWithTimeout` and `StartBackgroundRefresh`.
- Environment / Instance / Version don't vary in a session so don't need to be in the key.

### Content (`77162fc`)
- Add optional `application` parameter to `IQuilt4ContentService.GetAsync` so callers can scope a content lookup without dropping down to `IContentService`.
- Fix the same cache-key-only-by-key bug in `RemoteContentCallService` — key upgraded from `$"{key}_{languageKey}"` to `$"{key}_{languageKey}|{effectiveApplication ?? \"\"}"`, with the effective application resolved once at the top of `GetContentAsync`.

## Application-parameter convention (applies to both subsystems)

| Passed | Sent to server | Meaning |
|---|---|---|
| `null` | entry-assembly name (or `Options.Application` if configured) | default — toolkit resolves |
| `""` | `""` | shared (cross-application) |
| `"X"` | `"X"` | exactly `"X"` |

Set/Delete are unaffected — they forward verbatim without toolkit-side defaulting.

## Backward compatibility

- Wire protocol unchanged — no DTO or controller-signature changes.
- Old toolkits (0.6.16, 0.7.0, 0.7.1) keep working against a server that has the companion auto-create fix (Quilt4Net Server `develop`).
- New toolkit talking to an old server also works — cache key change is purely local.
- `IQuilt4ContentService.GetAsync` gained an optional parameter with a default — non-breaking source-compatible change.

## Test plan
- [x] `Quilt4Net.Toolkit.Tests` — 34 pass (1 new `GetToggleAsync_Same_Key_Different_Application_Are_Separate_Cache_Entries` + 4 new `ContentTests.cs` via real loopback `HttpListener` decoding outgoing requests)
- [x] `Quilt4Net.Toolkit.Blazor.Tests` — 36 pass
- [ ] CI green on this PR
- [ ] After merge: smoke-test the Quilt4Net.Toolkit.Blazor.Server.Sample with `GetToggleAsync("A", application: "Yee")` — confirm the admin UI shows the new toggle under Application "Yee" (requires the companion server fix on develop to be deployed)