### PR TITLE
feat: add DefaultAzureCredential auth mode for Application Insights

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,7 +62,14 @@ jobs:
           fi
 
       - name: Test with coverage
-        run: dotnet test -c Release --no-build --verbosity normal --collect:"XPlat Code Coverage" --results-directory ./coverage
+        # -m:1 disables MSBuild parallelism. Microsoft.NET.Test.Sdk 18.5.1 has a regression
+        # where parallel VSTest invocations across multiple test projects (especially Web SDK
+        # ones like Health.Tests) intermittently produce
+        #   "The argument <path-to-test.dll> is invalid. Please use the /help option..."
+        # because the test DLL gets passed as a positional argument to the wrong vstest.console
+        # process. Running with a single MSBuild node serializes the VSTest invocations and
+        # avoids the cross-project arg leak. Slightly slower, reliable.
+        run: dotnet test -c Release --no-build --verbosity normal --collect:"XPlat Code Coverage" --results-directory ./coverage -m:1
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,14 +62,7 @@ jobs:
           fi
 
       - name: Test with coverage
-        # -m:1 disables MSBuild parallelism. Microsoft.NET.Test.Sdk 18.5.1 has a regression
-        # where parallel VSTest invocations across multiple test projects (especially Web SDK
-        # ones like Health.Tests) intermittently produce
-        #   "The argument <path-to-test.dll> is invalid. Please use the /help option..."
-        # because the test DLL gets passed as a positional argument to the wrong vstest.console
-        # process. Running with a single MSBuild node serializes the VSTest invocations and
-        # avoids the cross-project arg leak. Slightly slower, reliable.
-        run: dotnet test -c Release --no-build --verbosity normal --collect:"XPlat Code Coverage" --results-directory ./coverage -m:1
+        run: dotnet test -c Release --no-build --verbosity normal --collect:"XPlat Code Coverage" --results-directory ./coverage
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5

--- a/Quilt4Net.Toolkit.Api.Tests/Quilt4Net.Toolkit.Api.Tests.csproj
+++ b/Quilt4Net.Toolkit.Api.Tests/Quilt4Net.Toolkit.Api.Tests.csproj
@@ -9,11 +9,10 @@
 		<PackageReference Include="AutoFixture" Version="4.18.1" />
 		<PackageReference Include="FluentAssertions" Version="8.9.0" />
 		<PackageReference Include="JetBrains.Annotations" Version="2025.2.4" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
 		<PackageReference Include="Moq" Version="4.20.72" />
-		<PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.6" />
+		<PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.7" />
 		<PackageReference Include="OneOf" Version="3.0.271" />
-		<PackageReference Include="xunit" Version="2.9.3" />
 		<PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
@@ -26,6 +25,7 @@
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
+		<PackageReference Include="xunit.v3" Version="3.2.2" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/Quilt4Net.Toolkit.Api/Quilt4Net.Toolkit.Api.csproj
+++ b/Quilt4Net.Toolkit.Api/Quilt4Net.Toolkit.Api.csproj
@@ -40,7 +40,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-	  <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.202">
+	  <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.203">
 		  <PrivateAssets>all</PrivateAssets>
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 	  </PackageReference>

--- a/Quilt4Net.Toolkit.Blazor.Server.Sample/Components/Pages/Configuration.razor
+++ b/Quilt4Net.Toolkit.Blazor.Server.Sample/Components/Pages/Configuration.razor
@@ -1,5 +1,8 @@
 @page "/configuration"
 @rendermode InteractiveServer
+@using Microsoft.Extensions.Options
+@using Quilt4Net.Toolkit
+@inject IOptions<RemoteConfigurationOptions> Options
 
 <PageTitle>Configuration</PageTitle>
 
@@ -7,7 +10,7 @@
 
 <p>
     The <code>RemoteConfigurationAdmin</code> component displays a data grid of feature toggles
-    and configuration values. Changes are saved to <a href="https://quilt4net.com">Quilt4Net Web</a>.
+    and configuration values. Changes are saved to <a href="@Options.Value.Quilt4NetAddress" target="_blank"><code>@Options.Value.Quilt4NetAddress</code></a>.
 </p>
 
 <h3>Full configuration view</h3>

