### PR TITLE
feat: Application Insights Managed Identity support

### DIFF
--- a/Quilt4Net.Toolkit.Tests/CredentialFactoryTests.cs
+++ b/Quilt4Net.Toolkit.Tests/CredentialFactoryTests.cs
@@ -1,0 +1,72 @@
+using Azure.Identity;
+using FluentAssertions;
+using Quilt4Net.Toolkit.Features.ApplicationInsights;
+using Xunit;
+
+namespace Quilt4Net.Toolkit.Tests;
+
+public class CredentialFactoryTests
+{
+    [Fact]
+    public void ClientSecret_mode_with_secret_returns_ClientSecretCredential()
+    {
+        var credential = CredentialFactory.Create(
+            ApplicationInsightsAuthMode.ClientSecret,
+            tenantId: "tenant-guid",
+            clientId: "client-guid",
+            clientSecret: "secret-value");
+
+        credential.Should().BeOfType<ClientSecretCredential>();
+    }
+
+    [Fact]
+    public void ClientSecret_mode_without_secret_throws_with_helpful_message()
+    {
+        var act = () => CredentialFactory.Create(
+            ApplicationInsightsAuthMode.ClientSecret,
+            tenantId: "tenant-guid",
+            clientId: "client-guid",
+            clientSecret: null);
+
+        act.Should().Throw<InvalidOperationException>()
+            .Which.Message.Should().Contain("ClientSecret").And.Contain("ManagedIdentity");
+    }
+
+    [Fact]
+    public void ManagedIdentity_mode_without_clientId_returns_system_assigned_credential()
+    {
+        var credential = CredentialFactory.Create(
+            ApplicationInsightsAuthMode.ManagedIdentity,
+            tenantId: null,
+            clientId: null,
+            clientSecret: null);
+
+        credential.Should().BeOfType<ManagedIdentityCredential>();
+    }
+
+    [Fact]
+    public void ManagedIdentity_mode_with_clientId_returns_user_assigned_credential()
+    {
+        // User-assigned MI: client id is the identity's client id, not an app registration.
+        var credential = CredentialFactory.Create(
+            ApplicationInsightsAuthMode.ManagedIdentity,
+            tenantId: null,
+            clientId: "11111111-1111-1111-1111-111111111111",
+            clientSecret: null);
+
+        credential.Should().BeOfType<ManagedIdentityCredential>();
+    }
+
+    [Fact]
+    public void ManagedIdentity_mode_does_not_require_ClientSecret()
+    {
+        // No throw — MI flow must not depend on a secret being set.
+        var act = () => CredentialFactory.Create(
+            ApplicationInsightsAuthMode.ManagedIdentity,
+            tenantId: null,
+            clientId: null,
+            clientSecret: null);
+
+        act.Should().NotThrow();
+    }
+}

--- a/Quilt4Net.Toolkit/ApplicationInsightsOptions.cs
+++ b/Quilt4Net.Toolkit/ApplicationInsightsOptions.cs
@@ -1,4 +1,6 @@
-﻿namespace Quilt4Net.Toolkit;
+﻿using Quilt4Net.Toolkit.Features.ApplicationInsights;
+
+namespace Quilt4Net.Toolkit;
 
 /// <summary>
 /// This option can be configured by code or with appsettings.json on location "Quilt4Net/ApplicationInsights"
