### PR TITLE
feat: app/env version matrix infrastructure

### DIFF
--- a/Quilt4Net.Toolkit.Blazor.Tests/LogEnvironmentSelectorIncidentTests.cs
+++ b/Quilt4Net.Toolkit.Blazor.Tests/LogEnvironmentSelectorIncidentTests.cs
@@ -42,6 +42,7 @@ public class LogEnvironmentSelectorIncidentTests : BunitContext
         public Task<LogDetails> GetDetail(IApplicationInsightsContext context, string id, LogSource source, string environment, TimeSpan timeSpan) => Task.FromException<LogDetails>(_ex);
         public Task<SummaryData> GetSummary(IApplicationInsightsContext context, string fingerprint, LogSource source, string environment, TimeSpan timeSpan) => Task.FromException<SummaryData>(_ex);
         public IAsyncEnumerable<SummarySubset> GetSummaries(IApplicationInsightsContext context, string environment, TimeSpan timeSpan) => Throw<SummarySubset>();
+        public IAsyncEnumerable<VersionMatrixCell> GetVersionMatrixAsync(IApplicationInsightsContext context, TimeSpan? lookback = null) => Throw<VersionMatrixCell>();
 
 #pragma warning disable CS1998
         private async IAsyncEnumerable<T> Throw<T>()

--- a/Quilt4Net.Toolkit.Blazor.Tests/LogViewConfigTests.cs
+++ b/Quilt4Net.Toolkit.Blazor.Tests/LogViewConfigTests.cs
@@ -61,6 +61,7 @@ public class LogViewConfigTests : BunitContext
         public Task<LogDetails> GetDetail(IApplicationInsightsContext context, string id, LogSource source, string environment, TimeSpan timeSpan) => Task.FromResult<LogDetails>(null);
         public Task<SummaryData> GetSummary(IApplicationInsightsContext context, string fingerprint, LogSource source, string environment, TimeSpan timeSpan) => Task.FromResult<SummaryData>(null);
         public IAsyncEnumerable<SummarySubset> GetSummaries(IApplicationInsightsContext context, string environment, TimeSpan timeSpan) => Empty<SummarySubset>();
