### PR TITLE
develop → master: AI service null-safety hardening + Quilt4Net.Toolkit.Mcp (Phase 1)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -117,7 +117,8 @@ jobs:
             Quilt4Net.Toolkit/Quilt4Net.Toolkit.csproj \
             Quilt4Net.Toolkit.Api/Quilt4Net.Toolkit.Api.csproj \
             Quilt4Net.Toolkit.Health/Quilt4Net.Toolkit.Health.csproj \
-            Quilt4Net.Toolkit.Blazor/Quilt4Net.Toolkit.Blazor.csproj; do
+            Quilt4Net.Toolkit.Blazor/Quilt4Net.Toolkit.Blazor.csproj \
+            Quilt4Net.Toolkit.Mcp/Quilt4Net.Toolkit.Mcp.csproj; do
             echo "Packing $proj ($VERSION)..."
             dotnet pack "$proj" -c Release --no-build -o ./artifacts -p:PackageVersion="$VERSION"
           done

--- a/Quilt4Net.Toolkit.Blazor.Tests/LogEnvironmentSelectorIncidentTests.cs
+++ b/Quilt4Net.Toolkit.Blazor.Tests/LogEnvironmentSelectorIncidentTests.cs
@@ -43,6 +43,8 @@ public class LogEnvironmentSelectorIncidentTests : BunitContext
         public Task<SummaryData> GetSummary(IApplicationInsightsContext context, string fingerprint, LogSource source, string environment, TimeSpan timeSpan) => Task.FromException<SummaryData>(_ex);
         public IAsyncEnumerable<SummarySubset> GetSummaries(IApplicationInsightsContext context, string environment, TimeSpan timeSpan) => Throw<SummarySubset>();
         public IAsyncEnumerable<VersionMatrixCell> GetVersionMatrixAsync(IApplicationInsightsContext context, TimeSpan? lookback = null) => Throw<VersionMatrixCell>();
+        public IAsyncEnumerable<LogItem> SearchByIncidentIdAsync(IApplicationInsightsContext context, string incidentId, TimeSpan timeSpan) => Throw<LogItem>();
+        public IAsyncEnumerable<LogItem> SearchByCorrelationIdAsync(IApplicationInsightsContext context, string correlationId, TimeSpan timeSpan) => Throw<LogItem>();
 
 #pragma warning disable CS1998
         private async IAsyncEnumerable<T> Throw<T>()

--- a/Quilt4Net.Toolkit.Blazor.Tests/LogViewConfigTests.cs
+++ b/Quilt4Net.Toolkit.Blazor.Tests/LogViewConfigTests.cs
@@ -62,6 +62,8 @@ public class LogViewConfigTests : BunitContext
         public Task<SummaryData> GetSummary(IApplicationInsightsContext context, string fingerprint, LogSource source, string environment, TimeSpan timeSpan) => Task.FromResult<SummaryData>(null);
         public IAsyncEnumerable<SummarySubset> GetSummaries(IApplicationInsightsContext context, string environment, TimeSpan timeSpan) => Empty<SummarySubset>();
         public IAsyncEnumerable<VersionMatrixCell> GetVersionMatrixAsync(IApplicationInsightsContext context, TimeSpan? lookback = null) => Empty<VersionMatrixCell>();