--- a/Quilt4Net.Toolkit.Blazor.Tests/Quilt4Net.Toolkit.Blazor.Tests.csproj
+++ b/Quilt4Net.Toolkit.Blazor.Tests/Quilt4Net.Toolkit.Blazor.Tests.csproj
@@ -13,12 +13,12 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
-    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="xunit.v3" Version="3.2.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Quilt4Net.Toolkit.Blazor.Wasm.Sample/Quilt4Net.Toolkit.Blazor.Wasm.Sample.csproj
+++ b/Quilt4Net.Toolkit.Blazor.Wasm.Sample/Quilt4Net.Toolkit.Blazor.Wasm.Sample.csproj
@@ -8,8 +8,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.2" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="10.0.6" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.7" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="10.0.7" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Quilt4Net.Toolkit.Blazor/Quilt4Net.Toolkit.Blazor.csproj
+++ b/Quilt4Net.Toolkit.Blazor/Quilt4Net.Toolkit.Blazor.csproj
@@ -25,9 +25,9 @@
     <None Remove="wwwroot\**" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Authentication.WebAssembly.Msal" Version="10.0.6" />
+    <PackageReference Include="Microsoft.Authentication.WebAssembly.Msal" Version="10.0.7" />
     <PackageReference Include="Microsoft.Identity.Client" Version="4.83.3" />
-    <PackageReference Include="Tharga.Blazor" Version="2.1.3" />
+    <PackageReference Include="Tharga.Blazor" Version="2.1.4" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Quilt4Net.Toolkit\Quilt4Net.Toolkit.csproj" />
@@ -36,6 +36,6 @@
     <PackageReference Include="Microsoft.AspNetCore.Components.Authorization" Version="9.0.15" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
-    <PackageReference Include="Microsoft.AspNetCore.Components.Authorization" Version="10.0.6" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.Authorization" Version="10.0.7" />
   </ItemGroup>
 </Project>

--- a/Quilt4Net.Toolkit.Console.Sample/Quilt4Net.Toolkit.Console.Sample.csproj
+++ b/Quilt4Net.Toolkit.Console.Sample/Quilt4Net.Toolkit.Console.Sample.csproj
@@ -12,7 +12,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.6" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.7" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Quilt4Net.Toolkit.Health.Tests/HeadEndpointTests.cs
+++ b/Quilt4Net.Toolkit.Health.Tests/HeadEndpointTests.cs
@@ -10,7 +10,7 @@ public class HeadEndpointTests : IAsyncLifetime
     private WebApplication _app;
     private HttpClient _client;
 
-    public async Task InitializeAsync()
+    public async ValueTask InitializeAsync()
     {
         var builder = WebApplication.CreateBuilder();
         builder.WebHost.UseUrls("http://127.0.0.1:0");
@@ -36,7 +36,7 @@ public class HeadEndpointTests : IAsyncLifetime
         _client = new HttpClient { BaseAddress = new Uri(address) };
     }
 
-    public async Task DisposeAsync()
+    public async ValueTask DisposeAsync()
     {
         _client?.Dispose();
         if (_app != null) await _app.DisposeAsync();

--- a/Quilt4Net.Toolkit.Health.Tests/Quilt4Net.Toolkit.Health.Tests.csproj
+++ b/Quilt4Net.Toolkit.Health.Tests/Quilt4Net.Toolkit.Health.Tests.csproj
@@ -9,11 +9,10 @@
 		<PackageReference Include="AutoBogus" Version="2.13.1" />
 		<PackageReference Include="FluentAssertions" Version="8.9.0" />
 		<PackageReference Include="JetBrains.Annotations" Version="2025.2.4" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
-		<PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.6" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
+		<PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.7" />
 		<PackageReference Include="Moq" Version="4.20.72" />
 		<PackageReference Include="OneOf" Version="3.0.271" />
-		<PackageReference Include="xunit" Version="2.9.3" />
 		<PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
@@ -26,6 +25,7 @@
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
+		<PackageReference Include="xunit.v3" Version="3.2.2" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/Quilt4Net.Toolkit.Health/Quilt4Net.Toolkit.Health.csproj
+++ b/Quilt4Net.Toolkit.Health/Quilt4Net.Toolkit.Health.csproj
@@ -41,7 +41,7 @@
 
 	<ItemGroup>
 	  <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="3.1.0" />
-	  <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.202">
+	  <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.203">
 		  <PrivateAssets>all</PrivateAssets>
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 	  </PackageReference>

--- a/Quilt4Net.Toolkit.Tests/CredentialFactoryTests.cs
+++ b/Quilt4Net.Toolkit.Tests/CredentialFactoryTests.cs
@@ -69,4 +69,30 @@ public class CredentialFactoryTests
 
         act.Should().NotThrow();
     }