+        public IAsyncEnumerable<VersionMatrixCell> GetVersionMatrixAsync(IApplicationInsightsContext context, TimeSpan? lookback = null) => Empty<VersionMatrixCell>();
 
         private static async IAsyncEnumerable<T> Empty<T>()
         {

--- a/Quilt4Net.Toolkit.Blazor/Quilt4Net.Toolkit.Blazor.csproj
+++ b/Quilt4Net.Toolkit.Blazor/Quilt4Net.Toolkit.Blazor.csproj
@@ -26,7 +26,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Authentication.WebAssembly.Msal" Version="10.0.7" />
-    <PackageReference Include="Microsoft.Identity.Client" Version="4.83.3" />
+    <PackageReference Include="Microsoft.Identity.Client" Version="4.84.0" />
     <PackageReference Include="Tharga.Blazor" Version="2.1.4" />
   </ItemGroup>
   <ItemGroup>

--- a/Quilt4Net.Toolkit.Tests/Quilt4NetStartupLoggerTests.cs
+++ b/Quilt4Net.Toolkit.Tests/Quilt4NetStartupLoggerTests.cs
@@ -1,0 +1,141 @@
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Quilt4Net.Toolkit.Features.Logging;
+using Xunit;
+
+namespace Quilt4Net.Toolkit.Tests;
+
+public class Quilt4NetStartupLoggerTests
+{
+    [Fact]
+    public void Log_emits_information_entry_with_application_details()
+    {
+        var capture = new CapturingLogger();
+        var options = new Quilt4NetLoggingOptions
+        {
+            ApplicationName = "florida-server",
+            Version = "1.4.7",
+            Environment = "Production"
+        };
+
+        Quilt4NetStartupLogger.Log(capture, options);
+
+        capture.Entries.Should().ContainSingle();
+        var entry = capture.Entries[0];
+        entry.Level.Should().Be(LogLevel.Information);
+        entry.FormattedMessage.Should().Contain("florida-server");
+        entry.FormattedMessage.Should().Contain("1.4.7");
+        entry.FormattedMessage.Should().Contain("Production");
+    }
+
+    [Fact]
+    public void Log_attaches_Quilt4NetStartup_marker_in_scope()
+    {
+        var capture = new CapturingLogger();
+        var options = new Quilt4NetLoggingOptions { ApplicationName = "x" };
+
+        Quilt4NetStartupLogger.Log(capture, options);
+
+        capture.Entries.Should().ContainSingle();
+        capture.Entries[0].Scopes.Should().ContainSingle()
+            .Which.Should().BeAssignableTo<IDictionary<string, object>>()
+            .Which["Quilt4NetStartup"].Should().Be("true");
+    }
+
+    [Fact]
+    public void Log_handles_null_option_values_with_unknown_placeholder()
+    {
+        var capture = new CapturingLogger();
+        var options = new Quilt4NetLoggingOptions();
+
+        Quilt4NetStartupLogger.Log(capture, options);
+
+        capture.Entries[0].FormattedMessage.Should().Contain("(unknown)");
+    }
+
+    [Fact]
+    public async Task Hosted_service_emits_log_on_StartAsync()
+    {
+        var capture = new CapturingLogger<Quilt4NetStartupHostedService>();
+        var options = new Quilt4NetLoggingOptions { ApplicationName = "from-host" };
+        var service = new Quilt4NetStartupHostedService(capture, options);
+
+        await service.StartAsync(CancellationToken.None);
+
+        capture.Inner.Entries.Should().ContainSingle()
+            .Which.FormattedMessage.Should().Contain("from-host");
+    }
+
+    [Fact]
+    public void LogQuilt4NetStartup_extension_resolves_logger_from_provider()
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton(new Quilt4NetLoggingOptions { ApplicationName = "wpf-app", Version = "2.0.0", Environment = "Production" });
+        var capture = new CapturingLogger();
+        services.AddSingleton<ILoggerFactory>(new CapturingLoggerFactory(capture));
+        var provider = services.BuildServiceProvider();
+
+        provider.LogQuilt4NetStartup();
+
+        capture.Entries.Should().ContainSingle()
+            .Which.FormattedMessage.Should().Contain("wpf-app");
+    }
+
+    [Fact]
+    public void Hosted_service_is_registered_by_AddQuilt4NetLogging()
+    {
+        var services = new ServiceCollection();
+        services.AddQuilt4NetLogging(applicationName: "x");
+
+        services.Should().Contain(d => d.ServiceType == typeof(IHostedService)
+            && d.ImplementationType == typeof(Quilt4NetStartupHostedService));
+    }
+
+    private sealed record LogEntry(LogLevel Level, string FormattedMessage, List<object> Scopes);
+
+    private sealed class CapturingLogger : ILogger
+    {
+        public List<LogEntry> Entries { get; } = new();
+        private readonly List<object> _activeScopes = new();
+
+        public IDisposable BeginScope<TState>(TState state) where TState : notnull
+        {
+            _activeScopes.Add(state);
+            return new Pop(() => _activeScopes.RemoveAt(_activeScopes.Count - 1));
+        }
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter)
+        {
+            Entries.Add(new LogEntry(logLevel, formatter(state, exception), new List<object>(_activeScopes)));
+        }
+
+        private sealed class Pop : IDisposable
+        {
+            private readonly Action _action;
+            public Pop(Action action) { _action = action; }
+            public void Dispose() => _action();
+        }
+    }
+
+    private sealed class CapturingLogger<T> : ILogger<T>
+    {
+        public CapturingLogger Inner { get; } = new();
+        public IDisposable BeginScope<TState>(TState state) where TState : notnull => Inner.BeginScope(state);
+        public bool IsEnabled(LogLevel logLevel) => Inner.IsEnabled(logLevel);
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter)
+            => Inner.Log(logLevel, eventId, state, exception, formatter);
+    }
+
+    private sealed class CapturingLoggerFactory : ILoggerFactory
+    {
+        private readonly CapturingLogger _logger;
+        public CapturingLoggerFactory(CapturingLogger logger) { _logger = logger; }
+        public ILogger CreateLogger(string categoryName) => _logger;
+        public void AddProvider(ILoggerProvider provider) { }
+        public void Dispose() { }
+    }
+}

