### PR TITLE
fix: harden ApplicationInsightsService against null row values

### DIFF
--- a/Quilt4Net.Toolkit/Features/ApplicationInsights/ApplicationInsightsService.cs
+++ b/Quilt4Net.Toolkit/Features/ApplicationInsights/ApplicationInsightsService.cs
@@ -672,7 +672,10 @@ AppRequests
         var correlationIndex = GetColumnIndex(table, "CorrelationId");
         var rawIndex = GetColumnIndex(table, "Raw");
 
-        var binary = (BinaryData)row[rawIndex]!;
+        if (row[rawIndex] is not BinaryData binary)
+        {
+            throw new InvalidOperationException($"Row for {source} item id '{id}' has no Raw payload (got {row[rawIndex]?.GetType().Name ?? "null"}).");
+        }
         var json = binary.ToString();
 
         var rawNullable = JsonSerializer.Deserialize<Dictionary<string, object>>(
@@ -782,21 +785,24 @@ AppRequests
         var appIndex = GetColumnIndex(table, "Application");
         var severityIndex = GetColumnIndex(table, "SeverityLevel");
 
-        var items = table.Rows.Select(row => new SummaryData.Item
-        {
-            Id = row[idIndex]!.ToString()!,
-            TimeGenerated = GetDateTime(row, timeIndex),
-            Message = row[messageIndex]!.ToString()!
-        }).ToArray();
+        var items = table.Rows
+            .Select(row => new SummaryData.Item
+            {
+                Id = row[idIndex]?.ToString() ?? "",
+                TimeGenerated = GetDateTime(row, timeIndex),
+                Message = row[messageIndex]?.ToString() ?? ""
+            })
+            .Where(item => !string.IsNullOrEmpty(item.Id)) // skip rows without an Id — they can't be linked back
+            .ToArray();
 
         var first = table.Rows[0];
 
         return new SummaryData
         {
             Fingerprint = fingerprint,
-            Message = first[messageIndex]!.ToString()!,
-            Environment = first[envIndex]!.ToString()!,
-            Application = first[appIndex]!.ToString()!,
+            Message = first[messageIndex]?.ToString() ?? "",
+            Environment = first[envIndex]?.ToString() ?? "",
+            Application = first[appIndex]?.ToString() ?? "",
             SeverityLevel = (SeverityLevel)GetInt(first, severityIndex),
             Source = source,
             Items = items
@@ -910,9 +916,12 @@ AppRequests
 
             foreach (var row in table.Rows)
             {
+                var fingerprint = row[fp]?.ToString();
+                if (string.IsNullOrEmpty(fingerprint)) continue; // can't summarize a row without a fingerprint key
+
                 yield return new SummarySubset
                 {
-                    Fingerprint = row[fp]!.ToString()!,
+                    Fingerprint = fingerprint,
                     Message = row[msg]?.ToString() ?? "",
                     Environment = row[env]?.ToString() ?? "",
                     Application = row[app]?.ToString() ?? "",


### PR DESCRIPTION
## Summary

Live AI lookup against \`[Incident: 76RAEE]\` (reported on \`/monitor/log?tab=summary\`) traced the alert "Could not query Application Insights. Object reference not set to an instance of an object." to a \`NullReferenceException\` thrown from \`GetSummariesInternal\`'s \`Run\` local function:

\`\`\`
Fingerprint = row[fp]!.ToString()!,
\`\`\`

The null-forgiving \`!\` only silences the compiler. When \`row[fp]\` is null at runtime, \`.ToString()\` is invoked on null → NRE → the Blazor circuit's \`LoggingErrorBoundary\` catches it and the user sees the friendly alert with the incident id.

Hardened three sibling sites in the same file that used the same anti-pattern:

- \`GetSummariesInternal.Run\` (the actual crash) — \`?.ToString()\` and **skip** rows with null/empty fingerprint; can't summarise without the grouping key.
- \`GetSummary\` item projection — \`Id\`/\`Message\` null-safe; items with empty \`Id\` filtered out (they can't be linked back to detail).
- \`GetSummary\` header projection (\`Message\`/\`Environment\`/\`Application\`) — null-safe, matches the pattern already used elsewhere.
- \`GetDetail\` Raw cast — \`(BinaryData)row[rawIndex]!\` → pattern test that throws a clear \`InvalidOperationException\` identifying the source/id if the Raw payload is missing.

The new structured logging from PR #74 is what made this diagnosable: stack trace landed in AI exactly as designed, queryable by IncidentId. Without it we'd still be guessing.

## Test plan

- [x] \`Quilt4Net.Toolkit.Tests\` 60/60 pass
- [x] \`Quilt4Net.Toolkit.Blazor.Tests\` 50/50 pass
- [x] Build clean across net8.0 / net9.0 / net10.0; warning ratchet not breached
- [ ] CI green
- [ ] Smoke: navigate to \`/monitor/log?tab=summary\` against the Server's dev workspace, select an environment — should render the summary list instead of the error alert

## Notes

No regression test added: writing one requires mocking \`LogsQueryClient\` and synthesising \`Response<LogsQueryResult>\` via \`LogsModelFactory\` — ~100 lines of Azure SDK scaffolding for a 4-line null-safety patch. The change matches the null-safe pattern already used five other places in the same file.