+        public IAsyncEnumerable<LogItem> SearchByIncidentIdAsync(IApplicationInsightsContext context, string incidentId, TimeSpan timeSpan) => Empty<LogItem>();
+        public IAsyncEnumerable<LogItem> SearchByCorrelationIdAsync(IApplicationInsightsContext context, string correlationId, TimeSpan timeSpan) => Empty<LogItem>();
 
         private static async IAsyncEnumerable<T> Empty<T>()
         {

--- a/Quilt4Net.Toolkit.Mcp.Tests/ApplicationInsightsResourceProviderTests.cs
+++ b/Quilt4Net.Toolkit.Mcp.Tests/ApplicationInsightsResourceProviderTests.cs
@@ -1,0 +1,77 @@
+using System.Text.Json;
+using FluentAssertions;
+using Moq;
+using Quilt4Net.Toolkit.Features.ApplicationInsights;
+using Quilt4Net.Toolkit.Mcp;
+using Tharga.Mcp;
+using Xunit;
+
+namespace Quilt4Net.Toolkit.Mcp.Tests;
+
+public class ApplicationInsightsResourceProviderTests
+{
+    [Fact]
+    public void Provider_runs_on_System_scope()
+    {
+        var sut = NewSut();
+        sut.Scope.Should().Be(McpScope.System);
+    }
+
+    [Fact]
+    public async Task Lists_two_resources()
+    {
+        var sut = NewSut();
+        var resources = await sut.ListResourcesAsync(StubContext, default);
+
+        resources.Select(r => r.Uri).Should().BeEquivalentTo(
+            ApplicationInsightsResourceProvider.EnvironmentsUri,
+            ApplicationInsightsResourceProvider.SummariesUri);
+    }
+
+    [Fact]
+    public async Task Reading_environments_resource_calls_service_and_serialises_payload()
+    {
+        var ais = new Mock<IApplicationInsightsService>();
+        ais.Setup(x => x.GetEnvironments(It.IsAny<IApplicationInsightsContext>()))
+           .Returns(ToAsync(new EnvironmentOption("Production"), new EnvironmentOption("Test")));
+
+        var sut = new ApplicationInsightsResourceProvider(ais.Object, new Quilt4NetMcpOptions());
+
+        var content = await sut.ReadResourceAsync(
+            ApplicationInsightsResourceProvider.EnvironmentsUri, StubContext, default);
+
+        content.MimeType.Should().Be("application/json");
+        var payload = JsonDocument.Parse(content.Text).RootElement;
+        payload.GetProperty("environments").EnumerateArray()
+            .Select(e => e.GetProperty("value").GetString())
+            .Should().Contain(["Production", "Test"]);
+    }
+
+    [Fact]
+    public async Task Reading_unknown_uri_throws()
+    {
+        var sut = NewSut();
+        var act = () => sut.ReadResourceAsync("quilt4net://nope", StubContext, default);
+        await act.Should().ThrowAsync<InvalidOperationException>();
+    }
+
+    private static ApplicationInsightsResourceProvider NewSut()
+        => new(Mock.Of<IApplicationInsightsService>(), new Quilt4NetMcpOptions());
+
+    private static IMcpContext StubContext => new TestMcpContext();
+
+#pragma warning disable CS1998
+    private static async IAsyncEnumerable<T> ToAsync<T>(params T[] items)
+#pragma warning restore CS1998
+    {
+        foreach (var item in items) yield return item;
+    }
+
+    private sealed class TestMcpContext : IMcpContext
+    {
+        public string UserId => "test-user";
+        public string TeamId => null;
+        public bool IsDeveloper => true;
+        public McpScope Scope => McpScope.System;
+    }
+}

--- a/Quilt4Net.Toolkit.Mcp.Tests/ApplicationInsightsToolProviderTests.cs
+++ b/Quilt4Net.Toolkit.Mcp.Tests/ApplicationInsightsToolProviderTests.cs
@@ -1,0 +1,196 @@
+using System.Text.Json;
+using FluentAssertions;
+using Moq;
+using Quilt4Net.Toolkit.Features.ApplicationInsights;
+using Quilt4Net.Toolkit.Mcp;
+using Tharga.Mcp;
+using Xunit;
+
+namespace Quilt4Net.Toolkit.Mcp.Tests;
+
+public class ApplicationInsightsToolProviderTests
+{
+    private static readonly JsonElement EmptyArgs = JsonDocument.Parse("{}").RootElement;
+
+    [Fact]
+    public void Provider_runs_on_System_scope()
+    {
+        var sut = NewSut(new Quilt4NetMcpOptions());
+        sut.Scope.Should().Be(McpScope.System);
+    }
+
+    [Fact]
+    public async Task Metadata_only_lists_get_environments()
+    {
+        var sut = NewSut(new Quilt4NetMcpOptions { DataAccess = DataAccessLevel.Metadata });
+
+        var tools = await sut.ListToolsAsync(StubContext, default);
+
+        tools.Select(t => t.Name).Should().BeEquivalentTo(
+            ApplicationInsightsToolProvider.GetEnvironmentsToolName);
+    }
+
+    [Fact]
+    public async Task DataRead_lists_all_seven_tools()
+    {
+        var sut = NewSut(new Quilt4NetMcpOptions { DataAccess = DataAccessLevel.DataRead });
+
+        var tools = await sut.ListToolsAsync(StubContext, default);
+
+        tools.Select(t => t.Name).Should().BeEquivalentTo(
+            ApplicationInsightsToolProvider.GetEnvironmentsToolName,
+            ApplicationInsightsToolProvider.SearchLogsToolName,
+            ApplicationInsightsToolProvider.GetLogDetailToolName,
+            ApplicationInsightsToolProvider.ListSummariesToolName,
+            ApplicationInsightsToolProvider.GetSummaryToolName,
+            ApplicationInsightsToolProvider.LookupIncidentToolName,
+            ApplicationInsightsToolProvider.LookupCorrelationToolName);
+    }
+
+    [Fact]
+    public async Task Calling_DataRead_tool_at_Metadata_level_returns_error()
+    {
+        var sut = NewSut(new Quilt4NetMcpOptions { DataAccess = DataAccessLevel.Metadata });
+
+        var result = await sut.CallToolAsync(
+            ApplicationInsightsToolProvider.SearchLogsToolName, EmptyArgs, StubContext, default);
+
+        result.IsError.Should().BeTrue();
+        result.Content.Single().Text.Should().Contain("requires DataAccessLevel.DataRead");
+    }
+
+    [Fact]
+    public async Task Get_environments_calls_service_and_returns_payload()
+    {
+        var ais = new Mock<IApplicationInsightsService>();
+        ais.Setup(x => x.GetEnvironments(It.IsAny<IApplicationInsightsContext>()))
+           .Returns(ToAsync(new EnvironmentOption("Production"), new EnvironmentOption("Test")));
+
+        var sut = new ApplicationInsightsToolProvider(ais.Object, new Quilt4NetMcpOptions());
+
+        var result = await sut.CallToolAsync(
+            ApplicationInsightsToolProvider.GetEnvironmentsToolName, EmptyArgs, StubContext, default);
+
+        result.IsError.Should().BeFalse();
+        var payload = JsonDocument.Parse(result.Content.Single().Text).RootElement;
+        payload.GetProperty("count").GetInt32().Should().Be(2);
+        payload.GetProperty("environments").EnumerateArray()
+            .Select(e => e.GetProperty("value").GetString())
+            .Should().Contain(["Production", "Test"]);
+    }
+
+    [Fact]
+    public async Task Lookup_incident_passes_id_and_lookback_to_service()
+    {
+        var ais = new Mock<IApplicationInsightsService>();
+        ais.Setup(x => x.SearchByIncidentIdAsync(
+                It.IsAny<IApplicationInsightsContext>(), "ABC123", TimeSpan.FromHours(2)))
+           .Returns(ToAsync(new LogItem
+           {
+               Id = "row1",
+               Source = LogSource.Exception,
+               Message = "boom",
+               Fingerprint = "fp",
+               TimeGenerated = DateTime.UtcNow,
+               Environment = "Production",
+               Application = "Quilt4Net.Server",
+               SeverityLevel = SeverityLevel.Error
+           }))
+           .Verifiable();
+
+        var sut = new ApplicationInsightsToolProvider(ais.Object,
+            new Quilt4NetMcpOptions { DataAccess = DataAccessLevel.DataRead });
+
+        var args = JsonDocument.Parse("""{"incidentId":"ABC123","lookbackHours":2}""").RootElement;
+        var result = await sut.CallToolAsync(
+            ApplicationInsightsToolProvider.LookupIncidentToolName, args, StubContext, default);
+
+        result.IsError.Should().BeFalse();
+        ais.Verify();
+        var payload = JsonDocument.Parse(result.Content.Single().Text).RootElement;
+        payload.GetProperty("count").GetInt32().Should().Be(1);
+        payload.GetProperty("incidentId").GetString().Should().Be("ABC123");
+        payload.GetProperty("lookbackHours").GetInt32().Should().Be(2);
+    }
+
+    [Fact]
+    public async Task Lookback_is_clamped_to_MaxLookback()
+    {
+        var ais = new Mock<IApplicationInsightsService>();
+        ais.Setup(x => x.SearchByIncidentIdAsync(
+                It.IsAny<IApplicationInsightsContext>(), It.IsAny<string>(), TimeSpan.FromHours(24)))
+           .Returns(ToAsync<LogItem>())
+           .Verifiable();
+
+        var sut = new ApplicationInsightsToolProvider(ais.Object,
+            new Quilt4NetMcpOptions
+            {
+                DataAccess = DataAccessLevel.DataRead,
+                MaxLookback = TimeSpan.FromHours(24)
+            });
+
+        // Request 999h — should clamp to MaxLookback (24h).
+        var args = JsonDocument.Parse("""{"incidentId":"X","lookbackHours":999}""").RootElement;
+        var result = await sut.CallToolAsync(
+            ApplicationInsightsToolProvider.LookupIncidentToolName, args, StubContext, default);
+
+        result.IsError.Should().BeFalse();
+        ais.Verify();
+        JsonDocument.Parse(result.Content.Single().Text).RootElement
+            .GetProperty("lookbackHours").GetInt32().Should().Be(24);
+    }
+
+    [Fact]
+    public async Task Default_lookback_is_used_when_arg_missing()
+    {
+        var ais = new Mock<IApplicationInsightsService>();
+        ais.Setup(x => x.SearchByCorrelationIdAsync(
+                It.IsAny<IApplicationInsightsContext>(), It.IsAny<string>(), TimeSpan.FromHours(6)))
+           .Returns(ToAsync<LogItem>())
+           .Verifiable();
+
+        var sut = new ApplicationInsightsToolProvider(ais.Object,
+            new Quilt4NetMcpOptions
+            {
+                DataAccess = DataAccessLevel.DataRead,
+                DefaultLookback = TimeSpan.FromHours(6)
+            });
+
+        var args = JsonDocument.Parse("""{"correlationId":"abc"}""").RootElement;
+        await sut.CallToolAsync(
+            ApplicationInsightsToolProvider.LookupCorrelationToolName, args, StubContext, default);
+
+        ais.Verify();
+    }
+
+    [Fact]
+    public async Task Unknown_tool_returns_error()
+    {
+        var sut = NewSut(new Quilt4NetMcpOptions());
+
+        var result = await sut.CallToolAsync("quilt4net.bogus", EmptyArgs, StubContext, default);
+
+        result.IsError.Should().BeTrue();
+        result.Content.Single().Text.Should().Contain("Unknown tool");
+    }
+
+    private static ApplicationInsightsToolProvider NewSut(Quilt4NetMcpOptions options)
+        => new(Mock.Of<IApplicationInsightsService>(), options);
+
+    private static IMcpContext StubContext => new TestMcpContext();
+
+#pragma warning disable CS1998
+    private static async IAsyncEnumerable<T> ToAsync<T>(params T[] items)
+#pragma warning restore CS1998
+    {
+        foreach (var item in items) yield return item;
+    }
+
+    private sealed class TestMcpContext : IMcpContext
+    {
+        public string UserId => "test-user";
+        public string TeamId => null;
+        public bool IsDeveloper => true;
+        public McpScope Scope => McpScope.System;
+    }
+}

--- a/Quilt4Net.Toolkit.Mcp.Tests/Quilt4Net.Toolkit.Mcp.Tests.csproj
+++ b/Quilt4Net.Toolkit.Mcp.Tests/Quilt4Net.Toolkit.Mcp.Tests.csproj
@@ -1,0 +1,27 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+	<PropertyGroup>
+		<TargetFramework>net10.0</TargetFramework>
+		<ImplicitUsings>enable</ImplicitUsings>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<PackageReference Include="FluentAssertions" Version="8.9.0" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
+		<PackageReference Include="Moq" Version="4.20.72" />
+		<PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
+		<PackageReference Include="coverlet.collector" Version="10.0.0">
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
+		<PackageReference Include="xunit.v3" Version="3.2.2" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<ProjectReference Include="..\Quilt4Net.Toolkit.Mcp\Quilt4Net.Toolkit.Mcp.csproj" />
+	</ItemGroup>
+
+</Project>

--- a/Quilt4Net.Toolkit.Mcp.Tests/ThargaMcpBuilderExtensionsTests.cs
+++ b/Quilt4Net.Toolkit.Mcp.Tests/ThargaMcpBuilderExtensionsTests.cs
@@ -1,0 +1,56 @@
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using Quilt4Net.Toolkit.Features.ApplicationInsights;
+using Quilt4Net.Toolkit.Mcp;
+using Tharga.Mcp;
+using Xunit;
+
+namespace Quilt4Net.Toolkit.Mcp.Tests;
+
+public class ThargaMcpBuilderExtensionsTests
+{
+    [Fact]
+    public void AddQuilt4Net_registers_options_and_providers()
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton(Mock.Of<IApplicationInsightsService>());
+
+        services.AddThargaMcp(mcp =>
+        {
+            mcp.AddQuilt4Net(o =>
+            {
+                o.DataAccess = DataAccessLevel.DataRead;
+                o.DefaultLookback = TimeSpan.FromHours(2);
+            });
+        });
+
+        var sp = services.BuildServiceProvider();
+
+        var options = sp.GetRequiredService<Quilt4NetMcpOptions>();
+        options.DataAccess.Should().Be(DataAccessLevel.DataRead);
+        options.DefaultLookback.Should().Be(TimeSpan.FromHours(2));
+
+        var toolProviders = sp.GetServices<IMcpToolProvider>().ToArray();
+        toolProviders.Should().ContainSingle(p => p is ApplicationInsightsToolProvider);
+
+        var resourceProviders = sp.GetServices<IMcpResourceProvider>().ToArray();
+        resourceProviders.Should().ContainSingle(p => p is ApplicationInsightsResourceProvider);
+    }
+
+    [Fact]
+    public void AddQuilt4Net_uses_defaults_when_no_callback_provided()
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton(Mock.Of<IApplicationInsightsService>());
+
+        services.AddThargaMcp(mcp => mcp.AddQuilt4Net());
+
+        var sp = services.BuildServiceProvider();
+        var options = sp.GetRequiredService<Quilt4NetMcpOptions>();
+
+        options.DataAccess.Should().Be(DataAccessLevel.Metadata);
+        options.DefaultLookback.Should().Be(TimeSpan.FromDays(1));
+        options.MaxLookback.Should().Be(TimeSpan.FromDays(7));
+    }
+}

