### PR TITLE
feat: log AI failures with structured exception + IncidentId

### DIFF
--- a/Quilt4Net.Toolkit.Blazor.Tests/ApplicationInsightsErrorMessageTests.cs
+++ b/Quilt4Net.Toolkit.Blazor.Tests/ApplicationInsightsErrorMessageTests.cs
@@ -1,0 +1,51 @@
+using FluentAssertions;
+using Quilt4Net.Toolkit.Blazor.Features.Log;
+using Xunit;
+
+namespace Quilt4Net.Toolkit.Blazor.Tests;
+
+public class ApplicationInsightsErrorMessageTests
+{
+    [Fact]
+    public void Format_without_incidentId_omits_incident_suffix()
+    {
+        var msg = ApplicationInsightsErrorMessage.Format("Could not load.", new InvalidOperationException("boom"));
+
+        msg.Should().Be("Could not load. boom");
+        msg.Should().NotContain("[Incident:");
+    }
+
+    [Fact]
+    public void Format_with_incidentId_appends_bracketed_incident_suffix()
+    {
+        var msg = ApplicationInsightsErrorMessage.Format("Could not load.", new InvalidOperationException("boom"), "K7XQ4P");
+
+        msg.Should().Be("Could not load. boom [Incident: K7XQ4P]");
+    }
+
+    [Fact]
+    public void Format_authentication_failure_includes_friendly_text_and_incident()
+    {
+        var inner = new InvalidOperationException("AADSTS7000215: Invalid client secret provided.");
+        var outer = new Exception("wrapper", inner);
+
+        var msg = ApplicationInsightsErrorMessage.Format("Could not load.", outer, "K7XQ4P");
+
+        msg.Should().StartWith("Could not load. Application Insights authentication failed");
+        msg.Should().EndWith("[Incident: K7XQ4P]");
+    }
+
+    [Fact]
+    public void Format_with_null_incidentId_behaves_like_two_arg_overload()
+    {
+        var msg = ApplicationInsightsErrorMessage.Format("Could not load.", new InvalidOperationException("boom"), null);
+        msg.Should().NotContain("[Incident:");
+    }
+
+    [Fact]
+    public void Format_with_empty_incidentId_behaves_like_two_arg_overload()
+    {
+        var msg = ApplicationInsightsErrorMessage.Format("Could not load.", new InvalidOperationException("boom"), string.Empty);
+        msg.Should().NotContain("[Incident:");
+    }
+}

--- a/Quilt4Net.Toolkit.Blazor.Tests/LogEnvironmentSelectorIncidentTests.cs
+++ b/Quilt4Net.Toolkit.Blazor.Tests/LogEnvironmentSelectorIncidentTests.cs
@@ -1,0 +1,62 @@
+using Bunit;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Quilt4Net.Toolkit.Blazor.Features.Log;
+using Quilt4Net.Toolkit.Features.ApplicationInsights;
+using Xunit;
+
+namespace Quilt4Net.Toolkit.Blazor.Tests;
+
+public class LogEnvironmentSelectorIncidentTests : BunitContext
+{
+    public LogEnvironmentSelectorIncidentTests()
+    {
+        Services.AddLogging();
+        Services.AddSingleton<IHostEnvironment>(new TestHostEnvironment());
+    }
+
+    [Fact]
+    public void Renders_alert_with_Incident_id_when_GetEnvironments_throws()
+    {
+        Services.AddSingleton<IApplicationInsightsService>(new ThrowingApplicationInsightsService(new InvalidOperationException("boom")));
+
+        var cut = Render<LogEnvironmentSelector>();
+
+        cut.Markup.Should().Contain("Could not load Application Insights environments.");
+        cut.Markup.Should().MatchRegex(@"\[Incident:\s+[2-9A-HJ-NP-Z]{6}\]");
+    }
+
+    private sealed class ThrowingApplicationInsightsService : IApplicationInsightsService
+    {
+        private readonly Exception _ex;
+        public ThrowingApplicationInsightsService(Exception ex) => _ex = ex;
+
+        public Task<bool> CanConnectAsync(IApplicationInsightsContext context) => Task.FromResult(false);
+
+        public IAsyncEnumerable<EnvironmentOption> GetEnvironments(IApplicationInsightsContext context) => Throw<EnvironmentOption>();
+        public IAsyncEnumerable<LogItem> SearchAsync(IApplicationInsightsContext context, string environment, string text, TimeSpan timeSpan, SeverityLevel minSeverityLevel = SeverityLevel.Verbose) => Throw<LogItem>();
+        public IAsyncEnumerable<MeasureData> GetMeasureAsync(IApplicationInsightsContext context, string environment, TimeSpan timeSpan) => Throw<MeasureData>();
+        public IAsyncEnumerable<CountData> GetCountAsync(IApplicationInsightsContext context, string environment, TimeSpan timeSpan) => Throw<CountData>();
+        public Task<LogDetails> GetDetail(IApplicationInsightsContext context, string id, LogSource source, string environment, TimeSpan timeSpan) => Task.FromException<LogDetails>(_ex);
+        public Task<SummaryData> GetSummary(IApplicationInsightsContext context, string fingerprint, LogSource source, string environment, TimeSpan timeSpan) => Task.FromException<SummaryData>(_ex);
+        public IAsyncEnumerable<SummarySubset> GetSummaries(IApplicationInsightsContext context, string environment, TimeSpan timeSpan) => Throw<SummarySubset>();
+
+#pragma warning disable CS1998
+        private async IAsyncEnumerable<T> Throw<T>()
+#pragma warning restore CS1998
+        {
+            throw _ex;
+            yield break;
+        }
+    }
+
+    private sealed class TestHostEnvironment : IHostEnvironment
+    {
+        public string EnvironmentName { get; set; } = "Test";
+        public string ApplicationName { get; set; } = "Tests";
+        public string ContentRootPath { get; set; } = string.Empty;
+        public Microsoft.Extensions.FileProviders.IFileProvider ContentRootFileProvider { get; set; } = new Microsoft.Extensions.FileProviders.NullFileProvider();
+    }
+}

