### PR TITLE
perf: cache ApplicationInsightsService query results

### DIFF
--- a/Quilt4Net.Toolkit/ApplicationInsightsRegistration.cs
+++ b/Quilt4Net.Toolkit/ApplicationInsightsRegistration.cs
@@ -39,9 +39,35 @@ public static class ApplicationInsightsRegistration
 
         services.AddCache(s =>
         {
+            // Environment list rarely changes — hold it for an hour.
             s.RegisterType<EnvironmentOption[], IMemory>(x =>
             {
                 x.DefaultFreshSpan = TimeSpan.FromHours(1);
+            });
+            // Search is user-interactive; keep it short so typing-triggered changes don't
+            // see stale results for long.
+            s.RegisterType<LogItem[], IMemory>(x =>
+            {
+                x.DefaultFreshSpan = TimeSpan.FromSeconds(30);
+            });
+            // Aggregation queries (measure, count, summary-list, single-fingerprint drilldown)
+            // — 1 minute is a reasonable fresh-reload cadence that still avoids re-running the
+            // same KQL on every page navigation.
+            s.RegisterType<MeasureData[], IMemory>(x =>
+            {
+                x.DefaultFreshSpan = TimeSpan.FromMinutes(1);
+            });
+            s.RegisterType<CountData[], IMemory>(x =>
+            {
+                x.DefaultFreshSpan = TimeSpan.FromMinutes(1);
+            });
+            s.RegisterType<SummaryData, IMemory>(x =>
+            {
+                x.DefaultFreshSpan = TimeSpan.FromMinutes(1);
+            });
+            s.RegisterType<SummarySubset[], IMemory>(x =>
+            {
+                x.DefaultFreshSpan = TimeSpan.FromMinutes(1);
             });
         });
     }

