### PR TITLE
feat: VersionMatrixDisplay component + alias/env ordering options

### DIFF
--- a/Quilt4Net.Toolkit.Blazor/Features/VersionMatrix/VersionMatrixDisplay.razor
+++ b/Quilt4Net.Toolkit.Blazor/Features/VersionMatrix/VersionMatrixDisplay.razor
@@ -1,0 +1,180 @@
+@using Quilt4Net.Toolkit
+@using Quilt4Net.Toolkit.Features.ApplicationInsights
+@using Microsoft.Extensions.Logging
+@using Microsoft.Extensions.Options
+@inject IVersionMatrixService VersionMatrixService
+@inject IOptions<ApplicationInsightsOptions> Options
+@inject ILogger<VersionMatrixDisplay> Logger
+
+<RadzenStack Orientation="Orientation.Vertical" Gap="1rem">
+    <RadzenStack Orientation="Orientation.Horizontal" AlignItems="AlignItems.Center" Gap="1rem">
+        <RadzenButton Icon="refresh" Text="Refresh" Click="OnRefreshAsync" Disabled="@_loading" ButtonStyle="ButtonStyle.Secondary" />
+        @if (_view != null)
+        {
+            <RadzenText TextStyle="TextStyle.Caption" Text="@($"Updated {_view.LastRefreshedUtc:u}")" />
+        }
+    </RadzenStack>
+
+    @if (_loading)
+    {
+        <RadzenText Text="Loading..." />
+    }
+    else if (_error != null)
+    {
+        <RadzenAlert AlertStyle="AlertStyle.Danger" Title="Failed to load version matrix" AllowClose="false" Text="@_error" />
+    }
+    else if (_view == null || _view.Applications.Count == 0)
+    {
+        <RadzenAlert AlertStyle="AlertStyle.Info" AllowClose="false" Text="No version data found in the configured time window." />
+    }
+    else
+    {
+        <table class="version-matrix">
+            <thead>
+                <tr>
+                    <th>Application</th>
+                    @foreach (var env in _orderedEnvironments)
+                    {
+                        <th>@env</th>
+                    }
+                </tr>
+            </thead>
+            <tbody>
+                @foreach (var app in _view.Applications)
+                {
+                    <tr>
+                        <td><strong>@app</strong></td>
+                        @foreach (var env in _orderedEnvironments)
+                        {
+                            <td>
+                                @if (_view.TryGetCell(app, env, out var cell))
+                                {
+                                    var hasAlias = _view.TryGetAlias(app, env, out var alias);
+                                    var lastSeenLabel = hasAlias
+                                        ? $"Last seen {cell.LastSeen:u}\nMerged from: {string.Join(", ", alias.SourceNames)}"
+                                        : $"Last seen {cell.LastSeen:u}";
+                                    <RadzenStack Orientation="Orientation.Horizontal" AlignItems="AlignItems.Center" Gap="0.4rem">
+                                        <span title="@lastSeenLabel">@cell.Version</span>
+                                        @if (cell.Source == VersionMatrixSource.Startup)
+                                        {
+                                            <RadzenBadge BadgeStyle="BadgeStyle.Success" Text="startup" Title="Identified from a Quilt4Net startup log entry" />
+                                        }
+                                        else
+                                        {
+                                            <RadzenBadge BadgeStyle="BadgeStyle.Light" Text="log" Title="Identified by scanning regular logs" />
+                                        }
+                                        @if (hasAlias && alias.HasConflict)
+                                        {
+                                            var conflictDetail = string.Join("\n", alias.ConflictingVersions.Select(c => $"{c.SourceName}: {c.Version} ({c.LastSeen:u})"));
+                                            <RadzenBadge BadgeStyle="BadgeStyle.Warning" Text="conflict" Title="@($"Source apps disagree on version:\n{conflictDetail}")" />
+                                        }
+                                    </RadzenStack>
+                                }
+                                else
+                                {
+                                    <RadzenText TextStyle="TextStyle.Caption" Text="—" />
+                                }
+                            </td>
+                        }
+                    </tr>
+                }
+            </tbody>
+        </table>
+    }
+</RadzenStack>
+
+<style>
+    .version-matrix { border-collapse: collapse; }
+    .version-matrix th, .version-matrix td {
+        border: 1px solid var(--rz-base);
+        padding: 0.4rem 0.8rem;
+        text-align: left;
+        color: var(--rz-text-color);
+    }
+    .version-matrix thead th {
+        background-color: var(--rz-base);
+        font-weight: 600;
+    }
+</style>
+
+@code {
+    [Parameter, EditorRequired]
+    public IApplicationInsightsContext Context { get; set; } = default!;
+
+    [Parameter]
+    public TimeSpan? Lookback { get; set; }
+
+    /// <summary>
+    /// Per-component alias-folding override. When set, wins over the static
+    /// <see cref="ApplicationInsightsOptions.ApplicationAlias"/> map. Hosts with a dynamic alias
+    /// source (e.g. per-team Mongo lookups) supply this; external/static consumers leave it
+    /// null and rely on the options-bound map.
+    /// </summary>
+    [Parameter]
+    public Func<VersionMatrixView, CancellationToken, Task<VersionMatrixView>> AliasFolder { get; set; }
+
+    /// <summary>
+    /// Per-component environment ordering override. When set, wins over
+    /// <see cref="ApplicationInsightsOptions.EnvironmentOrder"/>. Hosts with a dynamic
+    /// environment source (e.g. per-team) supply this.
+    /// </summary>
+    [Parameter]
+    public IReadOnlyList<string> EnvironmentOrder { get; set; }
+
+    private VersionMatrixView _view;
+    private IReadOnlyList<string> _orderedEnvironments = [];
+    private bool _loading;
+    private string _error;
+
+    protected override async Task OnInitializedAsync()
+    {
+        await LoadAsync(forceRefresh: false);
+    }
+
+    private async Task OnRefreshAsync()
+    {
+        await LoadAsync(forceRefresh: true);
+    }
+
+    private async Task LoadAsync(bool forceRefresh)
+    {
+        _loading = true;
+        _error = null;
+        StateHasChanged();
+
+        try
+        {
+            var raw = forceRefresh
+                ? await VersionMatrixService.RefreshAsync(Context, Lookback)
+                : await VersionMatrixService.GetAsync(Context, Lookback);
+
+            VersionMatrixView folded;
+            if (AliasFolder != null)
+            {
+                folded = await AliasFolder(raw, CancellationToken.None);
+            }
+            else if (Options.Value.ApplicationAlias is { Length: > 0 } staticMap)
+            {
+                folded = StaticAliasFolder.Fold(raw, staticMap);
+            }
+            else
+            {
+                folded = raw;
+            }
+
+            var order = EnvironmentOrder ?? Options.Value.EnvironmentOrder;
+            _orderedEnvironments = EnvironmentOrdering.Order(folded.Environments, order);
+            _view = folded;
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Failed to load version matrix.");
+            _error = ex.Message;
+        }
+        finally
+        {
+            _loading = false;
+            StateHasChanged();
+        }
+    }
+}