+
+    [Fact]
+    public void DefaultAzureCredential_mode_returns_DefaultAzureCredential()
+    {
+        var credential = CredentialFactory.Create(
+            ApplicationInsightsAuthMode.DefaultAzureCredential,
+            tenantId: "tenant-guid",
+            clientId: "11111111-1111-1111-1111-111111111111",
+            clientSecret: null);
+
+        credential.Should().BeOfType<DefaultAzureCredential>();
+    }
+
+    [Fact]
+    public void DefaultAzureCredential_mode_works_with_no_tenant_or_client()
+    {
+        // Local-dev story: developer has run `az login` and has nothing else configured.
+        // Empty TenantId / ClientId must fall through to the SDK's own discovery.
+        var act = () => CredentialFactory.Create(
+            ApplicationInsightsAuthMode.DefaultAzureCredential,
+            tenantId: null,
+            clientId: null,
+            clientSecret: null);
+
+        act.Should().NotThrow();
+    }
 }

--- a/Quilt4Net.Toolkit.Tests/Quilt4Net.Toolkit.Tests.csproj
+++ b/Quilt4Net.Toolkit.Tests/Quilt4Net.Toolkit.Tests.csproj
@@ -9,10 +9,9 @@
 		<PackageReference Include="AutoFixture" Version="4.18.1" />
 		<PackageReference Include="FluentAssertions" Version="8.9.0" />
 		<PackageReference Include="JetBrains.Annotations" Version="2025.2.4" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
 		<PackageReference Include="Moq" Version="4.20.72" />
-		<PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.6" />
-		<PackageReference Include="xunit" Version="2.9.3" />
+		<PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.7" />
 		<PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
@@ -25,6 +24,7 @@
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
+		<PackageReference Include="xunit.v3" Version="3.2.2" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/Quilt4Net.Toolkit/ApplicationInsightsOptions.cs
+++ b/Quilt4Net.Toolkit/ApplicationInsightsOptions.cs
@@ -24,18 +24,21 @@ public record ApplicationInsightsOptions
     /// Under workspace on your application insights, go to 'Access control (IAM)' and add role access 'Reader' to the app registration with app-name.
     ///
     /// For <see cref="ApplicationInsightsAuthMode.ManagedIdentity"/>: leave empty to use the system-assigned managed identity, or set to the client id of a user-assigned managed identity.
+    ///
+    /// For <see cref="ApplicationInsightsAuthMode.DefaultAzureCredential"/>: optional hint — when set, the chained credential prefers this user-assigned managed identity if Managed Identity lights up in the chain.
     /// </summary>
     public string ClientId { get; set; }
 
     /// <summary>
-    /// Only required when <see cref="AuthMode"/> is <see cref="ApplicationInsightsAuthMode.ClientSecret"/>.
+    /// Only required when <see cref="AuthMode"/> is <see cref="ApplicationInsightsAuthMode.ClientSecret"/>. Not consulted in <see cref="ApplicationInsightsAuthMode.ManagedIdentity"/> or <see cref="ApplicationInsightsAuthMode.DefaultAzureCredential"/>.
     /// </summary>
     public string ClientSecret { get; set; }
 
     /// <summary>
     /// Authentication mode for connecting to the Application Insights / Log Analytics workspace.