--- a/Quilt4Net.Toolkit.Mcp/ApplicationInsightsResourceProvider.cs
+++ b/Quilt4Net.Toolkit.Mcp/ApplicationInsightsResourceProvider.cs
@@ -1,0 +1,95 @@
+using System.Text.Json;
+using Quilt4Net.Toolkit.Features.ApplicationInsights;
+using Tharga.Mcp;
+
+namespace Quilt4Net.Toolkit.Mcp;
+
+/// <summary>
+/// Read-only browsing surfaces for Application Insights. Lives on
+/// <see cref="McpScope.System"/>; exposes environment names and recent
+/// summary buckets. The actual log-content tools are on
+/// <see cref="ApplicationInsightsToolProvider"/>.
+/// </summary>
+public sealed class ApplicationInsightsResourceProvider : IMcpResourceProvider
+{
+    internal const string EnvironmentsUri = "quilt4net://environments";
+    internal const string SummariesUri = "quilt4net://summaries";
+
+    private static readonly JsonSerializerOptions JsonOptions = new() { WriteIndented = true };
+
+    private readonly IApplicationInsightsService _ais;
+    private readonly Quilt4NetMcpOptions _options;
+
+    public ApplicationInsightsResourceProvider(IApplicationInsightsService ais, Quilt4NetMcpOptions options)
+    {
+        _ais = ais;
+        _options = options;
+    }
+
+    public McpScope Scope => McpScope.System;
+
+    public Task<IReadOnlyList<McpResourceDescriptor>> ListResourcesAsync(IMcpContext context, CancellationToken cancellationToken)
+    {
+        IReadOnlyList<McpResourceDescriptor> resources =
+        [
+            new McpResourceDescriptor
+            {
+                Uri = EnvironmentsUri,
+                Name = "Quilt4Net environments",
+                Description = "Environment names seen in the configured Application Insights workspace.",
+                MimeType = "application/json"
+            },
+            new McpResourceDescriptor
+            {
+                Uri = SummariesUri,
+                Name = "Quilt4Net summaries",
+                Description = "Recent log summary buckets across all environments (default lookback).",
+                MimeType = "application/json"
+            }
+        ];
+        return Task.FromResult(resources);
+    }
+
+    public async Task<McpResourceContent> ReadResourceAsync(string uri, IMcpContext context, CancellationToken cancellationToken)
+    {
+        return uri switch
+        {
+            EnvironmentsUri => await ReadEnvironmentsAsync(cancellationToken),
+            SummariesUri => await ReadSummariesAsync(cancellationToken),
+            _ => throw new InvalidOperationException($"Unknown resource: {uri}")
+        };
+    }
+
+    private async Task<McpResourceContent> ReadEnvironmentsAsync(CancellationToken cancellationToken)
+    {
+        var items = await _ais.GetEnvironments(null)
+            .Select(e => new { value = e.Value, label = e.Label })
+            .ToArrayAsync(cancellationToken);
+
+        return new McpResourceContent
+        {
+            Uri = EnvironmentsUri,
+            MimeType = "application/json",
+            Text = JsonSerializer.Serialize(new { environments = items }, JsonOptions)
+        };
+    }
+
+    private async Task<McpResourceContent> ReadSummariesAsync(CancellationToken cancellationToken)
+    {
+        var items = await _ais.GetSummaries(null, null, _options.DefaultLookback)
+            .Take(100)
+            .ToArrayAsync(cancellationToken);
+
+        return new McpResourceContent
+        {
+            Uri = SummariesUri,
+            MimeType = "application/json",
+            Text = JsonSerializer.Serialize(new
+            {
+                lookbackHours = (int)_options.DefaultLookback.TotalHours,
+                count = items.Length,
+                summaries = items
+            }, JsonOptions)
+        };
+    }
+}

