### PR TITLE
fix: log views render alert when IApplicationInsightsService isn't registered

### DIFF
--- a/Quilt4Net.Toolkit.Blazor.Tests/LogComponentsServiceMissingTests.cs
+++ b/Quilt4Net.Toolkit.Blazor.Tests/LogComponentsServiceMissingTests.cs
@@ -1,0 +1,101 @@
+using Bunit;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Options;
+using Quilt4Net.Toolkit.Blazor.Features.Log;
+using Quilt4Net.Toolkit.Features.ApplicationInsights;
+using Radzen;
+using Xunit;
+
+namespace Quilt4Net.Toolkit.Blazor.Tests;
+
+public class LogComponentsServiceMissingTests : BunitContext
+{
+    public LogComponentsServiceMissingTests()
+    {
+        // Required by some Log components but unrelated to the AI client guard.
+        Services.AddSingleton<IHostEnvironment>(new TestHostEnvironment());
+        Services.AddScoped<DialogService>();
+    }
+
+    [Fact]
+    public void LogEnvironmentSelector_Renders_Info_When_ApplicationInsightsService_Not_Registered()
+    {
+        var cut = Render<LogEnvironmentSelector>();
+
+        cut.Markup.Should().Contain(LogConfigurationGuard.ServiceNotRegisteredMessage);
+    }
+
+    [Fact]
+    public void LogSearchView_Renders_Info_When_ApplicationInsightsService_Not_Registered()
+    {
+        var cut = Render<LogSearchView>();
+
+        cut.Markup.Should().Contain(LogConfigurationGuard.ServiceNotRegisteredMessage);
+    }
+
+    [Fact]
+    public void LogSummaryListView_Renders_Info_When_ApplicationInsightsService_Not_Registered()
+    {
+        var cut = Render<LogSummaryListView>();
+
+        cut.Markup.Should().Contain(LogConfigurationGuard.ServiceNotRegisteredMessage);
+    }
+
+    [Fact]
+    public void LogMeasureView_Renders_Info_When_ApplicationInsightsService_Not_Registered()
+    {
+        var cut = Render<LogMeasureView>();
+
+        cut.Markup.Should().Contain(LogConfigurationGuard.ServiceNotRegisteredMessage);
+    }
+
+    [Fact]
+    public void LogCountView_Renders_Info_When_ApplicationInsightsService_Not_Registered()
+    {
+        var cut = Render<LogCountView>();
+
+        cut.Markup.Should().Contain(LogConfigurationGuard.ServiceNotRegisteredMessage);
+    }
+
+    [Fact]
+    public void LogDetailContent_Renders_Info_When_ApplicationInsightsService_Not_Registered()
+    {
+        var cut = Render<LogDetailContent>();
+
+        cut.Markup.Should().Contain(LogConfigurationGuard.ServiceNotRegisteredMessage);
+    }
+
+    [Fact]
+    public void LogSummaryContent_Renders_Info_When_ApplicationInsightsService_Not_Registered()
+    {
+        var cut = Render<LogSummaryContent>();
+
+        cut.Markup.Should().Contain(LogConfigurationGuard.ServiceNotRegisteredMessage);
+    }
+
+    [Fact]
+    public void LogView_Renders_Info_When_ApplicationInsightsService_Not_Registered()
+    {
+        Services.AddSingleton(Options.Create(new ApplicationInsightsOptions
+        {
+            TenantId = "tenant",
+            WorkspaceId = "workspace",
+            ClientId = "client",
+            ClientSecret = "secret"
+        }));
+
+        var cut = Render<LogView>();
+
+        cut.Markup.Should().Contain(LogConfigurationGuard.ServiceNotRegisteredMessage);
+    }
+
+    private sealed class TestHostEnvironment : IHostEnvironment
+    {
+        public string EnvironmentName { get; set; } = "Test";
+        public string ApplicationName { get; set; } = "Tests";
+        public string ContentRootPath { get; set; } = string.Empty;
+        public Microsoft.Extensions.FileProviders.IFileProvider ContentRootFileProvider { get; set; } = new Microsoft.Extensions.FileProviders.NullFileProvider();
+    }
+}