-    /// Defaults to <see cref="ApplicationInsightsAuthMode.ClientSecret"/>. Set to <see cref="ApplicationInsightsAuthMode.ManagedIdentity"/>
-    /// when running in Azure and the hosting identity has Log Analytics Reader access to the workspace.
+    /// Defaults to <see cref="ApplicationInsightsAuthMode.ClientSecret"/>.
+    /// Use <see cref="ApplicationInsightsAuthMode.ManagedIdentity"/> when running in Azure and the hosting identity has Log Analytics Reader on the workspace.
+    /// Use <see cref="ApplicationInsightsAuthMode.DefaultAzureCredential"/> for a chained credential that works locally (via <c>az login</c>) and in Azure (via Managed Identity) with the same configuration.
     /// </summary>
     public ApplicationInsightsAuthMode AuthMode { get; set; } = ApplicationInsightsAuthMode.ClientSecret;
 }

--- a/Quilt4Net.Toolkit/Features/ApplicationInsights/ApplicationInsightsAuthMode.cs
+++ b/Quilt4Net.Toolkit/Features/ApplicationInsights/ApplicationInsightsAuthMode.cs
@@ -17,4 +17,13 @@ public enum ApplicationInsightsAuthMode
     /// If <c>ClientId</c> is set, a user-assigned managed identity is used; otherwise the system-assigned identity.
     /// </summary>
     ManagedIdentity = 1,
+
+    /// <summary>
+    /// Azure <c>DefaultAzureCredential</c> chain — falls through environment variables, workload identity,
+    /// Managed Identity (in Azure), Visual Studio / VS Code credentials, and Azure CLI (<c>az login</c>),
+    /// returning the first that succeeds. Same configuration works for local development (developer runs
+    /// <c>az login</c> once) and for Azure-hosted deployments (system-assigned or user-assigned managed identity).
+    /// <c>TenantId</c> and <c>ClientId</c> are forwarded as hints; both may be left empty.
+    /// </summary>
+    DefaultAzureCredential = 2,
 }

--- a/Quilt4Net.Toolkit/Features/ApplicationInsights/CredentialFactory.cs
+++ b/Quilt4Net.Toolkit/Features/ApplicationInsights/CredentialFactory.cs
@@ -18,13 +18,22 @@ internal static class CredentialFactory
                     ? new ManagedIdentityCredential()
                     : new ManagedIdentityCredential(clientId);
 
+            case ApplicationInsightsAuthMode.DefaultAzureCredential:
+                // Forward TenantId + ClientId as hints. Empty values become null so the SDK's
+                // own discovery (env vars / az login / Visual Studio / etc.) kicks in.
+                return new DefaultAzureCredential(new DefaultAzureCredentialOptions
+                {
+                    TenantId = string.IsNullOrEmpty(tenantId) ? null : tenantId,
+                    ManagedIdentityClientId = string.IsNullOrEmpty(clientId) ? null : clientId,
+                });
+
             case ApplicationInsightsAuthMode.ClientSecret:
             default:
                 if (string.IsNullOrEmpty(clientSecret))
                     throw new InvalidOperationException(
                         $"No {nameof(ApplicationInsightsOptions.ClientSecret)} has been configured. " +
                         $"Set {nameof(ApplicationInsightsOptions.AuthMode)} = {nameof(ApplicationInsightsAuthMode)}.{nameof(ApplicationInsightsAuthMode.ManagedIdentity)} " +
-                        $"to use Managed Identity instead.");
+                        $"or {nameof(ApplicationInsightsAuthMode)}.{nameof(ApplicationInsightsAuthMode.DefaultAzureCredential)} to skip the secret.");
                 return new ClientSecretCredential(tenantId, clientId, clientSecret);
         }
     }

--- a/Quilt4Net.Toolkit/Features/ApplicationInsights/IApplicationInsightsContext.cs
+++ b/Quilt4Net.Toolkit/Features/ApplicationInsights/IApplicationInsightsContext.cs
@@ -10,6 +10,8 @@ public interface IApplicationInsightsContext
     /// <summary>
     /// Authentication mode used when connecting to the workspace. Defaults to <see cref="ApplicationInsightsAuthMode.ClientSecret"/>
     /// so existing implementers keep their current behaviour without needing to implement this member.