@@ -6,7 +8,7 @@
 public record ApplicationInsightsOptions
 {
     /// <summary>
-    /// This value can be found under 'Tenant properties' in Azure portal.
+    /// This value can be found under 'Tenant properties' in Azure portal. Only required when <see cref="AuthMode"/> is <see cref="ApplicationInsightsAuthMode.ClientSecret"/>.
     /// </summary>
     public string TenantId { get; set; }
 
@@ -16,15 +18,24 @@ public record ApplicationInsightsOptions
     public string WorkspaceId { get; set; }
 
     /// <summary>
-    /// Search for 'App registrations' in Azure portal or create a new App registration for Application Insights access. (Remember the app-name)
+    /// For <see cref="ApplicationInsightsAuthMode.ClientSecret"/>: search for 'App registrations' in Azure portal or create a new App registration for Application Insights access. (Remember the app-name)
     /// When creating a new app registration, assign the API permission 'Application Insights API' with 'Data.Read' access. (Add a permission / APIs my organization uses / Application Insights API) (Use Application permission, not Delegated)
     /// Also create a Client secret that will be used for 'ClientSecret' below.
     /// Under workspace on your application insights, go to 'Access control (IAM)' and add role access 'Reader' to the app registration with app-name.
+    ///
+    /// For <see cref="ApplicationInsightsAuthMode.ManagedIdentity"/>: leave empty to use the system-assigned managed identity, or set to the client id of a user-assigned managed identity.
     /// </summary>
     public string ClientId { get; set; }
 
     /// <summary>
-    ///
+    /// Only required when <see cref="AuthMode"/> is <see cref="ApplicationInsightsAuthMode.ClientSecret"/>.
     /// </summary>
     public string ClientSecret { get; set; }
+
+    /// <summary>
+    /// Authentication mode for connecting to the Application Insights / Log Analytics workspace.
+    /// Defaults to <see cref="ApplicationInsightsAuthMode.ClientSecret"/>. Set to <see cref="ApplicationInsightsAuthMode.ManagedIdentity"/>
+    /// when running in Azure and the hosting identity has Log Analytics Reader access to the workspace.
+    /// </summary>
+    public ApplicationInsightsAuthMode AuthMode { get; set; } = ApplicationInsightsAuthMode.ClientSecret;
 }

--- a/Quilt4Net.Toolkit/Features/ApplicationInsights/ApplicationInsightsAuthMode.cs
+++ b/Quilt4Net.Toolkit/Features/ApplicationInsights/ApplicationInsightsAuthMode.cs
@@ -1,0 +1,20 @@
+namespace Quilt4Net.Toolkit.Features.ApplicationInsights;
+
+/// <summary>
+/// Authentication mode for querying an Application Insights / Log Analytics workspace.
+/// </summary>
+public enum ApplicationInsightsAuthMode
+{
+    /// <summary>
+    /// Service principal with a client secret (TenantId + ClientId + ClientSecret).
+    /// The default for backward compatibility.
+    /// </summary>
+    ClientSecret = 0,
+
+    /// <summary>
+    /// Azure Managed Identity. Works when the app runs in Azure (App Service, Container Apps, VMs, …)
+    /// and its identity has been granted Log Analytics Reader (or Monitoring Reader) on the target workspace.
+    /// If <c>ClientId</c> is set, a user-assigned managed identity is used; otherwise the system-assigned identity.
+    /// </summary>
+    ManagedIdentity = 1,
+}

--- a/Quilt4Net.Toolkit/Features/ApplicationInsights/ApplicationInsightsContextExtensions.cs
+++ b/Quilt4Net.Toolkit/Features/ApplicationInsights/ApplicationInsightsContextExtensions.cs
@@ -41,6 +41,7 @@ public static class ApplicationInsightsContextExtensions
         public required string WorkspaceId { get; init; }
         public required string ClientId { get; init; }
         public required string ClientSecret { get; init; }
+        public ApplicationInsightsAuthMode AuthMode { get; init; } = ApplicationInsightsAuthMode.ClientSecret;
 
         public static Ctx Current;
     }

--- a/Quilt4Net.Toolkit/Features/ApplicationInsights/ApplicationInsightsService.cs
+++ b/Quilt4Net.Toolkit/Features/ApplicationInsights/ApplicationInsightsService.cs
@@ -891,14 +891,13 @@ AppRequests
     {
         if (context.IsCurrent()) context = null;
 
+        var authMode = context?.AuthMode ?? _options.AuthMode;
         var clientSecret = context?.ClientSecret ?? _options.ClientSecret;
         var tenantId = context?.TenantId ?? _options.TenantId;
         var clientId = context?.ClientId ?? _options.ClientId;
 
-        if (string.IsNullOrEmpty(clientSecret)) throw new InvalidOperationException($"No {nameof(ApplicationInsightsOptions.ClientSecret)} has been configured.");
-        var clientSecretCredential = new ClientSecretCredential(tenantId, clientId, clientSecret);
-        var client = new LogsQueryClient(clientSecretCredential);
-        return client;
+        var credential = CredentialFactory.Create(authMode, tenantId, clientId, clientSecret);
+        return new LogsQueryClient(credential);
     }
 
     private static int GetColumnIndex(LogsTable table, string name)