--- a/Quilt4Net.Toolkit.Tests/VersionMatrixCellTests.cs
+++ b/Quilt4Net.Toolkit.Tests/VersionMatrixCellTests.cs
@@ -1,0 +1,51 @@
+using FluentAssertions;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Quilt4Net.Toolkit.Features.ApplicationInsights;
+using Tharga.Cache;
+using Xunit;
+
+namespace Quilt4Net.Toolkit.Tests;
+
+public class VersionMatrixCellTests
+{
+    [Fact]
+    public void Cell_record_carries_application_environment_version_and_source()
+    {
+        var cell = new VersionMatrixCell
+        {
+            ApplicationName = "florida-server",
+            Environment = "Production",
+            Version = "1.4.7",
+            LastSeen = new DateTime(2026, 5, 6, 14, 0, 0, DateTimeKind.Utc),
+            Source = VersionMatrixSource.Startup
+        };
+
+        cell.ApplicationName.Should().Be("florida-server");
+        cell.Environment.Should().Be("Production");
+        cell.Version.Should().Be("1.4.7");
+        cell.LastSeen.Kind.Should().Be(DateTimeKind.Utc);
+        cell.Source.Should().Be(VersionMatrixSource.Startup);
+    }
+
+    [Fact]
+    public void VersionMatrixCell_array_cache_type_is_registered()
+    {
+        var services = new ServiceCollection();
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string>
+            {
+                ["Quilt4Net:ApplicationInsights:WorkspaceId"] = "ws-id",
+                ["Quilt4Net:ApplicationInsights:TenantId"] = "tenant",
+                ["Quilt4Net:ApplicationInsights:ClientId"] = "client",
+                ["Quilt4Net:ApplicationInsights:ClientSecret"] = "secret"
+            })
+            .Build();
+
+        services.AddQuilt4NetApplicationInsightsClient(configuration);
+        var provider = services.BuildServiceProvider();
+
+        var cache = provider.GetRequiredService<ITimeToLiveCache>();
+        cache.Should().NotBeNull();
+    }
+}

--- a/Quilt4Net.Toolkit/ApplicationInsightsRegistration.cs
+++ b/Quilt4Net.Toolkit/ApplicationInsightsRegistration.cs
@@ -69,6 +69,12 @@ public static class ApplicationInsightsRegistration
             {
                 x.DefaultFreshSpan = TimeSpan.FromMinutes(1);
             });
+            // Version matrix scans for the latest version per (app, env). The view is
+            // typically refreshed manually; 5 minutes balances freshness with query cost.
+            s.RegisterType<VersionMatrixCell[], IMemory>(x =>
+            {
+                x.DefaultFreshSpan = TimeSpan.FromMinutes(5);
+            });
         });
     }
 }

--- a/Quilt4Net.Toolkit/Features/ApplicationInsights/ApplicationInsightsService.cs
+++ b/Quilt4Net.Toolkit/Features/ApplicationInsights/ApplicationInsightsService.cs
@@ -934,6 +934,76 @@ AppRequests
         }
     }
 