+    /// Other options: <see cref="ApplicationInsightsAuthMode.ManagedIdentity"/> (Azure-hosted, MI granted Reader on workspace)
+    /// and <see cref="ApplicationInsightsAuthMode.DefaultAzureCredential"/> (chained — works locally via <c>az login</c> and in Azure via MI).
     /// </summary>
     public ApplicationInsightsAuthMode AuthMode => ApplicationInsightsAuthMode.ClientSecret;
 }

--- a/Quilt4Net.Toolkit/Quilt4Net.Toolkit.csproj
+++ b/Quilt4Net.Toolkit/Quilt4Net.Toolkit.csproj
@@ -39,7 +39,7 @@
   <ItemGroup>
     <PackageReference Include="Azure.Identity" Version="1.21.0" />
     <PackageReference Include="Microsoft.ApplicationInsights" Version="3.1.0" />
-    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.15.1" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.15.2" />
     <PackageReference Include="Azure.Monitor.Query" Version="1.7.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.6" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.6" />

--- a/Quilt4Net.Toolkit/Quilt4Net.Toolkit.csproj
+++ b/Quilt4Net.Toolkit/Quilt4Net.Toolkit.csproj
@@ -39,18 +39,18 @@
   <ItemGroup>
     <PackageReference Include="Azure.Identity" Version="1.21.0" />
     <PackageReference Include="Microsoft.ApplicationInsights" Version="3.1.0" />
-    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.15.2" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.15.3" />
     <PackageReference Include="Azure.Monitor.Query" Version="1.7.1" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.6" />
-    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.6" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.6" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.6" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.202">
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.7" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.7" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.7" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.7" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.203">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="System.Management" Version="10.0.6" />
+    <PackageReference Include="System.Management" Version="10.0.7" />
     <PackageReference Include="System.Linq.Async" Version="7.0.1" />
-    <PackageReference Include="Tharga.Cache" Version="0.4.1" />
+    <PackageReference Include="Tharga.Cache" Version="0.4.2" />
   </ItemGroup>
 </Project>

--- a/Quilt4Net.Toolkit/README.md
+++ b/Quilt4Net.Toolkit/README.md
@@ -136,9 +136,9 @@ builder.AddQuilt4NetApplicationInsightsClient();
 |----------|---------|-------------|
 | `TenantId` | `null` | Azure AD tenant ID (found under "Tenant properties" in Azure portal). Only required when `AuthMode = ClientSecret`. |
 | `WorkspaceId` | `null` | Application Insights workspace ID. |
-| `ClientId` | `null` | For `ClientSecret`: app registration client ID with `Data.Read` permission on Application Insights API. For `ManagedIdentity`: empty for system-assigned MI, or the user-assigned MI's client ID. |
+| `ClientId` | `null` | For `ClientSecret`: app registration client ID with `Data.Read` permission on Application Insights API. For `ManagedIdentity`: empty for system-assigned MI, or the user-assigned MI's client ID. For `DefaultAzureCredential`: optional hint, used as the preferred user-assigned MI when MI lights up in the chain. |
 | `ClientSecret` | `null` | Client secret for the app registration. Only required when `AuthMode = ClientSecret`. |
-| `AuthMode` | `ClientSecret` | Authentication mode: `ClientSecret` (service principal) or `ManagedIdentity` (Azure-hosted apps). |
+| `AuthMode` | `ClientSecret` | Authentication mode: `ClientSecret` (service principal), `ManagedIdentity` (Azure-hosted apps), or `DefaultAzureCredential` (chained — same config works locally via `az login` and in Azure via MI). |
 
 Configuration path: `Quilt4Net:ApplicationInsights`
 