--- a/Quilt4Net.Toolkit.Mcp/ApplicationInsightsToolProvider.cs
+++ b/Quilt4Net.Toolkit.Mcp/ApplicationInsightsToolProvider.cs
@@ -1,0 +1,353 @@
+using System.Text.Json;
+using Quilt4Net.Toolkit.Features.ApplicationInsights;
+using Tharga.Mcp;
+
+namespace Quilt4Net.Toolkit.Mcp;
+
+/// <summary>
+/// Exposes the Quilt4Net Application Insights query surface as MCP tools on
+/// <see cref="McpScope.System"/>. All tools delegate to
+/// <see cref="IApplicationInsightsService"/>.
+/// </summary>
+public sealed class ApplicationInsightsToolProvider : IMcpToolProvider
+{
+    internal const string GetEnvironmentsToolName = "quilt4net.get_environments";
+    internal const string SearchLogsToolName = "quilt4net.search_logs";
+    internal const string GetLogDetailToolName = "quilt4net.get_log_detail";
+    internal const string ListSummariesToolName = "quilt4net.list_summaries";
+    internal const string GetSummaryToolName = "quilt4net.get_summary";
+    internal const string LookupIncidentToolName = "quilt4net.lookup_incident";
+    internal const string LookupCorrelationToolName = "quilt4net.lookup_correlation";
+
+    private static readonly JsonElement EmptyArgSchema = JsonSerializer.Deserialize<JsonElement>("""
+        { "type": "object", "properties": {} }
+        """);
+
+    private static readonly JsonElement SearchLogsArgSchema = JsonSerializer.Deserialize<JsonElement>("""
+        {
+          "type": "object",
+          "properties": {
+            "text": { "type": "string", "description": "Free-text fragment to find in Message or CorrelationId. Empty matches everything." },
+            "environment": { "type": "string", "description": "Optional environment to filter by (e.g. \"Production\")." },
+            "lookbackHours": { "type": "integer", "minimum": 1, "description": "Lookback window in hours. Defaults to the provider's DefaultLookback. Capped at MaxLookback." },
+            "minSeverity": { "type": "integer", "minimum": 0, "maximum": 4, "description": "Minimum SeverityLevel (0=Verbose, 1=Info, 2=Warning, 3=Error, 4=Critical). Default 0." }
+          }
+        }
+        """);
+
+    private static readonly JsonElement GetLogDetailArgSchema = JsonSerializer.Deserialize<JsonElement>("""
+        {
+          "type": "object",
+          "properties": {
+            "id": { "type": "string", "description": "_ItemId from the AI row (the LogItem.Id field)." },
+            "source": { "type": "string", "enum": ["Trace", "Exception", "Request"], "description": "Which AI table the row came from." },
+            "environment": { "type": "string" },
+            "lookbackHours": { "type": "integer", "minimum": 1 }
+          },
+          "required": ["id", "source"]
+        }
+        """);
+
+    private static readonly JsonElement ListSummariesArgSchema = JsonSerializer.Deserialize<JsonElement>("""
+        {
+          "type": "object",
+          "properties": {
+            "environment": { "type": "string" },
+            "lookbackHours": { "type": "integer", "minimum": 1 }
+          }
+        }
+        """);
+
+    private static readonly JsonElement GetSummaryArgSchema = JsonSerializer.Deserialize<JsonElement>("""
+        {
+          "type": "object",
+          "properties": {
+            "fingerprint": { "type": "string", "description": "Fingerprint from a SummarySubset / LogItem." },
+            "source": { "type": "string", "enum": ["Trace", "Exception", "Request"] },
+            "environment": { "type": "string" },
+            "lookbackHours": { "type": "integer", "minimum": 1 }
+          },
+          "required": ["fingerprint", "source"]
+        }
+        """);
+
+    private static readonly JsonElement LookupIncidentArgSchema = JsonSerializer.Deserialize<JsonElement>("""
+        {
+          "type": "object",
+          "properties": {
+            "incidentId": { "type": "string", "description": "6-char base32 incident id from a Quilt4Net UI alert." },
+            "lookbackHours": { "type": "integer", "minimum": 1 }
+          },
+          "required": ["incidentId"]
+        }
+        """);
+
+    private static readonly JsonElement LookupCorrelationArgSchema = JsonSerializer.Deserialize<JsonElement>("""
+        {
+          "type": "object",
+          "properties": {
+            "correlationId": { "type": "string", "description": "OperationId / CorrelationId / RequestId GUID." },
+            "lookbackHours": { "type": "integer", "minimum": 1 }
+          },
+          "required": ["correlationId"]
+        }
+        """);
+
+    private static readonly McpToolDescriptor[] AllTools =
+    [
+        new McpToolDescriptor
+        {
+            Name = GetEnvironmentsToolName,
+            Description = "List the environment names seen in the workspace's recent telemetry.",
+            InputSchema = EmptyArgSchema
+        },
+        new McpToolDescriptor
+        {
+            Name = SearchLogsToolName,
+            Description = "Search AppExceptions, AppTraces and AppRequests by free-text. Returns up to 100 LogItems (DataRead).",
+            InputSchema = SearchLogsArgSchema
+        },
+        new McpToolDescriptor
+        {
+            Name = GetLogDetailToolName,
+            Description = "Return the full LogDetails (raw JSON payload included) for a single AI row identified by id + source (DataRead).",
+            InputSchema = GetLogDetailArgSchema
+        },
+        new McpToolDescriptor
+        {
+            Name = ListSummariesToolName,
+            Description = "List grouped log summary buckets (fingerprint + count + last-seen). Up to 100 entries (DataRead).",
+            InputSchema = ListSummariesArgSchema
+        },
+        new McpToolDescriptor
+        {
+            Name = GetSummaryToolName,
+            Description = "Return the SummaryData for a fingerprint + source (DataRead).",
+            InputSchema = GetSummaryArgSchema
+        },
+        new McpToolDescriptor
+        {
+            Name = LookupIncidentToolName,
+            Description = "Look up Application Insights rows by Quilt4Net IncidentId (Properties.IncidentId match) (DataRead).",
+            InputSchema = LookupIncidentArgSchema
+        },
+        new McpToolDescriptor
+        {
+            Name = LookupCorrelationToolName,
+            Description = "Look up Application Insights rows by CorrelationId, OperationId, or RequestId (DataRead).",
+            InputSchema = LookupCorrelationArgSchema
+        }
+    ];
+
+    private static readonly IReadOnlyDictionary<string, DataAccessLevel> ToolLevels = new Dictionary<string, DataAccessLevel>
+    {
+        [GetEnvironmentsToolName] = DataAccessLevel.Metadata,
+        [SearchLogsToolName] = DataAccessLevel.DataRead,
+        [GetLogDetailToolName] = DataAccessLevel.DataRead,
+        [ListSummariesToolName] = DataAccessLevel.DataRead,
+        [GetSummaryToolName] = DataAccessLevel.DataRead,
+        [LookupIncidentToolName] = DataAccessLevel.DataRead,
+        [LookupCorrelationToolName] = DataAccessLevel.DataRead
+    };
+
+    private readonly IApplicationInsightsService _ais;
+    private readonly Quilt4NetMcpOptions _options;
+
+    public ApplicationInsightsToolProvider(IApplicationInsightsService ais, Quilt4NetMcpOptions options)
+    {
+        _ais = ais;
+        _options = options;
+    }
+
+    public McpScope Scope => McpScope.System;
+
+    public Task<IReadOnlyList<McpToolDescriptor>> ListToolsAsync(IMcpContext context, CancellationToken cancellationToken)
+    {
+        IReadOnlyList<McpToolDescriptor> filtered = AllTools
+            .Where(t => ToolLevels[t.Name] <= _options.DataAccess)
+            .ToArray();
+        return Task.FromResult(filtered);
+    }
+
+    public async Task<McpToolResult> CallToolAsync(string toolName, JsonElement arguments, IMcpContext context, CancellationToken cancellationToken)
+    {
+        if (!ToolLevels.TryGetValue(toolName, out var required))
+        {
+            return Error($"Unknown tool: {toolName}");
+        }
+        if (required > _options.DataAccess)
+        {
+            return Error($"Tool '{toolName}' requires DataAccessLevel.{required} but server is configured for DataAccessLevel.{_options.DataAccess}.");
+        }
+
+        try
+        {
+            return toolName switch
+            {
+                GetEnvironmentsToolName => await GetEnvironmentsAsync(cancellationToken),
+                SearchLogsToolName => await SearchLogsAsync(arguments, cancellationToken),
+                GetLogDetailToolName => await GetLogDetailAsync(arguments),
+                ListSummariesToolName => await ListSummariesAsync(arguments, cancellationToken),
+                GetSummaryToolName => await GetSummaryAsync(arguments),
+                LookupIncidentToolName => await LookupIncidentAsync(arguments, cancellationToken),
+                LookupCorrelationToolName => await LookupCorrelationAsync(arguments, cancellationToken),
+                _ => Error($"Unknown tool: {toolName}")
+            };
+        }
+        catch (Exception e)
+        {
+            return Error($"{e.GetType().Name}: {e.Message}");
+        }
+    }
+
+    private async Task<McpToolResult> GetEnvironmentsAsync(CancellationToken cancellationToken)
+    {
+        var items = await _ais.GetEnvironments(null)
+            .Select(e => new { value = e.Value, label = e.Label })
+            .ToArrayAsync(cancellationToken);
+        return Ok(new { count = items.Length, environments = items });
+    }
+
+    private async Task<McpToolResult> SearchLogsAsync(JsonElement arguments, CancellationToken cancellationToken)
+    {
+        var text = GetString(arguments, "text") ?? string.Empty;
+        var environment = GetString(arguments, "environment");
+        var lookback = GetLookback(arguments);
+        var minSeverity = (SeverityLevel)(GetInt(arguments, "minSeverity") ?? 0);
+
+        var items = await _ais.SearchAsync(null, environment, text, lookback, minSeverity)
+            .Take(100)
+            .ToArrayAsync(cancellationToken);
+        return Ok(new
+        {
+            lookbackHours = (int)lookback.TotalHours,
+            count = items.Length,
+            truncated = items.Length == 100,
+            items
+        });
+    }
+
+    private async Task<McpToolResult> GetLogDetailAsync(JsonElement arguments)
+    {
+        var id = arguments.GetProperty("id").GetString();
+        if (!TryParseSource(arguments.GetProperty("source").GetString(), out var source))
+            return Error("source must be Trace, Exception, or Request.");
+
+        var environment = GetString(arguments, "environment");
+        var lookback = GetLookback(arguments);
+
+        var detail = await _ais.GetDetail(null, id, source, environment, lookback);
+        if (detail is null) return Error($"No {source} item found with id '{id}' in the last {(int)lookback.TotalHours}h.");
+        return Ok(detail);
+    }
+
+    private async Task<McpToolResult> ListSummariesAsync(JsonElement arguments, CancellationToken cancellationToken)
+    {
+        var environment = GetString(arguments, "environment");
+        var lookback = GetLookback(arguments);
+
+        var items = await _ais.GetSummaries(null, environment, lookback)
+            .Take(100)
+            .ToArrayAsync(cancellationToken);
+        return Ok(new
+        {
+            lookbackHours = (int)lookback.TotalHours,
+            count = items.Length,
+            truncated = items.Length == 100,
+            summaries = items
+        });
+    }
+
+    private async Task<McpToolResult> GetSummaryAsync(JsonElement arguments)
+    {
+        var fingerprint = arguments.GetProperty("fingerprint").GetString();
+        if (!TryParseSource(arguments.GetProperty("source").GetString(), out var source))
+            return Error("source must be Trace, Exception, or Request.");
+
+        var environment = GetString(arguments, "environment");
+        var lookback = GetLookback(arguments);
+
+        var summary = await _ais.GetSummary(null, fingerprint, source, environment, lookback);
+        if (summary is null) return Error($"No {source} summary found for fingerprint '{fingerprint}' in the last {(int)lookback.TotalHours}h.");
+        return Ok(summary);
+    }
+
+    private async Task<McpToolResult> LookupIncidentAsync(JsonElement arguments, CancellationToken cancellationToken)
+    {
+        var incidentId = arguments.GetProperty("incidentId").GetString();
+        if (string.IsNullOrWhiteSpace(incidentId)) return Error("incidentId is required.");
+        var lookback = GetLookback(arguments);
+
+        var items = await _ais.SearchByIncidentIdAsync(null, incidentId, lookback)
+            .Take(100)
+            .ToArrayAsync(cancellationToken);
+        return Ok(new
+        {
+            incidentId,
+            lookbackHours = (int)lookback.TotalHours,
+            count = items.Length,
+            truncated = items.Length == 100,
+            items
+        });
+    }
+
+    private async Task<McpToolResult> LookupCorrelationAsync(JsonElement arguments, CancellationToken cancellationToken)
+    {
+        var correlationId = arguments.GetProperty("correlationId").GetString();
+        if (string.IsNullOrWhiteSpace(correlationId)) return Error("correlationId is required.");
+        var lookback = GetLookback(arguments);
+
+        var items = await _ais.SearchByCorrelationIdAsync(null, correlationId, lookback)
+            .Take(100)
+            .ToArrayAsync(cancellationToken);
+        return Ok(new
+        {
+            correlationId,
+            lookbackHours = (int)lookback.TotalHours,
+            count = items.Length,
+            truncated = items.Length == 100,
+            items
+        });
+    }
+
+    private TimeSpan GetLookback(JsonElement arguments)
+    {
+        var hours = GetInt(arguments, "lookbackHours");
+        if (!hours.HasValue || hours.Value <= 0) return _options.DefaultLookback;
+        var requested = TimeSpan.FromHours(hours.Value);
+        return requested > _options.MaxLookback ? _options.MaxLookback : requested;
+    }
+
+    private static string GetString(JsonElement arguments, string name)
+    {
+        if (arguments.ValueKind != JsonValueKind.Object) return null;
+        if (!arguments.TryGetProperty(name, out var prop)) return null;
+        if (prop.ValueKind != JsonValueKind.String) return null;
+        var value = prop.GetString();
+        return string.IsNullOrWhiteSpace(value) ? null : value;
+    }
+
+    private static int? GetInt(JsonElement arguments, string name)
+    {
+        if (arguments.ValueKind != JsonValueKind.Object) return null;
+        if (!arguments.TryGetProperty(name, out var prop)) return null;
+        if (prop.ValueKind != JsonValueKind.Number) return null;
+        return prop.GetInt32();
+    }
+
+    private static bool TryParseSource(string value, out LogSource source)
+    {
+        return Enum.TryParse(value, ignoreCase: true, out source);
+    }
+
+    private static McpToolResult Ok(object payload) => new()
+    {
+        Content = [new McpContent { Type = "text", Text = JsonSerializer.Serialize(payload) }]
+    };
+
+    private static McpToolResult Error(string message) => new()
+    {
+        IsError = true,
+        Content = [new McpContent { Type = "text", Text = message }]
+    };
+}