+    public async IAsyncEnumerable<VersionMatrixCell> GetVersionMatrixAsync(IApplicationInsightsContext context, TimeSpan? lookback = null)
+    {
+        var cacheKey = $"versionmatrix|{context.ToKey()}|{lookback}";
+        var items = await _timeToLiveCache.GetAsync(cacheKey, async () =>
+        {
+            return await GetVersionMatrixInternalAsync(context, lookback).ToArrayAsync();
+        });
+
+        foreach (var item in items)
+        {
+            yield return item;
+        }
+    }
+
+    private async IAsyncEnumerable<VersionMatrixCell> GetVersionMatrixInternalAsync(IApplicationInsightsContext context, TimeSpan? lookback)
+    {
+        var client = GetClient(context);
+        var workspaceId = context?.WorkspaceId ?? _options.WorkspaceId;
+
+        var query = @"
+let startup = AppTraces
+| extend _p = todynamic(Properties)
+| where tostring(_p[""Quilt4NetStartup""]) == ""true""
+| extend
+    ApplicationName = tostring(_p[""ApplicationName""]),
+    Environment = tostring(_p[""Environment""]),
+    Version = tostring(_p[""Version""])
+| where isnotempty(ApplicationName) and isnotempty(Version)
+| project TimeGenerated, ApplicationName, Environment, Version, Source = ""Startup"";
+let fallback = union AppTraces, AppExceptions, AppRequests
+| extend _p = todynamic(Properties)
+| extend
+    ApplicationName = coalesce(tostring(_p[""ApplicationName""]), tostring(AppRoleName)),
+    Environment = coalesce(tostring(_p[""AspNetCoreEnvironment""]), tostring(_p[""deployment.environment""])),
+    Version = coalesce(tostring(_p[""application_Version""]), tostring(_p[""service.version""]), tostring(AppVersion))
+| where isnotempty(ApplicationName) and isnotempty(Version)
+| project TimeGenerated, ApplicationName, Environment, Version, Source = ""Log"";
+union startup, fallback
+| extend Environment = iff(isempty(Environment), ""(unknown)"", Environment)
+| summarize arg_max(TimeGenerated, Version, Source) by ApplicationName, Environment
+| order by ApplicationName asc, Environment asc";
+
+        var range = lookback.HasValue
+            ? new LogsQueryTimeRange(DateTimeOffset.UtcNow - lookback.Value, DateTimeOffset.UtcNow)
+            : LogsQueryTimeRange.All;
+
+        var response = await client.QueryWorkspaceAsync(workspaceId, query, range);
+        var table = response.Value.Table;
+
+        var appIndex = GetColumnIndex(table, "ApplicationName");
+        var envIndex = GetColumnIndex(table, "Environment");
+        var versionIndex = GetColumnIndex(table, "Version");
+        var timeIndex = GetColumnIndex(table, "TimeGenerated");
+        var sourceIndex = GetColumnIndex(table, "Source");
+
+        foreach (var row in table.Rows)
+        {
+            yield return new VersionMatrixCell
+            {
+                ApplicationName = row[appIndex]?.ToString() ?? "",
+                Environment = row[envIndex]?.ToString() ?? "(unknown)",
+                Version = row[versionIndex]?.ToString() ?? "",
+                LastSeen = GetDateTime(row, timeIndex),
+                Source = string.Equals(row[sourceIndex]?.ToString(), "Startup", StringComparison.Ordinal)
+                    ? VersionMatrixSource.Startup
+                    : VersionMatrixSource.Log
+            };
+        }
+    }
+
     private LogsQueryClient GetClient(IApplicationInsightsContext context = null)
     {
         if (context.IsCurrent()) context = null;

--- a/Quilt4Net.Toolkit/Features/ApplicationInsights/IApplicationInsightsService.cs
+++ b/Quilt4Net.Toolkit/Features/ApplicationInsights/IApplicationInsightsService.cs
@@ -10,4 +10,13 @@ public interface IApplicationInsightsService
     Task<LogDetails> GetDetail(IApplicationInsightsContext context, string id, LogSource source, string environment, TimeSpan timeSpan);
     Task<SummaryData> GetSummary(IApplicationInsightsContext context, string fingerprint, LogSource source, string environment, TimeSpan timeSpan);
     IAsyncEnumerable<SummarySubset> GetSummaries(IApplicationInsightsContext context, string environment, TimeSpan timeSpan);
+
+    /// <summary>
+    /// Get the latest version of each (application, environment) combination
+    /// seen in the workspace. Tries the Quilt4NetStartup-tagged fast path
+    /// first, then falls back to a general scan for cells the fast path
+    /// did not cover. Pass <c>null</c> for <paramref name="lookback"/> to
+    /// query the workspace's full retention.
+    /// </summary>
+    IAsyncEnumerable<VersionMatrixCell> GetVersionMatrixAsync(IApplicationInsightsContext context, TimeSpan? lookback = null);
 }