--- a/Quilt4Net.Toolkit.Tests/EnvironmentOrderingTests.cs
+++ b/Quilt4Net.Toolkit.Tests/EnvironmentOrderingTests.cs
@@ -1,0 +1,62 @@
+using FluentAssertions;
+using Quilt4Net.Toolkit.Features.ApplicationInsights;
+using Xunit;
+
+namespace Quilt4Net.Toolkit.Tests;
+
+public class EnvironmentOrderingTests
+{
+    [Fact]
+    public void Order_uses_default_order_when_no_preferred_supplied()
+    {
+        var ordered = EnvironmentOrdering.Order(["Production", "Test", "Staging", "Development"]);
+
+        ordered.Should().Equal("Development", "Staging", "Test", "Production");
+    }
+
+    [Fact]
+    public void Order_places_unknown_named_envs_after_known_alphabetical()
+    {
+        var ordered = EnvironmentOrdering.Order(["Sandbox", "Production", "Acceptance"]);
+
+        ordered.Should().Equal("Production", "Acceptance", "Sandbox");
+    }
+
+    [Fact]
+    public void Order_places_unknown_environment_marker_last()
+    {
+        var ordered = EnvironmentOrdering.Order(["Production", "", "Development"]);
+
+        ordered.Should().Equal("Development", "Production", "(unknown)");
+    }
+
+    [Fact]
+    public void Order_honors_supplied_preferred_order()
+    {
+        var ordered = EnvironmentOrdering.Order(
+            ["Production", "Test", "CI", "Development"],
+            ["Development", "CI", "Test", "Production"]);
+
+        ordered.Should().Equal("Development", "CI", "Test", "Production");
+    }
+
+    [Fact]
+    public void Order_with_supplied_preferred_still_ranks_unlisted_after_listed_alphabetical()
+    {
+        var ordered = EnvironmentOrdering.Order(
+            ["Production", "Sandbox", "QA", "Development"],
+            ["Development", "Production"]);
+
+        ordered.Should().Equal("Development", "Production", "QA", "Sandbox");
+    }
+
+    [Fact]
+    public void Order_is_case_insensitive_for_distinct_and_ranking()
+    {
+        var ordered = EnvironmentOrdering.Order(
+            ["PRODUCTION", "production", "Development"],
+            ["development", "PRODUCTION"]);
+
+        ordered.Should().Equal("Development", "PRODUCTION");
+    }
+}