--- a/Quilt4Net.Toolkit.Mcp/DataAccessLevel.cs
+++ b/Quilt4Net.Toolkit.Mcp/DataAccessLevel.cs
@@ -1,0 +1,27 @@
+namespace Quilt4Net.Toolkit.Mcp;
+
+/// <summary>
+/// Controls how much Application Insights data the MCP surface exposes.
+/// Each level is a strict superset of the previous one. Mirrors
+/// <c>Tharga.MongoDB.Mcp.DataAccessLevel</c> by intent.
+/// </summary>
+public enum DataAccessLevel
+{
+    /// <summary>
+    /// Default. Only metadata is exposed — environment names and resource
+    /// listings — nothing that returns log content.
+    /// </summary>
+    Metadata = 0,
+
+    /// <summary>
+    /// Adds tools that return actual log content: search, detail, summary,
+    /// and the incident / correlation lookup tools.
+    /// </summary>
+    DataRead = 1,
+
+    /// <summary>
+    /// Reserved for a future write phase (e.g. cache invalidation, content
+    /// refresh). No tools at this level are emitted yet.
+    /// </summary>
+    DataReadWrite = 2,
+}

--- a/Quilt4Net.Toolkit.Mcp/Quilt4Net.Toolkit.Mcp.csproj
+++ b/Quilt4Net.Toolkit.Mcp/Quilt4Net.Toolkit.Mcp.csproj
@@ -1,0 +1,44 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Version>1.0.0</Version>
+    <Authors>Thargelion AB</Authors>
+    <Company>Thargelion AB</Company>
+    <Product>Quilt4Net Toolkit MCP</Product>
+    <Tag>MCP ApplicationInsights</Tag>
+    <Description>MCP (Model Context Protocol) provider for Quilt4Net.Toolkit. Exposes Application Insights query operations as MCP tools and resources, plugging into the Tharga.Mcp ecosystem so AI agents can look up incidents and correlate logs.</Description>
+    <PackageIconUrl>https://quilt4net.com/quilt4net-48x48.png</PackageIconUrl>
+    <GenerateDocumentationFile>True</GenerateDocumentationFile>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+    <PackageProjectUrl>https://github.com/Quilt4/Quilt4Net.Toolkit</PackageProjectUrl>
+    <DebugType>portable</DebugType>
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <IncludeSource>true</IncludeSource>
+    <IncludeSymbols>true</IncludeSymbols>
+  </PropertyGroup>
+  <PropertyGroup>
+    <NoWarn>1701;1702;CS1591;CS0809</NoWarn>
+  </PropertyGroup>
+  <ItemGroup>
+    <None Include="README.md">
+      <Pack>True</Pack>
+      <PackagePath>\</PackagePath>
+    </None>
+  </ItemGroup>
+  <ItemGroup>
+    <InternalsVisibleTo Include="Quilt4Net.Toolkit.Mcp.Tests" />
+    <InternalsVisibleTo Include="DynamicProxyGenAssembly2" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Tharga.Mcp" Version="0.1.3" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.203">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Quilt4Net.Toolkit\Quilt4Net.Toolkit.csproj" />
+  </ItemGroup>
+</Project>