--- a/Quilt4Net.Toolkit/Features/ApplicationInsights/VersionMatrixCell.cs
+++ b/Quilt4Net.Toolkit/Features/ApplicationInsights/VersionMatrixCell.cs
@@ -1,0 +1,28 @@
+namespace Quilt4Net.Toolkit.Features.ApplicationInsights;
+
+/// <summary>
+/// One cell in the application/environment version matrix — the latest
+/// version of an application seen in a given environment.
+/// </summary>
+public record VersionMatrixCell
+{
+    public required string ApplicationName { get; init; }
+    public required string Environment { get; init; }
+    public required string Version { get; init; }
+    public required DateTime LastSeen { get; init; }
+
+    /// <summary>
+    /// Whether the version was identified from a Quilt4Net startup log entry
+    /// (fast path) or from a general log scan (fallback).
+    /// </summary>
+    public required VersionMatrixSource Source { get; init; }
+}
+
+public enum VersionMatrixSource
+{
+    /// <summary>Identified via a Quilt4NetStartup-tagged log entry.</summary>
+    Startup,
+
+    /// <summary>Identified by scanning regular AppTraces/AppExceptions/AppRequests.</summary>
+    Log,
+}

--- a/Quilt4Net.Toolkit/Features/Logging/Quilt4NetStartupHostedService.cs
+++ b/Quilt4Net.Toolkit/Features/Logging/Quilt4NetStartupHostedService.cs
@@ -1,0 +1,30 @@
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace Quilt4Net.Toolkit.Features.Logging;
+
+/// <summary>
+/// Emits a single Information-level log entry on application startup with the
+/// resolved Quilt4NetLoggingOptions. The entry carries a Quilt4NetStartup=true
+/// structured property so observability tooling can locate startup events
+/// quickly (e.g. for the application/environment version matrix view).
+/// </summary>
+internal sealed class Quilt4NetStartupHostedService : IHostedService
+{
+    private readonly ILogger<Quilt4NetStartupHostedService> _logger;
+    private readonly Quilt4NetLoggingOptions _options;
+
+    public Quilt4NetStartupHostedService(ILogger<Quilt4NetStartupHostedService> logger, Quilt4NetLoggingOptions options)
+    {
+        _logger = logger;
+        _options = options;
+    }
+
+    public Task StartAsync(CancellationToken cancellationToken)
+    {
+        Quilt4NetStartupLogger.Log(_logger, _options);
+        return Task.CompletedTask;
+    }
+
+    public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+}

--- a/Quilt4Net.Toolkit/Features/Logging/Quilt4NetStartupLogger.cs
+++ b/Quilt4Net.Toolkit/Features/Logging/Quilt4NetStartupLogger.cs
@@ -1,0 +1,18 @@
+using Microsoft.Extensions.Logging;
+
+namespace Quilt4Net.Toolkit.Features.Logging;
+
+internal static class Quilt4NetStartupLogger
+{
+    public static void Log(ILogger logger, Quilt4NetLoggingOptions options)
+    {
+        using (logger.BeginScope(new Dictionary<string, object> { ["Quilt4NetStartup"] = "true" }))
+        {
+            logger.LogInformation(
+                "Quilt4Net startup: {ApplicationName} v{Version} in {Environment}",
+                options.ApplicationName ?? "(unknown)",
+                options.Version ?? "(unknown)",
+                options.Environment ?? "(unknown)");
+        }
+    }
+}