--- a/Quilt4Net.Toolkit.Tests/StaticAliasFolderTests.cs
+++ b/Quilt4Net.Toolkit.Tests/StaticAliasFolderTests.cs
@@ -1,0 +1,107 @@
+using FluentAssertions;
+using Quilt4Net.Toolkit.Features.ApplicationInsights;
+using Xunit;
+
+namespace Quilt4Net.Toolkit.Tests;
+
+public class StaticAliasFolderTests
+{
+    [Fact]
+    public void Fold_with_no_aliases_returns_input_unchanged()
+    {
+        var raw = MakeView(("Quilt4Net.Server", "Production", "1.0.0"));
+
+        var folded = StaticAliasFolder.Fold(raw, []);
+
+        folded.Should().BeSameAs(raw);
+    }
+
+    [Fact]
+    public void Fold_with_null_aliases_returns_input_unchanged()
+    {
+        var raw = MakeView(("Quilt4Net.Server", "Production", "1.0.0"));
+
+        var folded = StaticAliasFolder.Fold(raw, null);
+
+        folded.Should().BeSameAs(raw);
+    }
+
+    [Fact]
+    public void Fold_collapses_multiple_source_names_into_one_logical_row()
+    {
+        var raw = MakeView(
+            ("Quilt4Net.Server", "Production", "1.0.0"),
+            ("Quilt4Net.Server.Client", "Production", "1.0.0"));
+
+        var folded = StaticAliasFolder.Fold(raw,
+        [
+            new ApplicationAliasMap
+            {
+                LogicalName = "quilt4net-web",
+                SourceNames = ["Quilt4Net.Server", "Quilt4Net.Server.Client"]
+            }
+        ]);
+
+        folded.Applications.Should().Equal("quilt4net-web");
+        folded.TryGetCell("quilt4net-web", "Production", out var cell).Should().BeTrue();
+        cell.Version.Should().Be("1.0.0");
+        folded.TryGetAlias("quilt4net-web", "Production", out var alias).Should().BeTrue();
+        alias.SourceNames.Should().BeEquivalentTo("Quilt4Net.Server", "Quilt4Net.Server.Client");
+        alias.HasConflict.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Fold_surfaces_conflict_when_sources_disagree_on_version()
+    {
+        var raw = MakeView(
+            ("Quilt4Net.Server", "Production", "1.0.0", DateTime.UtcNow.AddHours(-2)),
+            ("Quilt4Net.Server.Client", "Production", "1.1.0", DateTime.UtcNow.AddHours(-1)));
+
+        var folded = StaticAliasFolder.Fold(raw,
+        [
+            new ApplicationAliasMap
+            {
+                LogicalName = "quilt4net-web",
+                SourceNames = ["Quilt4Net.Server", "Quilt4Net.Server.Client"]
+            }
+        ]);
+
+        folded.TryGetCell("quilt4net-web", "Production", out var cell).Should().BeTrue();
+        cell.Version.Should().Be("1.1.0"); // most recent wins
+        folded.TryGetAlias("quilt4net-web", "Production", out var alias).Should().BeTrue();
+        alias.HasConflict.Should().BeTrue();
+        alias.ConflictingVersions.Should().HaveCount(2);
+    }
+
+    [Fact]
+    public void Fold_passes_unmapped_names_through_unchanged_and_does_not_emit_alias_info()
+    {
+        var raw = MakeView(("Some.Other.App", "Production", "2.0.0"));
+
+        var folded = StaticAliasFolder.Fold(raw,
+        [
+            new ApplicationAliasMap { LogicalName = "quilt4net-web", SourceNames = ["Quilt4Net.Server"] }
+        ]);
+
+        folded.Applications.Should().Equal("Some.Other.App");
+        folded.TryGetAlias("Some.Other.App", "Production", out _).Should().BeFalse();
+    }
+
+    private static VersionMatrixView MakeView(params (string app, string env, string version)[] cells)
+        => MakeView(cells.Select(c => (c.app, c.env, c.version, DateTime.UtcNow)).ToArray());
+
+    private static VersionMatrixView MakeView(params (string app, string env, string version, DateTime lastSeen)[] cells)
+    {
+        var matrixCells = cells
+            .Select(c => new VersionMatrixCell
+            {
+                ApplicationName = c.app,
+                Environment = c.env,
+                Version = c.version,
+                LastSeen = c.lastSeen,
+                Source = VersionMatrixSource.Log
+            })
+            .ToArray();
+        return VersionMatrixView.FromCells(matrixCells);
+    }
+}

--- a/Quilt4Net.Toolkit.Tests/VersionMatrixViewTests.cs
+++ b/Quilt4Net.Toolkit.Tests/VersionMatrixViewTests.cs
@@ -1,0 +1,80 @@
+using FluentAssertions;
+using Quilt4Net.Toolkit.Features.ApplicationInsights;
+using Xunit;
+
+namespace Quilt4Net.Toolkit.Tests;
+
+public class VersionMatrixViewTests
+{
+    [Fact]
+    public void FromCells_returns_empty_collections_for_empty_input()
+    {
+        var view = VersionMatrixView.FromCells([]);
+
+        view.Applications.Should().BeEmpty();
+        view.Environments.Should().BeEmpty();
+        view.Cells.Should().BeEmpty();
+        view.LastRefreshedUtc.Kind.Should().Be(DateTimeKind.Utc);
+    }
+
+    [Fact]
+    public void FromCells_orders_applications_alphabetically_case_insensitive()
+    {
+        var view = VersionMatrixView.FromCells(
+        [
+            Cell("Zoo.App", "Production"),
+            Cell("alpha.app", "Production"),
+            Cell("Beta.App", "Production"),
+        ]);
+
+        view.Applications.Should().Equal("alpha.app", "Beta.App", "Zoo.App");
+    }
+
+    [Fact]
+    public void FromCells_returns_environments_alphabetical_for_render_time_ordering()
+    {
+        var view = VersionMatrixView.FromCells(
+        [
+            Cell("app", "Production"),
+            Cell("app", "Test"),
+            Cell("app", "Staging"),
+            Cell("app", "Development"),
+            Cell("app", "Sandbox"),
+        ]);
+
+        view.Environments.Should().Equal("Development", "Production", "Sandbox", "Staging", "Test");
+    }
+
+    [Fact]
+    public void FromCells_treats_empty_environment_as_unknown_in_cell_key()
+    {
+        var view = VersionMatrixView.FromCells([Cell("app", "", "1.0.0")]);
+
+        view.TryGetCell("app", "(unknown)", out var c).Should().BeTrue();
+        c.Version.Should().Be("1.0.0");
+    }
+
+    [Fact]
+    public void FromCells_picks_most_recent_when_duplicates_for_same_cell()
+    {
+        var view = VersionMatrixView.FromCells(
+        [
+            Cell("app", "Production", "1.0.0", DateTime.UtcNow.AddHours(-5)),
+            Cell("app", "Production", "1.2.0", DateTime.UtcNow.AddHours(-1)),
+            Cell("app", "Production", "1.1.0", DateTime.UtcNow.AddHours(-3)),
+        ]);
+
+        view.TryGetCell("app", "Production", out var picked).Should().BeTrue();
+        picked.Version.Should().Be("1.2.0");
+    }
+
+    private static VersionMatrixCell Cell(string app, string env, string version = "1.0.0", DateTime? lastSeen = null) =>
+        new()
+        {
+            ApplicationName = app,
+            Environment = env,
+            Version = version,
+            LastSeen = lastSeen ?? DateTime.UtcNow,
+            Source = VersionMatrixSource.Log
+        };
+}

--- a/Quilt4Net.Toolkit/ApplicationInsightsOptions.cs
+++ b/Quilt4Net.Toolkit/ApplicationInsightsOptions.cs
@@ -41,4 +41,21 @@ public record ApplicationInsightsOptions
     /// Use <see cref="ApplicationInsightsAuthMode.DefaultAzureCredential"/> for a chained credential that works locally (via <c>az login</c>) and in Azure (via Managed Identity) with the same configuration.
     /// </summary>
     public ApplicationInsightsAuthMode AuthMode { get; set; } = ApplicationInsightsAuthMode.ClientSecret;
+
+    /// <summary>
+    /// Preferred environment ordering for the version matrix. Environments listed here render
+    /// in the given order; environments seen in telemetry but not listed render after, sorted
+    /// alphabetically; environments with empty names render last as <c>(unknown)</c>.
+    /// Falls back to <c>["Development", "CI", "Staging", "Test", "Production"]</c> when null/empty.
+    /// </summary>
+    public string[] EnvironmentOrder { get; set; }
+
+    /// <summary>
+    /// Static application alias map used by <see cref="Quilt4Net.Toolkit.Features.ApplicationInsights.IVersionMatrixService"/>
+    /// consumers that don't pass a per-component AliasFolder. Each entry groups one or more raw
+    /// <c>cloud_RoleName</c> values under a single logical application name. Hosts with a dynamic
+    /// alias source (e.g. per-team Mongo lookups) bypass this by passing an AliasFolder delegate
+    /// directly to the component.
+    /// </summary>
+    public ApplicationAliasMap[] ApplicationAlias { get; set; } = [];
 }