--- a/Quilt4Net.Toolkit/Features/ApplicationInsights/ApplicationInsightsService.cs
+++ b/Quilt4Net.Toolkit/Features/ApplicationInsights/ApplicationInsightsService.cs
@@ -105,9 +105,13 @@ union
 
     public async IAsyncEnumerable<LogItem> SearchAsync(IApplicationInsightsContext context, string environment, string text, TimeSpan timeSpan, SeverityLevel minSeverityLevel = SeverityLevel.Verbose)
     {
-        //TODO: Refactor: Cache here...
-        var items = await SearchInternalAsync(context, environment, text, timeSpan, minSeverityLevel).ToArrayAsync();
-        foreach (var item in items.GroupBy(x => x.Id).Select(x => x.First()))
+        var cacheKey = $"search|{context.ToKey()}|{environment}|{text}|{timeSpan}|{minSeverityLevel}";
+        var items = await _timeToLiveCache.GetAsync(cacheKey, async () =>
+        {
+            var list = await SearchInternalAsync(context, environment, text, timeSpan, minSeverityLevel).ToArrayAsync();
+            return list.GroupBy(x => x.Id).Select(x => x.First()).ToArray();
+        });
+        foreach (var item in items)
         {
             yield return item;
         }
@@ -346,9 +350,13 @@ AppRequests
 
     public async IAsyncEnumerable<MeasureData> GetMeasureAsync(IApplicationInsightsContext context, string environment, TimeSpan timeSpan)
     {
-        //TODO: Refactor: Cache here...
-        var items = await GetMeasureInternalAsync(context, environment, timeSpan).ToArrayAsync();
-        foreach (var item in items.GroupBy(x => x.Id).Select(x => x.First()))
+        var cacheKey = $"measure|{context.ToKey()}|{environment}|{timeSpan}";
+        var items = await _timeToLiveCache.GetAsync(cacheKey, async () =>
+        {
+            var list = await GetMeasureInternalAsync(context, environment, timeSpan).ToArrayAsync();
+            return list.GroupBy(x => x.Id).Select(x => x.First()).ToArray();
+        });
+        foreach (var item in items)
         {
             yield return item;
         }
@@ -447,9 +455,13 @@ AppTraces
 
     public async IAsyncEnumerable<CountData> GetCountAsync(IApplicationInsightsContext context, string environment, TimeSpan timeSpan)
     {
-        //TODO: Refactor: Cache here...
-        var items = await GetCountInternalAsync(context, environment, timeSpan).ToArrayAsync();
-        foreach (var item in items.GroupBy(x => x.Id).Select(x => x.First()))
+        var cacheKey = $"count|{context.ToKey()}|{environment}|{timeSpan}";
+        var items = await _timeToLiveCache.GetAsync(cacheKey, async () =>
+        {
+            var list = await GetCountInternalAsync(context, environment, timeSpan).ToArrayAsync();
+            return list.GroupBy(x => x.Id).Select(x => x.First()).ToArray();
+        });
+        foreach (var item in items)
         {
             yield return item;
         }
@@ -662,7 +674,12 @@ AppRequests
 
     public async Task<SummaryData> GetSummary(IApplicationInsightsContext context, string fingerprint, LogSource source, string environment, TimeSpan timeSpan)
     {
-        //TODO: Refactor: Cache here...
+        var cacheKey = $"summary|{context.ToKey()}|{fingerprint}|{source}|{environment}|{timeSpan}";
+        return await _timeToLiveCache.GetAsync(cacheKey, () => GetSummaryInternalAsync(context, fingerprint, source, environment, timeSpan));
+    }
+
+    private async Task<SummaryData> GetSummaryInternalAsync(IApplicationInsightsContext context, string fingerprint, LogSource source, string environment, TimeSpan timeSpan)
+    {
         var client = GetClient(context);
         var workspaceId = context?.WorkspaceId ?? _options.WorkspaceId;
 
@@ -756,9 +773,13 @@ AppRequests
 
     public async IAsyncEnumerable<SummarySubset> GetSummaries(IApplicationInsightsContext context, string environment, TimeSpan timeSpan)
     {
-        //TODO: Refactor: Cache here...
-        var items = await GetSummariesInternal(context, environment, timeSpan).ToArrayAsync();
-        foreach (var item in items.GroupBy(x => x.Fingerprint).Select(x => x.First()))
+        var cacheKey = $"summaries|{context.ToKey()}|{environment}|{timeSpan}";
+        var items = await _timeToLiveCache.GetAsync(cacheKey, async () =>
+        {
+            var list = await GetSummariesInternal(context, environment, timeSpan).ToArrayAsync();
+            return list.GroupBy(x => x.Fingerprint).Select(x => x.First()).ToArray();
+        });
+        foreach (var item in items)
         {
             yield return item;
         }


### PR DESCRIPTION
## Summary

Five public methods in `ApplicationInsightsService` hit Log Analytics on every call. Each had a `//TODO: Refactor: Cache here…` marker. Wrap each in `_timeToLiveCache.GetAsync` so repeat views within the TTL reuse the materialised result.

## Methods cached

| Method | Cache key | TTL |
|---|---|---|
| `SearchAsync` | `search\|{context}\|{env}\|{text}\|{timeSpan}\|{minSeverityLevel}` | 30s (user-interactive) |
| `GetMeasureAsync` | `measure\|{context}\|{env}\|{timeSpan}` | 1min |
| `GetCountAsync` | `count\|{context}\|{env}\|{timeSpan}` | 1min |
| `GetSummary` | `summary\|{context}\|{fingerprint}\|{source}\|{env}\|{timeSpan}` | 1min |
| `GetSummaries` | `summaries\|{context}\|{env}\|{timeSpan}` | 1min |

`context.ToKey()` includes `AuthMode` so switching between ClientSecret and ManagedIdentity configs cache-misses correctly. Different filter combinations → different slots, as intended.

The `GroupBy(...).First()` deduplication pass now happens inside the cache factory, so on hits we skip both the KQL round-trip **and** the filter. `GetSummary` body was extracted to `GetSummaryInternalAsync` to fit the factory pattern.

## Registrations

Five new cache-type slots in `ApplicationInsightsRegistration` alongside the existing `EnvironmentOption[]` (1h, unchanged). All in-memory.

## What this doesn't do

Deliberately *not* included:

- **Day-partitioned eternal cache for `GetSummaries`** — captured in a follow-up plan `08-ai-day-partitioned-summary-cache.md`. Immutable-past-days + hot-zone design, big win for users flipping between 7d/30d repeatedly, but a different pattern than simple TTL.
- **`IEternalCache` on `GetDetail(id)`** — same follow-up plan. Items by `_ItemId` are immutable.

This PR is the direct 1:1 fix for the 5 TODO markers; it's a foundation the day-partitioned work extends rather than replaces.

## Test plan

- [x] Build clean (57 pre-existing warnings, unchanged)
- [x] Full Toolkit test sweep — 123 pass (39 Toolkit + 36 Blazor + 48 Health)
- [x] No new tests — cache wrapping uses existing Tharga.Cache infrastructure and doesn't change public method contracts
- [ ] CI green on this PR
- [ ] After merge: verify on a consumer by rapidly reopening `/developer/log` tabs — second visit should be instant

Closes the "Cache Application Insights queries — 5 TODO instances" backlog item.