### PR TITLE
chore: migrate from deprecated Azure.Monitor.Query to Azure.Monitor.Query.Logs

### DIFF
--- a/Quilt4Net.Toolkit/Features/ApplicationInsights/ApplicationInsightsService.cs
+++ b/Quilt4Net.Toolkit/Features/ApplicationInsights/ApplicationInsightsService.cs
@@ -1,7 +1,7 @@
 ﻿using System.Diagnostics;
 using Azure.Identity;
-using Azure.Monitor.Query;
-using Azure.Monitor.Query.Models;
+using Azure.Monitor.Query.Logs;
+using Azure.Monitor.Query.Logs.Models;
 using Microsoft.Extensions.Options;
 using System.Text.Json;
 using Tharga.Cache;
@@ -25,7 +25,7 @@ internal class ApplicationInsightsService : IApplicationInsightsService
         {
             var client = GetClient(context);
             var detailQuery = "AppTraces";
-            _ = await client.QueryWorkspaceAsync(context.WorkspaceId, detailQuery, new QueryTimeRange(DateTimeOffset.Now.AddDays(-1), DateTimeOffset.Now));
+            _ = await client.QueryWorkspaceAsync(context.WorkspaceId, detailQuery, new LogsQueryTimeRange(DateTimeOffset.Now.AddDays(-1), DateTimeOffset.Now));
 
             return true;
         }
@@ -88,7 +88,7 @@ union
         var response = await client.QueryWorkspaceAsync(
             workspaceId,
             query,
-            new QueryTimeRange(from, to));
+            new LogsQueryTimeRange(from, to));
 
         var table = response.Value.Table;
         var envIndex = GetColumnIndex(table, "Environment");
@@ -195,7 +195,7 @@ AppExceptions
         var response = await client.QueryWorkspaceAsync(
             workspaceId,
             query,
-            new QueryTimeRange(timeSpan));
+            new LogsQueryTimeRange(timeSpan));
 
         foreach (var table in response.Value.AllTables)
         {
@@ -256,7 +256,7 @@ AppTraces
         response = await client.QueryWorkspaceAsync(
             workspaceId,
             query,
-            new QueryTimeRange(timeSpan));
+            new LogsQueryTimeRange(timeSpan));
 
         foreach (var table in response.Value.AllTables)
         {
@@ -319,7 +319,7 @@ AppRequests
         response = await client.QueryWorkspaceAsync(
             workspaceId,
             query,
-            new QueryTimeRange(timeSpan));
+            new LogsQueryTimeRange(timeSpan));
 
         foreach (var table in response.Value.AllTables)
         {
@@ -421,7 +421,7 @@ AppTraces
         var response = await client.QueryWorkspaceAsync(
             workspaceId,
             query,
-            new QueryTimeRange(timeSpan));
+            new LogsQueryTimeRange(timeSpan));
 
         foreach (var table in response.Value.AllTables)
         {
@@ -528,7 +528,7 @@ AppTraces
         var response = await client.QueryWorkspaceAsync(
             workspaceId,
             query,
-            new QueryTimeRange(timeSpan));
+            new LogsQueryTimeRange(timeSpan));
 
         foreach (var table in response.Value.AllTables)
         {
@@ -620,7 +620,7 @@ AppRequests
         var response = await client.QueryWorkspaceAsync(
             workspaceId,
             query,
-            new QueryTimeRange(timeSpan));
+            new LogsQueryTimeRange(timeSpan));
 
         var table = response.Value.Table;
 
@@ -735,7 +735,7 @@ AppRequests
         var response = await client.QueryWorkspaceAsync(
             workspaceId,
             query,
-            new QueryTimeRange(timeSpan));
+            new LogsQueryTimeRange(timeSpan));
 
         var table = response.Value.Table;
         if (table.Rows.Count == 0)
@@ -864,7 +864,7 @@ AppRequests
             var response = await client.QueryWorkspaceAsync(
                 workspaceId,
                 query,
-                new QueryTimeRange(timeSpan));
+                new LogsQueryTimeRange(timeSpan));
 
             var table = response.Value.Table;
 

--- a/Quilt4Net.Toolkit/Quilt4Net.Toolkit.csproj
+++ b/Quilt4Net.Toolkit/Quilt4Net.Toolkit.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="Azure.Identity" Version="1.21.0" />
     <PackageReference Include="Microsoft.ApplicationInsights" Version="3.1.0" />
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.15.3" />
-    <PackageReference Include="Azure.Monitor.Query" Version="1.7.1" />
+    <PackageReference Include="Azure.Monitor.Query.Logs" Version="1.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.7" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.7" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.7" />


### PR DESCRIPTION
## Summary

- \`Azure.Monitor.Query\` 1.7.1 is flagged Legacy/deprecated by NuGet — \`dotnet list package --deprecated\` reports it on net8.0/net9.0/net10.0. Microsoft shipped \`Azure.Monitor.Query.Logs\` 1.0.0 (stable, GA) as the dedicated successor for the logs-only query path. We don't use the metrics path, so this is a clean swap.
- One package replaced, two \`using\` directives renamed, 10× \`QueryTimeRange\` → \`LogsQueryTimeRange\`. \`LogsQueryClient\`, \`QueryWorkspaceAsync\`, \`LogsQueryResult\`, \`LogsTable\` keep their names. \`IApplicationInsightsService\` exposes only our own DTOs — public API surface unchanged.
- Source: [official migration guide](https://github.com/Azure/azure-sdk-for-net/blob/Azure.Monitor.Query.Logs_1.0.0/sdk/monitor/Azure.Monitor.Query.Logs/MigrationGuide.md).

## Test plan

- [x] Build clean across net8.0/net9.0/net10.0, 0 errors
- [x] \`Quilt4Net.Toolkit.Tests\` 39/39 pass
- [x] \`Quilt4Net.Toolkit.Blazor.Tests\` 36/36 pass
- [x] \`dotnet list package --deprecated\` reports zero deprecated packages across the solution
- [x] Warning ratchet not breached
- [ ] CI green
- [ ] Smoke-test against a real AI workspace via \`/developer/log\` after merge — migration guide says these are pure renames, but a live query is the only way to verify the new client serializes/authenticates identically