--- a/Quilt4Net.Toolkit.Mcp/Quilt4NetMcpOptions.cs
+++ b/Quilt4Net.Toolkit.Mcp/Quilt4NetMcpOptions.cs
@@ -1,0 +1,29 @@
+namespace Quilt4Net.Toolkit.Mcp;
+
+/// <summary>
+/// Options consumed by the Quilt4Net.Toolkit.Mcp providers. Configured via
+/// <see cref="ThargaMcpBuilderExtensions.AddQuilt4Net"/> inside the
+/// <c>AddThargaMcp</c> callback.
+/// </summary>
+public sealed class Quilt4NetMcpOptions
+{
+    /// <summary>
+    /// Maximum sensitivity of data the tools will return.
+    /// Defaults to <see cref="DataAccessLevel.Metadata"/> (no log content).
+    /// Set to <see cref="DataAccessLevel.DataRead"/> to enable search /
+    /// detail / summary / lookup tools.
+    /// </summary>
+    public DataAccessLevel DataAccess { get; set; } = DataAccessLevel.Metadata;
+
+    /// <summary>
+    /// Lookback window applied when a tool call doesn't specify
+    /// <c>lookbackHours</c>. Default <c>1d</c>.
+    /// </summary>
+    public TimeSpan DefaultLookback { get; set; } = TimeSpan.FromDays(1);
+
+    /// <summary>
+    /// Maximum lookback window the tools will accept; <c>lookbackHours</c>
+    /// values larger than this are clamped server-side. Default <c>7d</c>.
+    /// </summary>
+    public TimeSpan MaxLookback { get; set; } = TimeSpan.FromDays(7);
+}