--- a/Quilt4Net.Toolkit.Blazor.Tests/LogViewConfigTests.cs
+++ b/Quilt4Net.Toolkit.Blazor.Tests/LogViewConfigTests.cs
@@ -3,12 +3,20 @@ using FluentAssertions;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using Quilt4Net.Toolkit.Blazor.Features.Log;
+using Quilt4Net.Toolkit.Features.ApplicationInsights;
 using Xunit;
 
 namespace Quilt4Net.Toolkit.Blazor.Tests;
 
 public class LogViewConfigTests : BunitContext
 {
+    public LogViewConfigTests()
+    {
+        // Register a stub service so the LogView's service-missing guard passes — these tests
+        // exercise the *options*-missing guard, which runs after the service guard.
+        Services.AddSingleton<IApplicationInsightsService>(new StubApplicationInsightsService());
+    }
+
     [Fact]
     public void Shows_Error_When_ApplicationInsights_Not_Configured()
     {
@@ -41,5 +49,23 @@ public class LogViewConfigTests : BunitContext
         var cut = Render<LogView>();
 
         cut.Markup.Should().Contain("Application Insights is not configured");
+    }
+
+    private sealed class StubApplicationInsightsService : IApplicationInsightsService
+    {
+        public Task<bool> CanConnectAsync(IApplicationInsightsContext context) => Task.FromResult(false);
+        public IAsyncEnumerable<EnvironmentOption> GetEnvironments(IApplicationInsightsContext context) => Empty<EnvironmentOption>();
+        public IAsyncEnumerable<LogItem> SearchAsync(IApplicationInsightsContext context, string environment, string text, TimeSpan timeSpan, SeverityLevel minSeverityLevel = SeverityLevel.Verbose) => Empty<LogItem>();
+        public IAsyncEnumerable<MeasureData> GetMeasureAsync(IApplicationInsightsContext context, string environment, TimeSpan timeSpan) => Empty<MeasureData>();
+        public IAsyncEnumerable<CountData> GetCountAsync(IApplicationInsightsContext context, string environment, TimeSpan timeSpan) => Empty<CountData>();
+        public Task<LogDetails> GetDetail(IApplicationInsightsContext context, string id, LogSource source, string environment, TimeSpan timeSpan) => Task.FromResult<LogDetails>(null);
+        public Task<SummaryData> GetSummary(IApplicationInsightsContext context, string fingerprint, LogSource source, string environment, TimeSpan timeSpan) => Task.FromResult<SummaryData>(null);
+        public IAsyncEnumerable<SummarySubset> GetSummaries(IApplicationInsightsContext context, string environment, TimeSpan timeSpan) => Empty<SummarySubset>();
+
+        private static async IAsyncEnumerable<T> Empty<T>()
+        {
+            await Task.CompletedTask;
+            yield break;
+        }
     }
 }

--- a/Quilt4Net.Toolkit.Blazor/Features/Log/LogConfigurationGuard.cs
+++ b/Quilt4Net.Toolkit.Blazor/Features/Log/LogConfigurationGuard.cs
@@ -1,0 +1,13 @@
+using Microsoft.Extensions.DependencyInjection;
+using Quilt4Net.Toolkit.Features.ApplicationInsights;
+
+namespace Quilt4Net.Toolkit.Blazor.Features.Log;
+
+internal static class LogConfigurationGuard
+{
+    public const string ServiceNotRegisteredMessage =
+        "Application Insights client is not registered. Call builder.AddQuilt4NetApplicationInsightsClient() in Program.cs to enable this view.";
+
+    public static IApplicationInsightsService TryResolve(IServiceProvider services)
+        => services.GetService<IApplicationInsightsService>();
+}

--- a/Quilt4Net.Toolkit.Blazor/Features/Log/LogCountView.razor
+++ b/Quilt4Net.Toolkit.Blazor/Features/Log/LogCountView.razor
@@ -1,9 +1,13 @@
 @using Quilt4Net.Toolkit.Features.ApplicationInsights
-@inject IApplicationInsightsService ApplicationInsightsService
+@inject IServiceProvider ServiceProvider
 @inject NavigationManager NavigationManager
 @inject DialogService DialogService
 
-@if (Model == null)
+@if (_configError != null)
+{
+    <RadzenAlert AlertStyle="AlertStyle.Info" Shade="Shade.Lighter" AllowClose="false">@_configError</RadzenAlert>
+}
+else if (Model == null)
 {
     <Loading />
 }