--- a/Quilt4Net.Toolkit.Blazor/Features/Log/ApplicationInsightsErrorMessage.cs
+++ b/Quilt4Net.Toolkit.Blazor/Features/Log/ApplicationInsightsErrorMessage.cs
@@ -3,13 +3,17 @@ namespace Quilt4Net.Toolkit.Blazor.Features.Log;
 internal static class ApplicationInsightsErrorMessage
 {
     public static string Format(string prefix, Exception ex)
-    {
-        if (IsAuthenticationFailure(ex))
-        {
-            return $"{prefix} Application Insights authentication failed — the configured TenantId, WorkspaceId, ClientId or ClientSecret may be incorrect, the secret may have expired, or the service principal may not have access to the workspace. Verify the Application Insights settings.";
-        }
+        => Format(prefix, ex, null);
 
-        return $"{prefix} {ex.Message}";
+    public static string Format(string prefix, Exception ex, string incidentId)
+    {
+        var body = IsAuthenticationFailure(ex)
+            ? "Application Insights authentication failed — the configured TenantId, WorkspaceId, ClientId or ClientSecret may be incorrect, the secret may have expired, or the service principal may not have access to the workspace. Verify the Application Insights settings."
+            : ex.Message;
+
+        return string.IsNullOrEmpty(incidentId)
+            ? $"{prefix} {body}"
+            : $"{prefix} {body} [Incident: {incidentId}]";
     }
 
     private static bool IsAuthenticationFailure(Exception ex)

--- a/Quilt4Net.Toolkit.Blazor/Features/Log/LogEnvironmentSelector.razor
+++ b/Quilt4Net.Toolkit.Blazor/Features/Log/LogEnvironmentSelector.razor
@@ -1,7 +1,9 @@
 ﻿@using Microsoft.Extensions.Hosting
+@using Microsoft.Extensions.Logging
 @using Quilt4Net.Toolkit.Features.ApplicationInsights
 @inject IHostEnvironment HostEnvironment
 @inject IServiceProvider ServiceProvider
+@inject ILogger<LogEnvironmentSelector> Logger
 
 @if (_configError != null)
 {
@@ -75,7 +77,8 @@ else
             }
             catch (Exception ex)
             {
-                _loadError = ApplicationInsightsErrorMessage.Format("Could not load Application Insights environments.", ex);
+                _loadError = LogIncidentLogger.LogAndFormat(Logger, ex, nameof(LogEnvironmentSelector),
+                    "Could not load Application Insights environments.");
                 _environments = Array.Empty<EnvironmentOption>();
             }
         }

--- a/Quilt4Net.Toolkit.Blazor/Features/Log/LogIncidentLogger.cs
+++ b/Quilt4Net.Toolkit.Blazor/Features/Log/LogIncidentLogger.cs
@@ -1,0 +1,25 @@
+using Microsoft.Extensions.Logging;
+using Quilt4Net.Toolkit.Features.Diagnostics;
+
+namespace Quilt4Net.Toolkit.Blazor.Features.Log;
+
+internal static class LogIncidentLogger
+{
+    /// <summary>
+    /// Mints an incident id, logs the exception with structured properties,
+    /// and returns a user-facing message that includes the same id so the
+    /// reporter and the log entry can be cross-referenced.
+    /// </summary>
+    public static string LogAndFormat(
+        ILogger logger,
+        Exception ex,
+        string componentName,
+        string userPrefix)
+    {
+        var incidentId = IncidentId.New();
+        logger.LogError(ex,
+            "AI call failed. Incident={IncidentId} Component={Component}",
+            incidentId, componentName);
+        return ApplicationInsightsErrorMessage.Format(userPrefix, ex, incidentId);
+    }
+}

--- a/Quilt4Net.Toolkit.Blazor/Features/Log/LogView.razor
+++ b/Quilt4Net.Toolkit.Blazor/Features/Log/LogView.razor
@@ -30,7 +30,7 @@
         </RadzenColumn>
     </RadzenRow>
 
-    <ErrorBoundary @ref="_errorBoundary">
+    <LoggingErrorBoundary @ref="_errorBoundary">
         <ChildContent>
             <RadzenTabs SelectedIndex="@_tabIndex" Change="@OnTabChange">
                 <Tabs>
@@ -54,10 +54,10 @@
         </ChildContent>
         <ErrorContent Context="ex">
             <RadzenAlert AlertStyle="AlertStyle.Warning" Shade="Shade.Lighter" AllowClose="false">
-                @ApplicationInsightsErrorMessage.Format("Could not query Application Insights.", ex)
+                @ApplicationInsightsErrorMessage.Format("Could not query Application Insights.", ex, _errorBoundary?.IncidentId)
             </RadzenAlert>
         </ErrorContent>
-    </ErrorBoundary>
+    </LoggingErrorBoundary>
 </CascadingValue>
 
 @code {
@@ -68,7 +68,7 @@
     private LogNavigationOptions _navOptions;
     private int _tabIndex;
     private string _configError;
-    private ErrorBoundary _errorBoundary;
+    private LoggingErrorBoundary _errorBoundary;
 
     [Parameter]
     public bool ShowRangeSelector { get; set; } = true;

--- a/Quilt4Net.Toolkit.Blazor/Features/Log/LoggingErrorBoundary.cs
+++ b/Quilt4Net.Toolkit.Blazor/Features/Log/LoggingErrorBoundary.cs
@@ -1,0 +1,27 @@
+using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Web;
+using Microsoft.Extensions.Logging;
+
+namespace Quilt4Net.Toolkit.Blazor.Features.Log;
+
+/// <summary>
+/// <see cref="ErrorBoundary"/> that mints an <see cref="Quilt4Net.Toolkit.Features.Diagnostics.IncidentId"/>
+/// once per caught exception and writes a structured error log entry. The id is exposed via
+/// <see cref="IncidentId"/> so the rendered error message can include it.
+/// </summary>
+public class LoggingErrorBoundary : ErrorBoundary
+{
+    [Inject]
+    public ILogger<LoggingErrorBoundary> Logger { get; set; } = default!;
+
+    public string IncidentId { get; private set; }
+
+    protected override Task OnErrorAsync(Exception exception)
+    {
+        IncidentId = Quilt4Net.Toolkit.Features.Diagnostics.IncidentId.New();
+        Logger.LogError(exception,
+            "AI call failed. Incident={IncidentId} Component=LogView",
+            IncidentId);
+        return base.OnErrorAsync(exception);
+    }
+}

--- a/Quilt4Net.Toolkit.Tests/IncidentIdTests.cs
+++ b/Quilt4Net.Toolkit.Tests/IncidentIdTests.cs
@@ -1,0 +1,50 @@
+using FluentAssertions;
+using Quilt4Net.Toolkit.Features.Diagnostics;
+using Xunit;
+
+namespace Quilt4Net.Toolkit.Tests;
+
+public class IncidentIdTests
+{
+    [Fact]
+    public void New_returns_id_of_default_length_6()
+    {
+        var id = IncidentId.New();
+        id.Length.Should().Be(6);
+    }
+
+    [Theory]
+    [InlineData(4)]
+    [InlineData(6)]
+    [InlineData(12)]
+    public void New_honors_requested_length(int length)
+    {
+        var id = IncidentId.New(length);
+        id.Length.Should().Be(length);
+    }
+
+    [Fact]
+    public void New_uses_unambiguous_alphabet_only()
+    {
+        for (var i = 0; i < 200; i++)
+        {
+            var id = IncidentId.New(8);
+            id.Should().MatchRegex("^[2-9A-HJ-NP-Z]+$",
+                "ids must avoid ambiguous characters 0/1/I/O");
+        }
+    }
+
+    [Fact]
+    public void New_returns_distinct_values_across_calls()
+    {
+        var ids = Enumerable.Range(0, 100).Select(_ => IncidentId.New()).ToHashSet();
+        ids.Count.Should().BeGreaterThan(95, "with 6-char ids over 32 alphabet, near-100 distinct out of 100 is expected");
+    }
+
+    [Fact]
+    public void New_throws_for_non_positive_length()
+    {
+        var act = () => IncidentId.New(0);
+        act.Should().Throw<ArgumentOutOfRangeException>();
+    }
+}

--- a/Quilt4Net.Toolkit/Features/ApplicationInsights/ApplicationInsightsService.cs
+++ b/Quilt4Net.Toolkit/Features/ApplicationInsights/ApplicationInsightsService.cs
@@ -2,8 +2,10 @@
 using Azure.Identity;
 using Azure.Monitor.Query.Logs;
 using Azure.Monitor.Query.Logs.Models;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using System.Text.Json;
+using Quilt4Net.Toolkit.Features.Diagnostics;
 using Tharga.Cache;
 
 namespace Quilt4Net.Toolkit.Features.ApplicationInsights;
@@ -12,27 +14,51 @@ internal class ApplicationInsightsService : IApplicationInsightsService
 {
     private readonly ITimeToLiveCache _timeToLiveCache;
     private readonly ApplicationInsightsOptions _options;
+    private readonly ILogger<ApplicationInsightsService> _logger;
 
-    public ApplicationInsightsService(ITimeToLiveCache timeToLiveCache, IOptions<ApplicationInsightsOptions> options)
+    public ApplicationInsightsService(
+        ITimeToLiveCache timeToLiveCache,
+        IOptions<ApplicationInsightsOptions> options,
+        ILogger<ApplicationInsightsService> logger)
     {
         _timeToLiveCache = timeToLiveCache;
         _options = options.Value;
+        _logger = logger;
     }
 
     public async Task<bool> CanConnectAsync(IApplicationInsightsContext context)
     {
+        var incidentId = IncidentId.New();
+        var workspaceId = context?.WorkspaceId ?? _options.WorkspaceId;
+        var tenantId = context?.TenantId ?? _options.TenantId;
+        var clientId = context?.ClientId ?? _options.ClientId;
+        var authMode = context?.AuthMode ?? _options.AuthMode;
+
         try
         {
             var client = GetClient(context);
-            var detailQuery = "AppTraces";
-            _ = await client.QueryWorkspaceAsync(context.WorkspaceId, detailQuery, new LogsQueryTimeRange(DateTimeOffset.Now.AddDays(-1), DateTimeOffset.Now));
+            const string detailQuery = "AppTraces";
+            _ = await client.QueryWorkspaceAsync(workspaceId, detailQuery, new LogsQueryTimeRange(DateTimeOffset.Now.AddDays(-1), DateTimeOffset.Now));
+
+            _logger.LogInformation(
+                "AI CanConnect succeeded. Incident={IncidentId} WorkspaceId={WorkspaceId} TenantId={TenantId} ClientId={ClientId} AuthMode={AuthMode}",
+                incidentId, MaskId(workspaceId), MaskId(tenantId), MaskId(clientId), authMode);
 
             return true;
         }
-        catch (Exception)
+        catch (Exception ex)
         {
+            _logger.LogError(ex,
+                "AI CanConnect failed. Incident={IncidentId} WorkspaceId={WorkspaceId} TenantId={TenantId} ClientId={ClientId} AuthMode={AuthMode}",
+                incidentId, MaskId(workspaceId), MaskId(tenantId), MaskId(clientId), authMode);
             return false;
         }
+    }
+
+    private static string MaskId(string id)
+    {
+        if (string.IsNullOrEmpty(id)) return "(none)";
+        return id.Length <= 8 ? id : id.Substring(0, 8) + "…";
     }
 
     public async IAsyncEnumerable<EnvironmentOption> GetEnvironments(IApplicationInsightsContext context)

--- a/Quilt4Net.Toolkit/Features/Diagnostics/IncidentId.cs
+++ b/Quilt4Net.Toolkit/Features/Diagnostics/IncidentId.cs
@@ -1,0 +1,29 @@
+using System.Security.Cryptography;
+
+namespace Quilt4Net.Toolkit.Features.Diagnostics;
+
+/// <summary>
+/// Generates short, human-readable incident identifiers for cross-referencing
+/// a user-facing error message with a corresponding log entry.
+/// 6 chars over a 32-char alphabet, ambiguous characters (0/1/I/O) excluded.
+/// </summary>
+public static class IncidentId
+{
+    private const string Alphabet = "23456789ABCDEFGHJKLMNPQRSTUVWXYZ";
+
+    public static string New(int length = 6)
+    {
+        if (length <= 0) throw new ArgumentOutOfRangeException(nameof(length));
+
+        Span<byte> bytes = stackalloc byte[length];
+        RandomNumberGenerator.Fill(bytes);
+
+        Span<char> chars = stackalloc char[length];
+        for (var i = 0; i < length; i++)
+        {
+            chars[i] = Alphabet[bytes[i] % Alphabet.Length];
+        }
+
+        return new string(chars);
+    }
+}


### PR DESCRIPTION
## Summary

Until now, failures in the AI query path (`ApplicationInsightsService` and the Blazor Log views) produced a friendly UI alert but **zero log entry**. Two live incidents on quilt4net.com (auth failure on `/developer/log`, NRE on `/monitor/log?tab=summary`) were undiagnosable for this reason — no stack trace, no Azure error code, no record at all.

This change:

- Adds public `Quilt4Net.Toolkit.Features.Diagnostics.IncidentId` — 6-char base32, ambiguous chars (\`0/1/I/O\`) excluded. The same id appears in the structured log entry (\`{IncidentId}\`) and in the user-visible message as \`[Incident: K7XQ4P]\` so reporters can quote it back to support.
- \`ApplicationInsightsService\` now takes \`ILogger<ApplicationInsightsService>\`. \`CanConnectAsync\` logs both the success path (Information) and failure path (Error) with structured \`{WorkspaceId}/{TenantId}/{ClientId}/{AuthMode}\` (ids masked to first 8 chars; secret never logged). The Test button on \`/monitor/configuration\` now leaves an audit trail.
- New \`LoggingErrorBoundary\` (public component) mints an id once per caught exception and writes a structured error log entry. \`LogView\` uses it via \`@ref\` so the rendered alert references the same id.
- \`LogEnvironmentSelector\` catches via a new one-line helper \`LogIncidentLogger.LogAndFormat\`.
- \`ApplicationInsightsErrorMessage.Format\` gains a 3-arg overload that appends the bracketed id; 2-arg overload preserved for any external caller.

Plan: \`plans/Quilt4Net/Toolkit/12-ai-error-logging-and-correlation.md\` (Synology / Obsidian).

## Test plan

- [x] \`Quilt4Net.Toolkit.Tests\` 48/48 (5 new \`IncidentIdTests\`)
- [x] \`Quilt4Net.Toolkit.Blazor.Tests\` 50/50 (5 new \`ApplicationInsightsErrorMessageTests\`, 1 new \`LogEnvironmentSelectorIncidentTests\` confirming the rendered alert contains \`[Incident: …]\` when the service throws)
- [x] Build clean across net8.0 / net9.0 / net10.0
- [x] Warning ratchet not breached
- [ ] CI green
- [ ] Manual smoke on \`/developer/log\` after publish — confirm the auth failure now produces a log entry with full stack trace and AADSTS code; copy the \`[Incident: …]\` from the UI and verify it matches the log