--- a/Quilt4Net.Toolkit/ApplicationInsightsRegistration.cs
+++ b/Quilt4Net.Toolkit/ApplicationInsightsRegistration.cs
@@ -35,6 +35,7 @@ public static class ApplicationInsightsRegistration
         services.AddSingleton(Options.Create(o));
 
         services.AddTransient<IApplicationInsightsService, ApplicationInsightsService>();
+        services.AddSingleton<IVersionMatrixService, VersionMatrixService>();
         services.AddTransient<IHealthClient, HealthClient>();
 
         services.AddCache(s =>

--- a/Quilt4Net.Toolkit/Features/ApplicationInsights/ApplicationAliasMap.cs
+++ b/Quilt4Net.Toolkit/Features/ApplicationInsights/ApplicationAliasMap.cs
@@ -1,0 +1,12 @@
+namespace Quilt4Net.Toolkit.Features.ApplicationInsights;
+
+/// <summary>
+/// Static map entry for grouping multiple raw application names (cloud_RoleName)
+/// under one logical name. Configured via <see cref="ApplicationInsightsOptions.ApplicationAlias"/>;
+/// applied by <see cref="VersionMatrixDisplay"/> when no per-component AliasFolder is supplied.
+/// </summary>
+public sealed record ApplicationAliasMap
+{
+    public required string LogicalName { get; init; }
+    public required string[] SourceNames { get; init; }
+}

--- a/Quilt4Net.Toolkit/Features/ApplicationInsights/EnvironmentOrdering.cs
+++ b/Quilt4Net.Toolkit/Features/ApplicationInsights/EnvironmentOrdering.cs
@@ -1,0 +1,36 @@
+namespace Quilt4Net.Toolkit.Features.ApplicationInsights;
+
+/// <summary>
+/// Helpers for ordering environment names consistently across the version matrix UI.
+/// </summary>
+public static class EnvironmentOrdering
+{
+    /// <summary>The default order applied when no <c>EnvironmentOrder</c> is configured.</summary>
+    public static readonly IReadOnlyList<string> DefaultOrder = ["Development", "CI", "Staging", "Test", "Production"];
+
+    internal const string Unknown = "(unknown)";
+
+    /// <summary>
+    /// Order <paramref name="environments"/> by the supplied <paramref name="preferredOrder"/>:
+    /// listed names first (in the supplied order), then unlisted names alphabetically, then
+    /// <c>(unknown)</c> last. When <paramref name="preferredOrder"/> is null/empty,
+    /// <see cref="DefaultOrder"/> is used.
+    /// </summary>
+    public static IReadOnlyList<string> Order(IEnumerable<string> environments, IReadOnlyList<string> preferredOrder = null)
+    {
+        var order = preferredOrder is { Count: > 0 } ? preferredOrder : DefaultOrder;
+
+        var ranks = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+        for (var i = 0; i < order.Count; i++)
+        {
+            ranks.TryAdd(order[i], i);
+        }
+
+        return environments
+            .Select(e => string.IsNullOrWhiteSpace(e) ? Unknown : e)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .OrderBy(e => string.Equals(e, Unknown, StringComparison.OrdinalIgnoreCase) ? int.MaxValue : ranks.GetValueOrDefault(e, ranks.Count + 1))
+            .ThenBy(e => e, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+    }
+}

--- a/Quilt4Net.Toolkit/Features/ApplicationInsights/IVersionMatrixService.cs
+++ b/Quilt4Net.Toolkit/Features/ApplicationInsights/IVersionMatrixService.cs
@@ -1,0 +1,14 @@
+namespace Quilt4Net.Toolkit.Features.ApplicationInsights;
+
+public interface IVersionMatrixService
+{
+    /// <summary>
+    /// Get the version matrix for a workspace. Uses an in-memory cache keyed by (workspaceId, lookback).
+    /// </summary>
+    Task<VersionMatrixView> GetAsync(IApplicationInsightsContext context, TimeSpan? lookback = null, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Force a fresh fetch from Application Insights, bypassing the in-memory cache.
+    /// </summary>
+    Task<VersionMatrixView> RefreshAsync(IApplicationInsightsContext context, TimeSpan? lookback = null, CancellationToken cancellationToken = default);
+}

--- a/Quilt4Net.Toolkit/Features/ApplicationInsights/StaticAliasFolder.cs
+++ b/Quilt4Net.Toolkit/Features/ApplicationInsights/StaticAliasFolder.cs
@@ -1,0 +1,78 @@
+namespace Quilt4Net.Toolkit.Features.ApplicationInsights;
+
+/// <summary>
+/// Folds a raw <see cref="VersionMatrixView"/> using a static <see cref="ApplicationAliasMap"/>
+/// list (typically from <see cref="ApplicationInsightsOptions.ApplicationAlias"/>). Same
+/// (logical, env) merge semantics as a dynamic per-team folder: cells whose ApplicationName
+/// matches a known source name are merged under the logical name; for groups with disagreeing
+/// versions the latest by LastSeen wins and the disagreement surfaces via
+/// <see cref="CellAlias.ConflictingVersions"/>.
+/// </summary>
+public static class StaticAliasFolder
+{
+    public static VersionMatrixView Fold(VersionMatrixView raw, IReadOnlyList<ApplicationAliasMap> aliases)
+    {
+        if (aliases is null || aliases.Count == 0) return raw;
+
+        var sourceToLogical = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var alias in aliases)
+        {
+            foreach (var src in alias.SourceNames ?? [])
+            {
+                if (string.IsNullOrWhiteSpace(src)) continue;
+                sourceToLogical[src] = alias.LogicalName;
+            }
+        }
+
+        if (sourceToLogical.Count == 0) return raw;
+
+        var grouped = raw.Cells.Values
+            .Select(c => new { Logical = sourceToLogical.GetValueOrDefault(c.ApplicationName, c.ApplicationName), Cell = c })
+            .GroupBy(x => (App: x.Logical, Env: x.Cell.Environment), x => x.Cell);
+
+        var newCells = new Dictionary<(string App, string Env), VersionMatrixCell>();
+        var newAliases = new Dictionary<(string App, string Env), CellAlias>();
+
+        foreach (var g in grouped)
+        {
+            var key = g.Key;
+            var members = g.ToList();
+            var winner = members.OrderByDescending(c => c.LastSeen).First();
+            newCells[key] = winner with { ApplicationName = key.App };
+
+            var sourceNames = members
+                .Select(c => c.ApplicationName)
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .OrderBy(x => x, StringComparer.OrdinalIgnoreCase)
+                .ToArray();
+
+            var aliasApplied = sourceNames.Length > 1
+                || !string.Equals(sourceNames[0], key.App, StringComparison.OrdinalIgnoreCase);
+            if (!aliasApplied) continue;
+
+            var distinctVersions = members.Select(c => c.Version).Distinct(StringComparer.OrdinalIgnoreCase).Count();
+            var conflicts = distinctVersions > 1
+                ? members
+                    .OrderByDescending(c => c.LastSeen)
+                    .Select(c => new CellAliasSource(c.ApplicationName, c.Version, c.LastSeen))
+                    .ToArray()
+                : [];
+
+            newAliases[key] = new CellAlias
+            {
+                SourceNames = sourceNames,
+                ConflictingVersions = conflicts
+            };
+        }
+
+        var newApps = newCells.Keys.Select(k => k.App).Distinct(StringComparer.OrdinalIgnoreCase)
+            .OrderBy(x => x, StringComparer.OrdinalIgnoreCase).ToList();
+
+        return raw with
+        {
+            Applications = newApps,
+            Cells = newCells,
+            CellAliases = newAliases
+        };
+    }
+}

--- a/Quilt4Net.Toolkit/Features/ApplicationInsights/VersionMatrixService.cs
+++ b/Quilt4Net.Toolkit/Features/ApplicationInsights/VersionMatrixService.cs
@@ -1,0 +1,42 @@
+using System.Collections.Concurrent;
+
+namespace Quilt4Net.Toolkit.Features.ApplicationInsights;
+
+internal sealed class VersionMatrixService : IVersionMatrixService
+{
+    private readonly IApplicationInsightsService _ai;
+    private readonly ConcurrentDictionary<CacheKey, VersionMatrixView> _cache = new();
+
+    public VersionMatrixService(IApplicationInsightsService ai)
+    {
+        _ai = ai;
+    }
+
+    public Task<VersionMatrixView> GetAsync(IApplicationInsightsContext context, TimeSpan? lookback = null, CancellationToken cancellationToken = default)
+    {
+        var key = new CacheKey(context?.WorkspaceId ?? string.Empty, lookback);
+        if (_cache.TryGetValue(key, out var cached))
+        {
+            return Task.FromResult(cached);
+        }
+
+        return RefreshAsync(context, lookback, cancellationToken);
+    }
+
+    public async Task<VersionMatrixView> RefreshAsync(IApplicationInsightsContext context, TimeSpan? lookback = null, CancellationToken cancellationToken = default)
+    {
+        var cells = new List<VersionMatrixCell>();
+        await foreach (var cell in _ai.GetVersionMatrixAsync(context, lookback).WithCancellation(cancellationToken))
+        {
+            cells.Add(cell);
+        }
+
+        var view = VersionMatrixView.FromCells(cells);
+
+        var key = new CacheKey(context?.WorkspaceId ?? string.Empty, lookback);
+        _cache[key] = view;
+        return view;
+    }
+
+    private readonly record struct CacheKey(string WorkspaceId, TimeSpan? Lookback);
+}

--- a/Quilt4Net.Toolkit/Features/ApplicationInsights/VersionMatrixView.cs
+++ b/Quilt4Net.Toolkit/Features/ApplicationInsights/VersionMatrixView.cs
@@ -1,0 +1,86 @@
+namespace Quilt4Net.Toolkit.Features.ApplicationInsights;
+
+/// <summary>
+/// Materialized application/environment version matrix ready for UI rendering.
+/// </summary>
+public sealed record VersionMatrixView
+{
+    internal const string UnknownEnvironment = "(unknown)";
+
+    /// <summary>Application names sorted alphabetically.</summary>
+    public required IReadOnlyList<string> Applications { get; init; }
+
+    /// <summary>Environment names sorted by standard order (Development → Staging → Test → Production → other → unknown).</summary>
+    public required IReadOnlyList<string> Environments { get; init; }
+
+    /// <summary>Cells keyed by (ApplicationName, Environment). Missing keys = empty cell.</summary>
+    public required IReadOnlyDictionary<(string App, string Env), VersionMatrixCell> Cells { get; init; }
+
+    /// <summary>UTC timestamp the data was fetched from Application Insights.</summary>
+    public required DateTime LastRefreshedUtc { get; init; }
+
+    /// <summary>
+    /// Per-cell alias info, populated only when an alias map has been applied
+    /// (typically by a host that provides an <c>AliasFolder</c> delegate to
+    /// <c>VersionMatrixDisplay</c>). Empty by default — consumers that don't
+    /// have an alias concept can ignore this entirely.
+    /// </summary>
+    public IReadOnlyDictionary<(string App, string Env), CellAlias> CellAliases { get; init; }
+        = new Dictionary<(string, string), CellAlias>();
+
+    public bool TryGetCell(string app, string env, out VersionMatrixCell cell) => Cells.TryGetValue((app, env), out cell);
+    public bool TryGetAlias(string app, string env, out CellAlias info) => CellAliases.TryGetValue((app, env), out info);
+
+    /// <summary>
+    /// Build a view from a flat list of cells. Environments are returned alphabetical;
+    /// final domain ordering (Development → Staging → Test → Production, then unknown) is
+    /// applied at render time by <c>VersionMatrixDisplay</c>, so the same fetched view can
+    /// be reused under different ordering preferences.
+    /// </summary>
+    public static VersionMatrixView FromCells(IReadOnlyList<VersionMatrixCell> cells)
+    {
+        var apps = cells
+            .Select(c => c.ApplicationName)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .OrderBy(x => x, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+        var envs = cells
+            .Select(c => string.IsNullOrWhiteSpace(c.Environment) ? UnknownEnvironment : c.Environment)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .OrderBy(x => x, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+        var cellMap = cells
+            .GroupBy(c => (App: c.ApplicationName, Env: string.IsNullOrWhiteSpace(c.Environment) ? UnknownEnvironment : c.Environment))
+            .ToDictionary(g => g.Key, g => g.OrderByDescending(c => c.LastSeen).First());
+
+        return new VersionMatrixView
+        {
+            Applications = apps,
+            Environments = envs,
+            Cells = cellMap,
+            LastRefreshedUtc = DateTime.UtcNow
+        };
+    }
+}
+
+/// <summary>
+/// Detail about how a folded cell was constructed from underlying raw cells.
+/// </summary>
+public sealed record CellAlias
+{
+    /// <summary>The raw application names that contributed to this cell, sorted alphabetically.</summary>
+    public required IReadOnlyList<string> SourceNames { get; init; }
+
+    /// <summary>
+    /// When 2+ source apps in this (LogicalApp, Environment) reported different versions,
+    /// each reporting source is listed here with its version + last-seen timestamp.
+    /// Empty when all sources agreed (or only one source contributed).
+    /// </summary>
+    public IReadOnlyList<CellAliasSource> ConflictingVersions { get; init; } = [];
+
+    public bool HasConflict => ConflictingVersions.Count > 1;
+}
+
+public sealed record CellAliasSource(string SourceName, string Version, DateTime LastSeen);


### PR DESCRIPTION
## Summary
- New drop-in `<VersionMatrixDisplay>` Blazor component for any app with an Application Insights workspace — handles fetch, in-memory cache, and rendering.
- Alias-folding and environment ordering are pluggable: per-component `AliasFolder` / `EnvironmentOrder` parameters take precedence over options, options take precedence over defaults. Hosts with a dynamic alias source (e.g. per-team Mongo) supply the parameter; static consumers configure `ApplicationInsightsOptions.ApplicationAlias` / `EnvironmentOrder` once at startup.
- New supporting types in `Quilt4Net.Toolkit`: `VersionMatrixView` (+ `FromCells` factory, `CellAlias`, `CellAliasSource`), `IVersionMatrixService` + impl (singleton, registered by `AddQuilt4NetApplicationInsightsClient`), `EnvironmentOrdering` helper, `ApplicationAliasMap` + `StaticAliasFolder`.

## Test plan
- [x] `Quilt4Net.Toolkit.Tests` — 16 new tests covering `VersionMatrixView.FromCells`, `EnvironmentOrdering.Order` (defaults, supplied order, unknown last, case-insensitive), and `StaticAliasFolder.Fold` (no-op, collapse, conflict, unmapped pass-through). All Toolkit suites green: 76 + 50 + 48 + 15 + 1 = 190 tests.
- [ ] Quilt4Net.Server consumes the new prerelease NuGet on its `feature/application-alias` branch (separate Server PR — both `/monitor/version` (per-team `AliasFolder` + `EnvironmentOrder`) and `/developer/version` (options-only, external-consumer behavior) verified end-to-end against the live Application Insights workspace).