@@ -158,6 +158,32 @@ When the app runs in Azure (App Service, Container Apps, VMs, …) you can skip 
 ```
 
 Grant the App Service identity the **Log Analytics Reader** (or Monitoring Reader) role on the target workspace. Use a user-assigned MI by setting `ClientId` to the identity's client ID; leave it empty for system-assigned.
+
+#### DefaultAzureCredential
+
+Use `DefaultAzureCredential` to share a single configuration across local dev and Azure-hosted environments:
+
+```json
+{
+  "Quilt4Net": {
+    "ApplicationInsights": {
+      "WorkspaceId": "your-workspace-id",
+      "AuthMode": "DefaultAzureCredential"
+    }
+  }
+}
+```
+
+The chained credential probes (in order): environment variables → workload identity → Managed Identity → Visual Studio / VS Code account → Azure CLI (`az login`) → Azure PowerShell. The first that succeeds is used.
+
+Typical setup:
+
+- **Local development**: developer runs `az login` once. The toolkit picks up that token and queries the workspace directly — no service principal secret to copy into user-secrets.
+- **Azure**: the App Service identity is used (same effect as `ManagedIdentity`). Grant it Log Analytics Reader as above.
+
+`TenantId` and `ClientId` are forwarded as hints (filter to a specific tenant; prefer a specific user-assigned MI) — both can be left empty.
+
+> **Trade-off**: `DefaultAzureCredential` masks *which* underlying credential succeeded. If authentication fails, the error chain is less specific than the explicit modes. For diagnosis, switch to `ClientSecret` or `ManagedIdentity` to isolate the issue.
 
 ## Universal telemetry tagging
 


### PR DESCRIPTION
## Summary

Adds a third value to `ApplicationInsightsAuthMode`: `DefaultAzureCredential = 2`. Uses `Azure.Identity.DefaultAzureCredential` under the hood — chains environment variables → workload identity → Managed Identity → Visual Studio / VS Code credentials → Azure CLI (`az login`) → Azure PowerShell, returning the first that succeeds.

A single `appsettings.json` works for local dev (developer runs `az login` once) and for Azure-hosted deployments (system- or user-assigned MI) without per-environment switching.

Closes the **IKEA Beräkna** ask filed 2026-04-28: developers can now use the Application Insights log viewer locally without deploying a service-principal secret.

## Headline change (commit `956f0ce`)

| File | Change |
|---|---|
| `Quilt4Net.Toolkit/Features/ApplicationInsights/ApplicationInsightsAuthMode.cs` | `DefaultAzureCredential = 2` with XML doc |
| `Quilt4Net.Toolkit/Features/ApplicationInsights/CredentialFactory.cs` | New switch arm; forwards `TenantId` / `ClientId` as hints (empty → null so SDK discovery kicks in); `ClientSecret` not consulted |
| `Quilt4Net.Toolkit/ApplicationInsightsOptions.cs`, `IApplicationInsightsContext.cs` | XML docs reference all three modes |
| `Quilt4Net.Toolkit.Tests/CredentialFactoryTests.cs` | 2 new tests (returns `DefaultAzureCredential`; works with empty tenant/client) |
| `Quilt4Net.Toolkit/README.md` | Options table + new "DefaultAzureCredential" subsection (local-dev story, probe order, diagnostic-clarity trade-off) |

## Bundled with this PR (already-developed content riding on local `develop`)

The branch was cut from local `develop` rather than `origin/master` (intentional change of approach), so this PR also brings:

- **`a27b36c`** — `chore(sample): show actually-resolved Quilt4Net address on Configuration page`. Same content currently sitting in PR #70. **PR #70 can be closed when this merges** (or this can be merged after #70).
- **`876cf65`, `f9fc7f7`** — Dependabot-style "update nuget packages" commits across the project files. No behaviour change, just version bumps.

If preferred, this branch can be rebased onto `origin/master` to isolate the feature commit; flag it and I'll redo.

## Backward compatibility

- New enum value at end (no reordering); default stays `ClientSecret`; existing `ClientSecret` and `ManagedIdentity` behaviour unchanged.
- No new package references — `DefaultAzureCredential` lives in `Azure.Identity`, already a dep of the Toolkit.
- The `IApplicationInsightsContext` default interface implementation still returns `ClientSecret`, so external implementers compiled against the old interface keep working.

## Test plan

- [x] 7 `CredentialFactoryTests` pass (5 existing + 2 new)
- [x] Full Toolkit test sweep — 126 pass (41 Toolkit + 36 Blazor + 48 Health + 1 Api)
- [x] Build clean (57 pre-existing warnings, unchanged)
- [ ] CI green on this PR
- [ ] After merge: confirm a consumer can `dotnet user-secrets remove "Quilt4Net:ApplicationInsights:ClientSecret"`, set `"AuthMode": "DefaultAzureCredential"`, run `az login`, and successfully render `/developer/log` locally