--- a/Quilt4Net.Toolkit/Features/ApplicationInsights/CredentialFactory.cs
+++ b/Quilt4Net.Toolkit/Features/ApplicationInsights/CredentialFactory.cs
@@ -1,0 +1,31 @@
+using Azure.Core;
+using Azure.Identity;
+
+namespace Quilt4Net.Toolkit.Features.ApplicationInsights;
+
+/// <summary>
+/// Builds the appropriate Azure <see cref="TokenCredential"/> for the configured <see cref="ApplicationInsightsAuthMode"/>.
+/// </summary>
+internal static class CredentialFactory
+{
+    public static TokenCredential Create(ApplicationInsightsAuthMode authMode, string tenantId, string clientId, string clientSecret)
+    {
+        switch (authMode)
+        {
+            case ApplicationInsightsAuthMode.ManagedIdentity:
+                // Empty ClientId -> system-assigned MI; value -> user-assigned MI.
+                return string.IsNullOrEmpty(clientId)
+                    ? new ManagedIdentityCredential()
+                    : new ManagedIdentityCredential(clientId);
+
+            case ApplicationInsightsAuthMode.ClientSecret:
+            default:
+                if (string.IsNullOrEmpty(clientSecret))
+                    throw new InvalidOperationException(
+                        $"No {nameof(ApplicationInsightsOptions.ClientSecret)} has been configured. " +
+                        $"Set {nameof(ApplicationInsightsOptions.AuthMode)} = {nameof(ApplicationInsightsAuthMode)}.{nameof(ApplicationInsightsAuthMode.ManagedIdentity)} " +
+                        $"to use Managed Identity instead.");
+                return new ClientSecretCredential(tenantId, clientId, clientSecret);
+        }
+    }
+}

--- a/Quilt4Net.Toolkit/Features/ApplicationInsights/IApplicationInsightsContext.cs
+++ b/Quilt4Net.Toolkit/Features/ApplicationInsights/IApplicationInsightsContext.cs
@@ -6,4 +6,10 @@ public interface IApplicationInsightsContext
     public string WorkspaceId { get; }
     public string ClientId { get; }
     public string ClientSecret { get; }
+
+    /// <summary>
+    /// Authentication mode used when connecting to the workspace. Defaults to <see cref="ApplicationInsightsAuthMode.ClientSecret"/>
+    /// so existing implementers keep their current behaviour without needing to implement this member.
+    /// </summary>
+    public ApplicationInsightsAuthMode AuthMode => ApplicationInsightsAuthMode.ClientSecret;
 }

--- a/Quilt4Net.Toolkit/README.md
+++ b/Quilt4Net.Toolkit/README.md
@@ -134,12 +134,30 @@ builder.AddQuilt4NetApplicationInsightsClient();
 
 | Property | Default | Description |
 |----------|---------|-------------|
-| `TenantId` | `null` | Azure AD tenant ID (found under "Tenant properties" in Azure portal). |
+| `TenantId` | `null` | Azure AD tenant ID (found under "Tenant properties" in Azure portal). Only required when `AuthMode = ClientSecret`. |
 | `WorkspaceId` | `null` | Application Insights workspace ID. |
-| `ClientId` | `null` | App registration client ID with `Data.Read` permission on Application Insights API. |
-| `ClientSecret` | `null` | Client secret for the app registration. |
+| `ClientId` | `null` | For `ClientSecret`: app registration client ID with `Data.Read` permission on Application Insights API. For `ManagedIdentity`: empty for system-assigned MI, or the user-assigned MI's client ID. |
+| `ClientSecret` | `null` | Client secret for the app registration. Only required when `AuthMode = ClientSecret`. |
+| `AuthMode` | `ClientSecret` | Authentication mode: `ClientSecret` (service principal) or `ManagedIdentity` (Azure-hosted apps). |
 
 Configuration path: `Quilt4Net:ApplicationInsights`
