### PR TITLE
fix: null-safe GetInt and GetDateTime in ApplicationInsightsService

### DIFF
--- a/Quilt4Net.Toolkit/Features/ApplicationInsights/ApplicationInsightsService.cs
+++ b/Quilt4Net.Toolkit/Features/ApplicationInsights/ApplicationInsightsService.cs
@@ -1066,7 +1066,8 @@ union startup, fallback
             return DateTime.SpecifyKind(dt, DateTimeKind.Utc);
         }
 
-        return DateTime.Parse(value.ToString()!);
+        var s = value?.ToString();
+        return string.IsNullOrEmpty(s) ? default : DateTime.Parse(s);
     }
 
     private static int GetInt(IReadOnlyList<object> row, int index)
@@ -1083,7 +1084,8 @@ union startup, fallback
             return (int)l;
         }
 
-        return int.Parse(value.ToString()!);
+        var s = value?.ToString();
+        return string.IsNullOrEmpty(s) ? 0 : int.Parse(s);
     }
 
     private static TimeSpan GetTimeSpan(IReadOnlyList<object> row, int index)

--- a/Quilt4Net.Toolkit/Quilt4Net.Toolkit.csproj
+++ b/Quilt4Net.Toolkit/Quilt4Net.Toolkit.csproj
@@ -51,6 +51,6 @@
     </PackageReference>
     <PackageReference Include="System.Management" Version="10.0.7" />
     <PackageReference Include="System.Linq.Async" Version="7.0.1" />
-    <PackageReference Include="Tharga.Cache" Version="0.4.2" />
+    <PackageReference Include="Tharga.Cache" Version="0.4.3" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary

Live AI lookup against \`[Incident: FPU9MX]\` traced "Could not query Application Insights. Object reference not set to an instance of an object." to a NRE one line past the one PR #77 fixed:

\`\`\`
ApplicationInsightsService.GetInt:43
  ← ApplicationInsightsService.<<GetSummariesInternal>g__Run|...>d.MoveNext
\`\`\`

\`GetInt\` and \`GetDateTime\` both did \`...Parse(value.ToString()!)\` — the \`!\` only silences the compiler, so a null cell value NREs at \`value.ToString()\`. \`GetTimeSpan\` was already null-safe (returns \`"00:00:00"\` on null); patched the other two helpers to match — return \`default\` / \`0\` when the cell value is null or empty.

Also includes a \`Tharga.Cache\` 0.4.2 → 0.4.3 dependency bump (separate commit) that was queued in the working tree.

## Test plan

- [x] \`Quilt4Net.Toolkit.Tests\` 60/60 pass
- [x] \`Quilt4Net.Toolkit.Blazor.Tests\` 50/50 pass
- [x] Build clean across net8.0 / net9.0 / net10.0; warning ratchet not breached
- [ ] CI green
- [ ] Once merged + new NuGet released + Server bumped: \`/monitor/log?tab=summary\` should fully render summaries instead of failing with \`[Incident: …]\` alerts

## Notes

No regression test added (same reasoning as PR #77) — mocking the Azure SDK \`Response<LogsQueryResult>\` is ~100 lines of scaffolding for a 2-line fix; the change matches the null-safe pattern already used by \`GetTimeSpan\` in the same file. If a third null-deref shows up in this file's row-projection paths, worth doing a comprehensive sweep + a single \`SafeRowReader\` helper rather than another one-off.