--- a/Quilt4Net.Toolkit.Mcp/README.md
+++ b/Quilt4Net.Toolkit.Mcp/README.md
@@ -1,0 +1,57 @@
+# Quilt4Net.Toolkit.Mcp
+
+MCP (Model Context Protocol) provider for Quilt4Net.Toolkit. Plugs into the [Tharga.Mcp](https://www.nuget.org/packages/Tharga.Mcp) ecosystem and exposes the Application Insights query surface (`IApplicationInsightsService`) as MCP tools and resources, so AI agents (Claude Desktop, Cursor, Claude Code, etc.) can look up incidents and correlate logs without writing KQL.
+
+## Get started
+
+Install the NuGet package and register the provider alongside any other MCP providers (`Tharga.Platform.Mcp` for auth, `Tharga.MongoDB.Mcp`, etc.):
+
+```csharp
+builder.Services.AddThargaMcp(mcp =>
+{
+    mcp.AddPlatform();                 // optional — auth via Tharga.Platform
+    mcp.AddQuilt4Net(o =>
+    {
+        o.DataAccess = Quilt4Net.Toolkit.Mcp.DataAccessLevel.DataRead; // default: Metadata
+    });
+});
+
+app.UseThargaMcp();                    // maps /mcp/system, /mcp/team, /mcp/me
+```
+
+The provider also requires `Quilt4Net.Toolkit`'s Application Insights services — typically registered via:
+
+```csharp
+builder.AddQuilt4NetApplicationInsightsClient();
+```
+
+## Exposed tools (`McpScope.System`)
+
+| Tool | Sensitivity | Args | Returns |
+|---|---|---|---|
+| `quilt4net.get_environments` | Metadata | — | environment names seen in the workspace |
+| `quilt4net.search_logs` | DataRead | `text`, `environment?`, `lookbackHours?`, `minSeverity?` | up to 100 `LogItem`s |
+| `quilt4net.get_log_detail` | DataRead | `id`, `source`, `environment?`, `lookbackHours?` | full `LogDetails` for one row |
+| `quilt4net.list_summaries` | DataRead | `environment?`, `lookbackHours?` | up to 100 `SummarySubset`s |
+| `quilt4net.get_summary` | DataRead | `fingerprint`, `source`, `environment?`, `lookbackHours?` | grouped `SummaryData` for one fingerprint |
+| `quilt4net.lookup_incident` | DataRead | `incidentId`, `lookbackHours?` | rows whose `Properties.IncidentId` matches |
+| `quilt4net.lookup_correlation` | DataRead | `correlationId`, `lookbackHours?` | rows whose `OperationId` / `Properties.CorrelationId` matches |
+
+## Exposed resources
+
+| URI | Description |
+|---|---|
+| `quilt4net://environments` | environment names seen in the workspace |
+| `quilt4net://summaries` | recent summary buckets (last 24h by default) |
+
+## Options
+
+| Property | Default | Description |
+|---|---|---|
+| `DataAccess` | `Metadata` | `Metadata` exposes only `get_environments` and the resources. `DataRead` enables search/detail/summary/lookup tools. `DataReadWrite` is reserved for a future write-tools phase. |
+| `DefaultLookback` | `1d` | Lookback window when a tool call doesn't specify `lookbackHours`. |
+| `MaxLookback` | `7d` | Server-side cap on `lookbackHours` to bound query cost. |
+
+## Phase
+
+This is Phase 1 of the Quilt4Net MCP plan — Application Insights logs (read). Health / Version / Dependencies / Components and write tools land in follow-up packages.

--- a/Quilt4Net.Toolkit.Mcp/ThargaMcpBuilderExtensions.cs
+++ b/Quilt4Net.Toolkit.Mcp/ThargaMcpBuilderExtensions.cs
@@ -1,0 +1,33 @@
+using Microsoft.Extensions.DependencyInjection;
+using Tharga.Mcp;
+
+namespace Quilt4Net.Toolkit.Mcp;
+
+/// <summary>
+/// Extension methods for <see cref="IThargaMcpBuilder"/> that register the
+/// Quilt4Net Application Insights MCP providers.
+/// </summary>
+public static class ThargaMcpBuilderExtensions
+{
+    /// <summary>
+    /// Registers <see cref="ApplicationInsightsToolProvider"/> and
+    /// <see cref="ApplicationInsightsResourceProvider"/>, exposing the
+    /// Quilt4Net Application Insights query surface on the System scope.
+    /// Requires <c>IApplicationInsightsService</c> to be registered (typically
+    /// via <c>builder.AddQuilt4NetApplicationInsightsClient()</c>).
+    /// </summary>
+    /// <param name="builder">The MCP builder.</param>
+    /// <param name="configure">Optional callback to configure
+    /// <see cref="Quilt4NetMcpOptions"/>. If omitted, defaults are used
+    /// (<see cref="DataAccessLevel.Metadata"/>, 1d default lookback, 7d cap).</param>
+    public static IThargaMcpBuilder AddQuilt4Net(this IThargaMcpBuilder builder, Action<Quilt4NetMcpOptions> configure = null)
+    {
+        var options = new Quilt4NetMcpOptions();
+        configure?.Invoke(options);
+        builder.Services.AddSingleton(options);
+
+        builder.AddResourceProvider<ApplicationInsightsResourceProvider>();
+        builder.AddToolProvider<ApplicationInsightsToolProvider>();
+        return builder;
+    }
+}

--- a/Quilt4Net.Toolkit.sln
+++ b/Quilt4Net.Toolkit.sln
@@ -37,6 +37,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Quilt4Net.Toolkit.Blazor.Se
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Quilt4Net.Toolkit.Blazor.Wasm.Sample", "Quilt4Net.Toolkit.Blazor.Wasm.Sample\Quilt4Net.Toolkit.Blazor.Wasm.Sample.csproj", "{41DC7068-991B-4A72-B4FE-7ABBB8A46AB5}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Quilt4Net.Toolkit.Mcp", "Quilt4Net.Toolkit.Mcp\Quilt4Net.Toolkit.Mcp.csproj", "{408CE415-BDE9-4574-A110-6079D6E7D419}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Quilt4Net.Toolkit.Mcp.Tests", "Quilt4Net.Toolkit.Mcp.Tests\Quilt4Net.Toolkit.Mcp.Tests.csproj", "{45AB6496-4DAA-49D9-B96C-8756D35FD700}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -191,6 +195,30 @@ Global
 		{41DC7068-991B-4A72-B4FE-7ABBB8A46AB5}.Release|x64.Build.0 = Release|Any CPU
 		{41DC7068-991B-4A72-B4FE-7ABBB8A46AB5}.Release|x86.ActiveCfg = Release|Any CPU
 		{41DC7068-991B-4A72-B4FE-7ABBB8A46AB5}.Release|x86.Build.0 = Release|Any CPU
+		{408CE415-BDE9-4574-A110-6079D6E7D419}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{408CE415-BDE9-4574-A110-6079D6E7D419}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{408CE415-BDE9-4574-A110-6079D6E7D419}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{408CE415-BDE9-4574-A110-6079D6E7D419}.Debug|x64.Build.0 = Debug|Any CPU
+		{408CE415-BDE9-4574-A110-6079D6E7D419}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{408CE415-BDE9-4574-A110-6079D6E7D419}.Debug|x86.Build.0 = Debug|Any CPU
+		{408CE415-BDE9-4574-A110-6079D6E7D419}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{408CE415-BDE9-4574-A110-6079D6E7D419}.Release|Any CPU.Build.0 = Release|Any CPU
+		{408CE415-BDE9-4574-A110-6079D6E7D419}.Release|x64.ActiveCfg = Release|Any CPU
+		{408CE415-BDE9-4574-A110-6079D6E7D419}.Release|x64.Build.0 = Release|Any CPU
+		{408CE415-BDE9-4574-A110-6079D6E7D419}.Release|x86.ActiveCfg = Release|Any CPU
+		{408CE415-BDE9-4574-A110-6079D6E7D419}.Release|x86.Build.0 = Release|Any CPU
+		{45AB6496-4DAA-49D9-B96C-8756D35FD700}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{45AB6496-4DAA-49D9-B96C-8756D35FD700}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{45AB6496-4DAA-49D9-B96C-8756D35FD700}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{45AB6496-4DAA-49D9-B96C-8756D35FD700}.Debug|x64.Build.0 = Debug|Any CPU
+		{45AB6496-4DAA-49D9-B96C-8756D35FD700}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{45AB6496-4DAA-49D9-B96C-8756D35FD700}.Debug|x86.Build.0 = Debug|Any CPU
+		{45AB6496-4DAA-49D9-B96C-8756D35FD700}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{45AB6496-4DAA-49D9-B96C-8756D35FD700}.Release|Any CPU.Build.0 = Release|Any CPU
+		{45AB6496-4DAA-49D9-B96C-8756D35FD700}.Release|x64.ActiveCfg = Release|Any CPU
+		{45AB6496-4DAA-49D9-B96C-8756D35FD700}.Release|x64.Build.0 = Release|Any CPU
+		{45AB6496-4DAA-49D9-B96C-8756D35FD700}.Release|x86.ActiveCfg = Release|Any CPU
+		{45AB6496-4DAA-49D9-B96C-8756D35FD700}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Quilt4Net.Toolkit/Features/ApplicationInsights/ApplicationInsightsService.cs
+++ b/Quilt4Net.Toolkit/Features/ApplicationInsights/ApplicationInsightsService.cs
@@ -1066,7 +1066,8 @@ union startup, fallback
             return DateTime.SpecifyKind(dt, DateTimeKind.Utc);
         }
 
-        return DateTime.Parse(value.ToString()!);
+        var s = value?.ToString();
+        return string.IsNullOrEmpty(s) ? default : DateTime.Parse(s);
     }
 
     private static int GetInt(IReadOnlyList<object> row, int index)
@@ -1083,7 +1084,8 @@ union startup, fallback
             return (int)l;
         }
 
-        return int.Parse(value.ToString()!);
+        var s = value?.ToString();
+        return string.IsNullOrEmpty(s) ? 0 : int.Parse(s);
     }
 
     private static TimeSpan GetTimeSpan(IReadOnlyList<object> row, int index)

--- a/Quilt4Net.Toolkit/Features/ApplicationInsights/ApplicationInsightsService.cs
+++ b/Quilt4Net.Toolkit/Features/ApplicationInsights/ApplicationInsightsService.cs
@@ -1019,6 +1019,90 @@ union startup, fallback
         }
     }
 