--- a/Quilt4Net.Toolkit/LoggingRegistration.cs
+++ b/Quilt4Net.Toolkit/LoggingRegistration.cs
@@ -2,7 +2,9 @@ using System.Reflection;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
 using OpenTelemetry.Resources;
+using Quilt4Net.Toolkit.Features.Logging;
 
 namespace Quilt4Net.Toolkit;
 
@@ -42,6 +44,8 @@ public static class LoggingRegistration
 
         services.AddSingleton(o);
 
+        services.AddHostedService<Quilt4NetStartupHostedService>();
+
         services.AddOpenTelemetry()
             .ConfigureResource(resource =>
             {
@@ -63,6 +67,19 @@ public static class LoggingRegistration
             });
 
         return new Quilt4NetLoggingBuilder(services, o);
+    }
+
+    /// <summary>
+    /// Manually emit the Quilt4Net startup log entry. Use this in non-hosted
+    /// applications (WPF, console without IHost) where IHostedService does not run.
+    /// Hosted applications (IHostApplicationBuilder) get the startup entry automatically.
+    /// </summary>
+    public static void LogQuilt4NetStartup(this IServiceProvider serviceProvider)
+    {
+        var options = serviceProvider.GetRequiredService<Quilt4NetLoggingOptions>();
+        var loggerFactory = serviceProvider.GetRequiredService<ILoggerFactory>();
+        var logger = loggerFactory.CreateLogger<Quilt4NetStartupHostedService>();
+        Quilt4NetStartupLogger.Log(logger, options);
     }
 
     private static string ResolveApplicationNameFromEntryAssembly()


### PR DESCRIPTION
## Summary

Adds Toolkit-side support for an upcoming Server "application/environment version matrix" view that shows the latest deployed version of each app in each environment from Application Insights data.

Three commits:

1. **`chore: bump Microsoft.Identity.Client 4.83.3 → 4.84.0`** — minor patch in `Quilt4Net.Toolkit.Blazor`.

2. **`feat: emit Quilt4Net startup log with Quilt4NetStartup marker`** — `AddQuilt4NetLogging()` now registers `Quilt4NetStartupHostedService`, which emits a single `Information`-level log entry on application start carrying `ApplicationName`/`Version`/`Environment` plus a `Quilt4NetStartup=true` scope marker. Non-hosted apps (WPF, console without `IHost`) can call `provider.LogQuilt4NetStartup()` to emit it manually. The marker enables observability tooling to locate startup events fast.

3. **`feat: GetVersionMatrixAsync — latest version per (app, env)`** — new `IApplicationInsightsService.GetVersionMatrixAsync(context, lookback)` returning `IAsyncEnumerable<VersionMatrixCell>`. KQL strategy:
   - **Fast path:** filter `AppTraces` by `_p["Quilt4NetStartup"] == "true"` and read structured props from the startup log entry.
   - **Fallback:** scan `union AppTraces, AppExceptions, AppRequests`, reading from OTel attributes (`service.version`, `deployment.environment`) or classic AspNetCore fields (`AppRoleName`, `AppVersion`, `AspNetCoreEnvironment`).
   - **Merge:** `union startup, fallback | summarize arg_max(TimeGenerated, Version, Source) by ApplicationName, Environment` — most recent observation wins; the fast path is purely an optimization.

   Result is cached for 5 minutes via `ITimeToLiveCache`; lookback is configurable (`null` = `LogsQueryTimeRange.All`).

## Test plan

- [ ] Unit tests pass (`Quilt4Net.Toolkit.Tests`, +8 new tests; 155 total)
- [ ] Build clean across `net8.0`, `net9.0`, `net10.0`
- [ ] No new vulnerabilities (`dotnet list package --vulnerable`)
- [ ] Manual verification of `GetVersionMatrixAsync` against a real AI workspace (deferred to Server-side integration)