+
+#### Managed Identity
+
+When the app runs in Azure (App Service, Container Apps, VMs, …) you can skip the client secret entirely and authenticate with the hosting identity:
+
+```json
+{
+  "Quilt4Net": {
+    "ApplicationInsights": {
+      "WorkspaceId": "your-workspace-id",
+      "AuthMode": "ManagedIdentity"
+    }
+  }
+}
+```
+
+Grant the App Service identity the **Log Analytics Reader** (or Monitoring Reader) role on the target workspace. Use a user-assigned MI by setting `ClientId` to the identity's client ID; leave it empty for system-assigned.
 
 ## Universal telemetry tagging
 
@@ -237,7 +255,8 @@ All options can be set via code or `appsettings.json`. Code takes priority.
       "TenantId": "your-tenant-id",
       "WorkspaceId": "your-workspace-id",
       "ClientId": "your-client-id",
-      "ClientSecret": "your-client-secret"
+      "ClientSecret": "your-client-secret",
+      "AuthMode": "ClientSecret"
     },
     "RemoteConfiguration": {
       "Ttl": "00:10:00"


### PR DESCRIPTION
## Summary

Let consumers that run in Azure authenticate the Application Insights / Log Analytics query client with **Managed Identity** instead of a rotatable app-registration secret. Backward-compatible: existing consumers with `ClientSecret` keep working with zero changes.

## Changes

- **New `ApplicationInsightsAuthMode` enum** — `ClientSecret = 0` (default, backward compat), `ManagedIdentity = 1`.
- **`IApplicationInsightsContext`** gains an `AuthMode` member with a default interface implementation returning `ClientSecret`. Existing implementers (Quilt4Net.Server's `ApplicationInsightsConfiguration` entity, other consumers) keep compiling and inherit the default.
- **`ApplicationInsightsOptions.AuthMode`** — matching property, configurable via code or `appsettings.json` at `Quilt4Net:ApplicationInsights:AuthMode`.
- **`CredentialFactory`** (internal, unit-testable) owns the credential selection:
  | AuthMode | ClientId | Credential |
  |---|---|---|
  | `ManagedIdentity` | set | `ManagedIdentityCredential(ClientId)` — user-assigned |
  | `ManagedIdentity` | empty | `ManagedIdentityCredential()` — system-assigned |
  | `ClientSecret` | secret set | `ClientSecretCredential(TenantId, ClientId, ClientSecret)` — current behaviour |
  | `ClientSecret` | no secret | `InvalidOperationException` with a message pointing at `ManagedIdentity` as the alternative |
- **`ApplicationInsightsService.GetClient()`** delegates to the factory.
- **Internal `Ctx` record** in `ApplicationInsightsContextExtensions` carries `AuthMode` so it round-trips through `ToKey` / `ToApplicationInsightsContext`.
- **README**: `ApplicationInsightsOptions` table updated, new Managed Identity subsection with copy-paste `appsettings.json` snippet and the role grant.

## Backward compatibility

- Wire protocol / API surface: no breaking changes. Default interface implementation on `IApplicationInsightsContext` means existing implementers don't need to declare `AuthMode`.
- `AuthMode` defaults to `ClientSecret` everywhere, so no existing config / behaviour changes.

## Deployment note (for consumers enabling Managed Identity)

Grant the Azure App Service / Container Apps / VM identity **Log Analytics Reader** (or Monitoring Reader) on the target workspace — replaces the current SPN grant.

## Test plan

- [x] 5 new `CredentialFactoryTests` cover every branch (2 ClientSecret, 2 ManagedIdentity, 1 MI-no-secret-required)
- [x] Full Toolkit test sweep: 39 (Toolkit, +5 new) + 36 (Blazor) + 48 (Health) = 123 pass
- [x] Local build clean (57 pre-existing warnings, unchanged)
- [ ] CI green on this PR
- [ ] Follow-up in Quilt4Net.Server (tracked in `plans/Quilt4Net/Toolkit/07-applicationinsights-managed-identity.md`): surface `AuthMode` in the `ApplicationInsightsConfiguration` entity + edit dialog, add badge column on `/monitor/configuration`, switch Server's own appsettings to MI in prod.