### PR TITLE
chore(sample): show resolved Quilt4Net address on Configuration page

### DIFF
--- a/Quilt4Net.Toolkit.Blazor.Server.Sample/Components/Pages/Configuration.razor
+++ b/Quilt4Net.Toolkit.Blazor.Server.Sample/Components/Pages/Configuration.razor
@@ -1,5 +1,8 @@
 @page "/configuration"
 @rendermode InteractiveServer
+@using Microsoft.Extensions.Options
+@using Quilt4Net.Toolkit
+@inject IOptions<RemoteConfigurationOptions> Options
 
 <PageTitle>Configuration</PageTitle>
 
@@ -7,7 +10,7 @@
 
 <p>
     The <code>RemoteConfigurationAdmin</code> component displays a data grid of feature toggles
-    and configuration values. Changes are saved to <a href="https://quilt4net.com">Quilt4Net Web</a>.
+    and configuration values. Changes are saved to <a href="@Options.Value.Quilt4NetAddress" target="_blank"><code>@Options.Value.Quilt4NetAddress</code></a>.
 </p>
 
 <h3>Full configuration view</h3>


### PR DESCRIPTION
## Summary

The Blazor Server sample's `/configuration` page showed a hardcoded link saying *"Changes are saved to [Quilt4Net Web](https://quilt4net.com)"*. It's marketing copy baked into the razor markup — **not** tied to the runtime's actual endpoint. At least one developer read that text and thought the sample was pointing at production while their appsettings.Development.json was correctly set to `https://localhost:7129/`.

Replace the hardcoded URL with a live, clickable link backed by `IOptions<RemoteConfigurationOptions>.Value.Quilt4NetAddress`, so the displayed URL always matches where the runtime is actually sending requests.

## Changes

One file, +4/−1 in [Quilt4Net.Toolkit.Blazor.Server.Sample/Components/Pages/Configuration.razor](Quilt4Net.Toolkit.Blazor.Server.Sample/Components/Pages/Configuration.razor):

- Add `@using Microsoft.Extensions.Options` + `@using Quilt4Net.Toolkit`
- Inject `IOptions<RemoteConfigurationOptions> Options`
- Replace `<a href="https://quilt4net.com">Quilt4Net Web</a>` with `<a href="@Options.Value.Quilt4NetAddress" target="_blank"><code>@Options.Value.Quilt4NetAddress</code></a>`

## Context

This branch was created during a debugging session on 2026-04-20 to resolve a "why doesn't this sample point at localhost?" confusion. The branch was left hanging when the conversation moved on to MCP and auth work; picking it up now to close it out.

## Test plan
- [x] Builds clean locally
- [ ] CI green on this PR
- [ ] Sample page shows the actually-configured URL when rendered