+    public IAsyncEnumerable<LogItem> SearchByIncidentIdAsync(IApplicationInsightsContext context, string incidentId, TimeSpan timeSpan)
+    {
+        var predicate = $"tostring(_p['IncidentId']) == '{EscapeKqlSingleQuoted(incidentId)}'";
+        return SearchByIdAsync(context, predicate, timeSpan);
+    }
+
+    public IAsyncEnumerable<LogItem> SearchByCorrelationIdAsync(IApplicationInsightsContext context, string correlationId, TimeSpan timeSpan)
+    {
+        var escaped = EscapeKqlSingleQuoted(correlationId);
+        var predicate =
+            $"OperationId == '{escaped}' or " +
+            $"tostring(_p['CorrelationId']) == '{escaped}' or " +
+            $"tostring(_p['RequestId']) == '{escaped}'";
+        return SearchByIdAsync(context, predicate, timeSpan);
+    }
+
+    private async IAsyncEnumerable<LogItem> SearchByIdAsync(IApplicationInsightsContext context, string wherePredicate, TimeSpan timeSpan)
+    {
+        var client = GetClient(context);
+        var workspaceId = context?.WorkspaceId ?? _options.WorkspaceId;
+
+        var query = $@"
+union withsource=_Source AppTraces, AppExceptions, AppRequests
+| extend _p = todynamic(Properties)
+| where {wherePredicate}
+| extend
+    Environment = tostring(_p[""AspNetCoreEnvironment""]),
+    Application = coalesce(tostring(_p[""ApplicationName""]), tostring(AppRoleName)),
+    Message = coalesce(tostring(Message), tostring(OuterMessage), tostring(Name)),
+    FingerprintSource = coalesce(tostring(ProblemId), tostring(_p[""OriginalFormat""]), tostring(Message), tostring(Name)),
+    EffectiveSeverity = iif(_Source == ""AppRequests"", iif(tobool(coalesce(Success, true)), 1, 3), toint(SeverityLevel))
+| extend
+    Id = _ItemId,
+    Fingerprint = base64_encode_tostring(tostring(hash(FingerprintSource)))
+| project TimeGenerated, _Source, Application, Environment, Message, EffectiveSeverity, Id, Fingerprint
+| order by TimeGenerated asc";
+
+        var response = await client.QueryWorkspaceAsync(workspaceId, query, new LogsQueryTimeRange(timeSpan));
+
+        foreach (var table in response.Value.AllTables)
+        {
+            var timeIndex = GetColumnIndex(table, "TimeGenerated");
+            var sourceColIndex = GetColumnIndex(table, "_Source");
+            var appIndex = GetColumnIndex(table, "Application");
+            var envIndex = GetColumnIndex(table, "Environment");
+            var messageIndex = GetColumnIndex(table, "Message");
+            var severityIndex = GetColumnIndex(table, "EffectiveSeverity");
+            var idIndex = GetColumnIndex(table, "Id");
+            var fingerprintIndex = GetColumnIndex(table, "Fingerprint");
+
+            foreach (var row in table.Rows)
+            {
+                var sourceTable = row[sourceColIndex]?.ToString();
+                var source = sourceTable switch
+                {
+                    "AppExceptions" => LogSource.Exception,
+                    "AppRequests" => LogSource.Request,
+                    _ => LogSource.Trace
+                };
+
+                yield return new LogItem
+                {
+                    Id = row[idIndex]?.ToString(),
+                    Fingerprint = row[fingerprintIndex]?.ToString(),
+                    TimeGenerated = GetDateTime(row, timeIndex),
+                    Source = source,
+                    SeverityLevel = (SeverityLevel)GetInt(row, severityIndex),
+                    Message = row[messageIndex]?.ToString(),
+                    Environment = row[envIndex]?.ToString(),
+                    Application = row[appIndex]?.ToString()
+                };
+            }
+        }
+    }
+
+    private static string EscapeKqlSingleQuoted(string value)
+    {
+        if (value is null) return string.Empty;
+        return value
+            .Replace("'", "''")
+            .Replace("\r", " ")
+            .Replace("\n", " ");
+    }
+
     internal LogsQueryClient GetClient(IApplicationInsightsContext context = null)
     {
         if (context.IsCurrent()) context = null;

--- a/Quilt4Net.Toolkit/Features/ApplicationInsights/IApplicationInsightsService.cs
+++ b/Quilt4Net.Toolkit/Features/ApplicationInsights/IApplicationInsightsService.cs
@@ -19,4 +19,21 @@ public interface IApplicationInsightsService
     /// query the workspace's full retention.
     /// </summary>
     IAsyncEnumerable<VersionMatrixCell> GetVersionMatrixAsync(IApplicationInsightsContext context, TimeSpan? lookback = null);
+
+    /// <summary>
+    /// Returns all telemetry rows whose <c>Properties.IncidentId</c> matches
+    /// <paramref name="incidentId"/>. Searches AppTraces, AppExceptions, and
+    /// AppRequests over the supplied lookback window. Used by the MCP
+    /// <c>quilt4net.lookup_incident</c> tool to map a user-facing incident id
+    /// (e.g. from a UI alert) back to the structured log entry that produced it.
+    /// </summary>
+    IAsyncEnumerable<LogItem> SearchByIncidentIdAsync(IApplicationInsightsContext context, string incidentId, TimeSpan timeSpan);
+
+    /// <summary>
+    /// Returns all telemetry rows whose <c>OperationId</c> or
+    /// <c>Properties.CorrelationId</c> matches <paramref name="correlationId"/>.
+    /// Searches AppTraces, AppExceptions, and AppRequests over the supplied
+    /// lookback window.
+    /// </summary>
+    IAsyncEnumerable<LogItem> SearchByCorrelationIdAsync(IApplicationInsightsContext context, string correlationId, TimeSpan timeSpan);
 }

--- a/Quilt4Net.Toolkit/Quilt4Net.Toolkit.csproj
+++ b/Quilt4Net.Toolkit/Quilt4Net.Toolkit.csproj
@@ -51,6 +51,6 @@
     </PackageReference>
     <PackageReference Include="System.Management" Version="10.0.7" />
     <PackageReference Include="System.Linq.Async" Version="7.0.1" />
-    <PackageReference Include="Tharga.Cache" Version="0.4.2" />
+    <PackageReference Include="Tharga.Cache" Version="0.4.3" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Consolidating three commits from \`develop\` into \`master\`. Supersedes PR #78 (which can be closed once this lands — its two commits are included verbatim here).

## Commits

1. **\`ae9249d\` — fix: null-safe \`GetInt\` and \`GetDateTime\`** (= PR #77 follow-up).
   Live AI lookup against \`[Incident: FPU9MX]\` traced "Could not query Application Insights. Object reference not set to an instance of an object." to a NRE one line past the one PR #77 fixed:
   \`int.Parse(value.ToString()!)\` blows up when \`value\` is null. \`GetTimeSpan\` was already null-safe — the other two helpers now match it (return \`default\` / \`0\` when null/empty).

2. **\`c63d64f\` — chore: bump \`Tharga.Cache\` 0.4.2 → 0.4.3** in \`Quilt4Net.Toolkit.csproj\`.

3. **\`fe29226\` — feat: Quilt4Net.Toolkit.Mcp** (Phase 1 of \`plans/Quilt4Net/Toolkit/04-mcp-quilt4net.md\`).
   New NuGet package that plugs into \`Tharga.Mcp\` and exposes the \`IApplicationInsightsService\` query surface as MCP tools and resources, so AI agents can look up incidents and correlate logs without writing KQL or opening the Azure portal.

   - Auth-agnostic; auth handled by \`Tharga.Platform.Mcp\` if the consumer adds it (mirrors the convention of \`Tharga.MongoDB.Mcp\`).
   - \`DataAccessLevel\` (Metadata / DataRead / DataReadWrite) with defensive \`Metadata\` default — content-returning tools are off until the consumer opts in.
   - 7 tools on \`McpScope.System\`: \`get_environments\`, \`search_logs\`, \`get_log_detail\`, \`list_summaries\`, \`get_summary\`, \`lookup_incident\`, \`lookup_correlation\`.
   - 2 resources: \`quilt4net://environments\`, \`quilt4net://summaries\`.
   - Two new methods on \`IApplicationInsightsService\` (\`SearchByIncidentIdAsync\`, \`SearchByCorrelationIdAsync\`) backing the lookup tools — KQL lifted from the throwaway console runner that's been used for the same lookups during this week's incidents.
   - One-line consumer integration: \`services.AddThargaMcp(mcp => mcp.AddQuilt4Net(o => o.DataAccess = DataAccessLevel.DataRead));\`.
   - One new line in \`build.yml\` Pack step.

## Test plan

- [x] Solution builds clean across net8.0 / net9.0 / net10.0 with no new warnings.
- [x] Tests: 60 (\`Quilt4Net.Toolkit.Tests\`) + 50 (\`Quilt4Net.Toolkit.Blazor.Tests\`) + 15 (new \`Quilt4Net.Toolkit.Mcp.Tests\`) = 125 passing.
- [x] Existing test stubs in \`Quilt4Net.Toolkit.Blazor.Tests\` (\`StubApplicationInsightsService\`, \`ThrowingApplicationInsightsService\`) updated for the two new interface methods.
- [x] Warning ratchet not breached.
- [ ] CI green.
- [ ] Smoke: bump Server's \`Quilt4Net.Toolkit.*\` to the next NuGet release, wire \`mcp.AddQuilt4Net(o => o.DataAccess = DataAccessLevel.DataRead)\` alongside the existing \`mcp.AddPlatform()\` + \`mcp.AddMongoDB()\`, then call \`quilt4net.lookup_incident\` against a known incident id.