@@ -64,6 +68,17 @@ else
 @code {
     private CountData[] Model { get; set; }
     private IReadOnlyList<ActionSeries> Series { get; set; } = Array.Empty<ActionSeries>();
+    private string _configError;
+    private IApplicationInsightsService _ais;
+
+    protected override void OnInitialized()
+    {
+        _ais = LogConfigurationGuard.TryResolve(ServiceProvider);
+        if (_ais == null)
+        {
+            _configError = LogConfigurationGuard.ServiceNotRegisteredMessage;
+        }
+    }
 
     [Parameter]
     public string Environment { get; set; }
@@ -81,8 +96,10 @@ else
 
     protected override async Task OnParametersSetAsync()
     {
+        if (_configError != null) return;
+
         Model = null;
-        Model = await ApplicationInsightsService
+        Model = await _ais
             .GetCountAsync(Context, Environment, Range)
             .ToArrayAsync();
 

--- a/Quilt4Net.Toolkit.Blazor/Features/Log/LogDetailContent.razor
+++ b/Quilt4Net.Toolkit.Blazor/Features/Log/LogDetailContent.razor
@@ -1,10 +1,14 @@
 @using System.Text.Json
 @using Quilt4Net.Toolkit.Features.ApplicationInsights
 @using Tharga.Toolkit
-@inject IApplicationInsightsService ApplicationInsightsService
+@inject IServiceProvider ServiceProvider
 @inject NavigationManager NavigationManager
 
-@if (Model == null)
+@if (_configError != null)
+{
+    <RadzenAlert AlertStyle="AlertStyle.Info" Shade="Shade.Lighter" AllowClose="false">@_configError</RadzenAlert>
+}
+else if (Model == null)
 {
     <Loading />
 }
@@ -81,6 +85,8 @@ else
 
 @code {
     private bool _showEmptyValues;
+    private string _configError;
+    private IApplicationInsightsService _ais;
 
     private string DisplayedJson => _showEmptyValues ? FormatJson(Model.RawJson) : FilterEmptyValues(Model.RawJson);
     private LogDetails Model { get; set; }
@@ -112,13 +118,24 @@ else
     [Parameter]
     public EventCallback OnSummaryNavigation { get; set; }
 
+    protected override void OnInitialized()
+    {
+        _ais = LogConfigurationGuard.TryResolve(ServiceProvider);
+        if (_ais == null)
+        {
+            _configError = LogConfigurationGuard.ServiceNotRegisteredMessage;
+        }
+    }
+
     protected override async Task OnParametersSetAsync()
     {
+        if (_configError != null) return;
+
         Model = null;
 
         if (!Source.HasValue || !Range.HasValue) return;
 
-        Model = await ApplicationInsightsService.GetDetail(Context, Id, Source.Value, Environment, Range.Value);
+        Model = await _ais.GetDetail(Context, Id, Source.Value, Environment, Range.Value);
 
         await base.OnParametersSetAsync();
     }

--- a/Quilt4Net.Toolkit.Blazor/Features/Log/LogEnvironmentSelector.razor
+++ b/Quilt4Net.Toolkit.Blazor/Features/Log/LogEnvironmentSelector.razor
@@ -1,9 +1,13 @@
 ﻿@using Microsoft.Extensions.Hosting
 @using Quilt4Net.Toolkit.Features.ApplicationInsights
 @inject IHostEnvironment HostEnvironment
-@inject IApplicationInsightsService ApplicationInsightsService
+@inject IServiceProvider ServiceProvider
 
-@if (_loadError != null)
+@if (_configError != null)
+{
+    <RadzenAlert AlertStyle="AlertStyle.Info" Shade="Shade.Lighter" AllowClose="false">@_configError</RadzenAlert>
+}
+else if (_loadError != null)
 {
     <RadzenAlert AlertStyle="AlertStyle.Warning" Shade="Shade.Lighter" AllowClose="false">@_loadError</RadzenAlert>
 }
@@ -29,6 +33,8 @@ else
     private IApplicationInsightsContext _loadedContext;
     private EnvironmentOption _firedContext;
     private string _loadError;
+    private string _configError;
+    private IApplicationInsightsService _ais;
 
     [Parameter]
     public EventCallback<EnvironmentOption> OnSelected { get; set; }
@@ -36,8 +42,19 @@ else
     [Parameter]
     public IApplicationInsightsContext Context { get; set; }
 
+    protected override void OnInitialized()
+    {
+        _ais = LogConfigurationGuard.TryResolve(ServiceProvider);
+        if (_ais == null)
+        {
+            _configError = LogConfigurationGuard.ServiceNotRegisteredMessage;
+        }
+    }
+
     protected override async Task OnParametersSetAsync()
     {
+        if (_configError != null) return;
+
         if (_environments == null || !Equals(_loadedContext, Context))
         {
             _loadedContext = Context;
@@ -45,7 +62,7 @@ else
 
             try
             {
-                var environments = await ApplicationInsightsService.GetEnvironments(_loadedContext).ToArrayAsync();
+                var environments = await _ais.GetEnvironments(_loadedContext).ToArrayAsync();
 
                 _environments = environments.Select(x => new EnvironmentOption(x)).ToArray();
 

--- a/Quilt4Net.Toolkit.Blazor/Features/Log/LogMeasureView.razor
+++ b/Quilt4Net.Toolkit.Blazor/Features/Log/LogMeasureView.razor
@@ -1,9 +1,13 @@
 @using Quilt4Net.Toolkit.Features.ApplicationInsights
-@inject IApplicationInsightsService ApplicationInsightsService
+@inject IServiceProvider ServiceProvider
 @inject NavigationManager NavigationManager
 @inject DialogService DialogService
 
-@if (Model == null)
+@if (_configError != null)
+{
+    <RadzenAlert AlertStyle="AlertStyle.Info" Shade="Shade.Lighter" AllowClose="false">@_configError</RadzenAlert>
+}
+else if (Model == null)
 {
     <Loading />
 }
@@ -71,6 +75,17 @@ else
 @code {
     private MeasureData[] Model { get; set; }
     private IReadOnlyList<ActionSeries> Series { get; set; } = Array.Empty<ActionSeries>();
+    private string _configError;
+    private IApplicationInsightsService _ais;
+
+    protected override void OnInitialized()
+    {
+        _ais = LogConfigurationGuard.TryResolve(ServiceProvider);
+        if (_ais == null)
+        {
+            _configError = LogConfigurationGuard.ServiceNotRegisteredMessage;
+        }
+    }
 
     [Parameter]
     public string Environment { get; set; }
@@ -88,8 +103,10 @@ else
 
     protected override async Task OnParametersSetAsync()
     {
+        if (_configError != null) return;
+
         Model = null;
-        Model = await ApplicationInsightsService
+        Model = await _ais
             .GetMeasureAsync(Context, Environment, Range)
             .Where(x => x.Elapsed < TimeSpan.FromHours(10)) //TODO: I made a misstake with a log entry, remove this when Neurolito log is clean. That would be about 2026-02-01.
             .ToArrayAsync();

--- a/Quilt4Net.Toolkit.Blazor/Features/Log/LogSearchView.razor
+++ b/Quilt4Net.Toolkit.Blazor/Features/Log/LogSearchView.razor
@@ -1,7 +1,13 @@
 ﻿@using Quilt4Net.Toolkit.Features.ApplicationInsights
-@inject IApplicationInsightsService ApplicationInsightsService
+@inject IServiceProvider ServiceProvider
 @inject DialogService DialogService
 @inject NavigationManager NavigationManager
+
+@if (_configError != null)
+{
+    <RadzenAlert AlertStyle="AlertStyle.Info" Shade="Shade.Lighter" AllowClose="false">@_configError</RadzenAlert>
+    return;
+}
 
 <RadzenStack Style="margin-bottom: 6px;" Orientation="Orientation.Horizontal">
     <RadzenTextBox @bind-value="@_searchText" />
@@ -43,7 +49,18 @@ else if (Model != null)
 @code {
     private bool _loading;
     private string _searchText;
+    private string _configError;
+    private IApplicationInsightsService _ais;
     private LogItem[] Model { get; set; }
+
+    protected override void OnInitialized()
+    {
+        _ais = LogConfigurationGuard.TryResolve(ServiceProvider);
+        if (_ais == null)
+        {
+            _configError = LogConfigurationGuard.ServiceNotRegisteredMessage;
+        }
+    }
 
     [CascadingParameter]
     private LogNavigationOptions _cascadedNavOptions { get; set; }
@@ -65,7 +82,7 @@ else if (Model != null)
         StateHasChanged();
 
         var searchText = _searchText ?? string.Empty;
-        Model = await ApplicationInsightsService.SearchAsync(Context, Environment, searchText, Range).ToArrayAsync();
+        Model = await _ais.SearchAsync(Context, Environment, searchText, Range).ToArrayAsync();
 
         _loading = false;
         StateHasChanged();

--- a/Quilt4Net.Toolkit.Blazor/Features/Log/LogSummaryContent.razor
+++ b/Quilt4Net.Toolkit.Blazor/Features/Log/LogSummaryContent.razor
@@ -1,8 +1,12 @@
 @using Quilt4Net.Toolkit.Features.ApplicationInsights
-@inject IApplicationInsightsService ApplicationInsightsService
+@inject IServiceProvider ServiceProvider
 @inject NavigationManager NavigationManager
 
-@if (Model == null)
+@if (_configError != null)
+{
+    <RadzenAlert AlertStyle="AlertStyle.Info" Shade="Shade.Lighter" AllowClose="false">@_configError</RadzenAlert>
+}
+else if (Model == null)
 {
     <Loading />
 }
@@ -66,6 +70,17 @@ else
 @code {
     private SummaryData Model { get; set; }
     private string _selectedDetailId;
+    private string _configError;
+    private IApplicationInsightsService _ais;
+
+    protected override void OnInitialized()
+    {
+        _ais = LogConfigurationGuard.TryResolve(ServiceProvider);
+        if (_ais == null)
+        {
+            _configError = LogConfigurationGuard.ServiceNotRegisteredMessage;
+        }
+    }
 
     [Parameter]
     public string Fingerprint { get; set; }
@@ -89,11 +104,13 @@ else
 
     protected override async Task OnParametersSetAsync()
     {
+        if (_configError != null) return;
+
         Model = null;
 
         if (!Source.HasValue || !Range.HasValue) return;
 
-        Model = await ApplicationInsightsService.GetSummary(Context, Fingerprint, Source.Value, Environment, Range.Value);
+        Model = await _ais.GetSummary(Context, Fingerprint, Source.Value, Environment, Range.Value);
 
         await base.OnParametersSetAsync();
     }

--- a/Quilt4Net.Toolkit.Blazor/Features/Log/LogSummaryListView.razor
+++ b/Quilt4Net.Toolkit.Blazor/Features/Log/LogSummaryListView.razor
@@ -1,9 +1,13 @@
 ﻿@using Quilt4Net.Toolkit.Features.ApplicationInsights
-@inject IApplicationInsightsService ApplicationInsightsService
+@inject IServiceProvider ServiceProvider
 @inject DialogService DialogService
 @inject NavigationManager NavigationManager
 
-@if (Model == null)
+@if (_configError != null)
+{
+    <RadzenAlert AlertStyle="AlertStyle.Info" Shade="Shade.Lighter" AllowClose="false">@_configError</RadzenAlert>
+}
+else if (Model == null)
 {
     <Loading />
 }
@@ -38,6 +42,17 @@ else
 
 @code {
     private SummarySubset[] Model { get; set; }
+    private string _configError;
+    private IApplicationInsightsService _ais;
+
+    protected override void OnInitialized()
+    {
+        _ais = LogConfigurationGuard.TryResolve(ServiceProvider);
+        if (_ais == null)
+        {
+            _configError = LogConfigurationGuard.ServiceNotRegisteredMessage;
+        }
+    }
 
     [CascadingParameter]
     private LogNavigationOptions _cascadedNavOptions { get; set; }
@@ -55,8 +70,10 @@ else
 
     protected override async Task OnParametersSetAsync()
     {
+        if (_configError != null) return;
+
         Model = null;
-        Model = await ApplicationInsightsService
+        Model = await _ais
             .GetSummaries(Context, Environment, Range)
             .ToArrayAsync();
     }

--- a/Quilt4Net.Toolkit.Blazor/Features/Log/LogView.razor
+++ b/Quilt4Net.Toolkit.Blazor/Features/Log/LogView.razor
@@ -121,6 +121,12 @@
 
     protected override void OnInitialized()
     {
+        if (LogConfigurationGuard.TryResolve(ServiceProvider) == null)
+        {
+            _configError = LogConfigurationGuard.ServiceNotRegisteredMessage;
+            return;
+        }
+
         if (Context == null)
         {
             var options = ServiceProvider.GetService<IOptions<ApplicationInsightsOptions>>()?.Value;


### PR DESCRIPTION
## Summary

- Resolves PlutusWave's High-priority report (Requests.md 2026-04-20): navigating to `/developer/log` on a consumer that hasn't called `AddQuilt4NetApplicationInsightsClient()` threw an `InvalidOperationException` from Blazor's `ComponentFactory` and could close the circuit, before the existing options-missing guard in `LogView` could run.
- Each affected Log component (`LogEnvironmentSelector`, `LogDetailContent`, `LogSearchView`, `LogSummaryContent`, `LogSummaryListView`, `LogMeasureView`, `LogCountView`) now resolves `IApplicationInsightsService` via `IServiceProvider` (returns null instead of throwing) and renders an info alert pointing the consumer at the registration call. `LogView` short-circuits at the top with the same message so children don't render. New `LogConfigurationGuard` keeps the resolve + message in one place.

## Test plan

- [x] `Quilt4Net.Toolkit.Blazor.Tests` — 44/44 pass (8 new tests in `LogComponentsServiceMissingTests`, 3 existing `LogViewConfigTests` updated to register a stub service so their options-missing branch is still exercised)
- [x] `Quilt4Net.Toolkit.Tests` — 39/39 pass
- [x] Local build clean, no new warnings (ratchet not breached)
- [ ] CI green