### PR TITLE
feat: log-views — telemetry identity, correlation, filter bar, stack trace

### DIFF
--- a/Quilt4Net.Toolkit.Api/Framework/CorrelationIdMiddleware.cs
+++ b/Quilt4Net.Toolkit.Api/Framework/CorrelationIdMiddleware.cs
@@ -1,29 +1,39 @@
-﻿namespace Quilt4Net.Toolkit.Api.Framework;
+using Microsoft.Extensions.Logging;
+
+namespace Quilt4Net.Toolkit.Api.Framework;
 
 public class CorrelationIdMiddleware
 {
-    private readonly RequestDelegate _next;
+    private const string HeaderName = "X-Correlation-ID";
 
-    public CorrelationIdMiddleware(RequestDelegate next)
+    private readonly RequestDelegate _next;
+    private readonly ILogger<CorrelationIdMiddleware> _logger;
+
+    public CorrelationIdMiddleware(RequestDelegate next, ILogger<CorrelationIdMiddleware> logger)
     {
         _next = next;
+        _logger = logger;
     }
 
     public async Task InvokeAsync(HttpContext context)
     {
-        // Check for an existing correlation ID
-        if (!context.Request.Headers.TryGetValue("X-Correlation-ID", out var correlationId))
+        if (!context.Request.Headers.TryGetValue(HeaderName, out var headerValue) || string.IsNullOrWhiteSpace(headerValue))
         {
-            // Generate a new correlation ID if not provided
-            correlationId = Guid.NewGuid().ToString();
+            headerValue = Guid.NewGuid().ToString();
         }
 
-        // Add the correlation ID to the response headers
-        context.Response.Headers["X-Correlation-ID"] = correlationId;
-
-        // Store it for logging or other purposes
+        var correlationId = headerValue.ToString();
+        context.Response.Headers[HeaderName] = correlationId;
         context.Items["CorrelationId"] = correlationId;
 
-        await _next(context);
+        // Push CorrelationId into a logging scope so every ILogger call made during this
+        // request inherits it as a structured property. The Azure Monitor exporter then
+        // writes customDimensions["CorrelationId"] on every AppTrace / AppException for
+        // the duration of the request — letting the same correlation id span the inbound
+        // request, any work it triggers, and the outgoing response.
+        using (_logger.BeginScope(new Dictionary<string, object> { ["CorrelationId"] = correlationId }))
+        {
+            await _next(context);
+        }
     }
 }

--- a/Quilt4Net.Toolkit.Api/Framework/RequestBodyLoggingMiddleware.cs
+++ b/Quilt4Net.Toolkit.Api/Framework/RequestBodyLoggingMiddleware.cs
@@ -80,13 +80,9 @@ public class RequestResponseLoggingMiddleware
             {
                 telemetry.Properties["UserId"] = context.User.Identity?.Name ?? "Anonymous";
                 if (!string.IsNullOrEmpty(correlationId)) telemetry.Properties["CorrelationId"] = correlationId;
-                var asm = Assembly.GetEntryAssembly();
-                var nm = asm?.GetName();
-                if (nm != null)
-                {
-                    telemetry.Properties["ApplicationName"] = nm.Name;
-                    telemetry.Properties["Version"] = $"{nm.Version}";
-                }
+                // ApplicationName + Version intentionally not duplicated here — AddQuilt4NetLogging
+                // attaches service.name / service.version to every record/span via OTel processors,
+                // which the Azure Monitor exporter forwards into customDimensions for AppRequests too.
             }
 
             sw.Start();
@@ -317,9 +313,11 @@ public class RequestResponseLoggingMiddleware
 
     private Dictionary<string, string> BuildDetails() //Exception e)
     {
+        // "Monitor" intentionally omitted — AddQuilt4NetLogging attaches it to every record
+        // as customDimensions["quilt4net.monitor"], so it no longer needs to live inside
+        // this per-request Details JSON blob.
         var dictionary = new Dictionary<string, string>
         {
-            { "Monitor", _options?.MonitorName ?? Constants.Monitor },
             { "Method", "Http" }
         };
 

--- a/Quilt4Net.Toolkit.Api/LoggingOptions.cs
+++ b/Quilt4Net.Toolkit.Api/LoggingOptions.cs
@@ -24,10 +24,14 @@ public record LoggingOptions
     public bool UseCorrelationId { get; set; } = true;
 
     /// <summary>
-    /// Monitor name used to track log-items to selected monitor.
-    /// If set to empty string the value will be omitted.
-    /// Default is Quilt4Net.
+    /// Monitor name used to identify log items from this Quilt4Net instrumentation.
     /// </summary>
+    /// <remarks>
+    /// Moved to <c>Quilt4NetLoggingOptions.MonitorName</c> so the value is attached to every
+    /// trace, exception and request via the OTel processors registered by
+    /// <c>AddQuilt4NetLogging</c>. Setting it here has no effect.
+    /// </remarks>
+    [Obsolete("Set MonitorName on Quilt4NetLoggingOptions (AddQuilt4NetLogging(o => o.MonitorName = ...)) instead. The value is now attached as customDimensions[\"quilt4net.monitor\"] on every record, not just AppRequests.")]
     public string MonitorName { get; set; } = Constants.Monitor;
 
     /// <summary>

--- a/Quilt4Net.Toolkit.Api/README.md
+++ b/Quilt4Net.Toolkit.Api/README.md
@@ -22,13 +22,27 @@ app.UseQuilt4NetLogging();
 app.Run();
 ```
 
-`AddQuilt4NetLogging()` registers an `ITelemetryInitializer` that tags all Application Insights telemetry (traces, exceptions, requests) with `Cloud.RoleName`, `Component.Version`, and `Environment`. `AddHttpRequestLogging()` opts in to HTTP request/response middleware. By default, all requests to paths starting with `/Api` are logged.
+`AddQuilt4NetLogging()` configures OpenTelemetry resource attributes and registers per-record processors that tag every `AppTrace` / `AppException` / `AppRequest` with `service.name`, `service.version`, `host.name`, `deployment.environment`, and `quilt4net.monitor` (see the core `Quilt4Net.Toolkit` README for details). `AddHttpRequestLogging()` opts in to HTTP request/response middleware on top of that. By default, all requests to paths starting with `/Api` are logged.
 
 > The old `AddQuilt4NetApiLogging()` and `UseQuilt4NetApiLogging()` methods still work but are deprecated.
 
 ## Correlation ID
 
-When `UseCorrelationId` is enabled (default), the middleware reads the `X-Correlation-ID` header from incoming requests. If no header is present, a new GUID is generated. The correlation ID is stored in `HttpContext.Items` and returned in the response header, enabling distributed tracing across services.
+`CorrelationIdMiddleware` reads the `X-Correlation-ID` header from incoming requests; if no header is present, a new GUID is generated. The id is:
+
+1. Stored in `HttpContext.Items["CorrelationId"]` for inspection by downstream code.
+2. Returned in the response's `X-Correlation-ID` header — clients can chain the same id to subsequent requests for distributed tracing.
+3. **Pushed into a logging scope** (`Logger.BeginScope({ ["CorrelationId"] = id })`) for the duration of the request, so every `ILogger` call made while handling the request inherits the id as a structured property. The Azure Monitor exporter writes it to `customDimensions["CorrelationId"]` on every resulting `AppTrace` / `AppException` / `AppRequest` row.
+
+KQL pattern for "show me everything from one call chain":
+
+```kql
+union AppTraces, AppExceptions, AppRequests
+| where Properties contains "<your-correlation-id>"
+| order by TimeGenerated asc
+```
+
+Or, in the toolkit's `LogView` Search tab, paste the id into the search box (it filters on both `Message` and `CorrelationId`). The Search tab's CorrelationId column also has a click-to-self-search shortcut — click any row's correlation chip and the grid re-runs scoped to that id.
 
 ## Logging mode
 

--- a/Quilt4Net.Toolkit.Blazor.Server.Sample/Program.cs
+++ b/Quilt4Net.Toolkit.Blazor.Server.Sample/Program.cs
@@ -1,4 +1,5 @@
 using Quilt4Net.Toolkit;
+using Quilt4Net.Toolkit.Api;
 using Quilt4Net.Toolkit.Blazor;
 using Quilt4Net.Toolkit.Blazor.Server.Sample.Components;
 using Radzen;
@@ -18,6 +19,12 @@ builder.AddQuilt4NetBlazorContent(o =>
 builder.AddQuilt4NetApplicationInsightsClient();
 builder.AddQuilt4NetRemoteConfiguration();
 
+// Register the per-record telemetry-identity processors (env / app / version / host /
+// quilt4net.monitor) and the request middleware that mints / honors X-Correlation-ID.
+// AddHttpRequestLogging is the opt-in that enables the middleware via UseQuilt4NetLogging.
+builder.AddQuilt4NetLogging()
+    .AddHttpRequestLogging();
+
 var app = builder.Build();
 
 if (!app.Environment.IsDevelopment())
@@ -27,7 +34,32 @@ if (!app.Environment.IsDevelopment())
 }
 
 app.UseHttpsRedirection();
+app.UseQuilt4NetLogging();
 app.UseAntiforgery();
+
+// Demo endpoint showing CorrelationId propagation across multiple log lines from a single
+// request. Hit GET /api/correlation-demo (optionally with header X-Correlation-ID: my-id)
+// — every ILogger call inside this request handler emits an AppTrace whose
+// customDimensions["CorrelationId"] holds the same value, because CorrelationIdMiddleware
+// wraps the pipeline in Logger.BeginScope for the duration of the request.
+app.MapGet("/api/correlation-demo", (HttpContext ctx, ILogger<Program> logger) =>
+{
+    logger.LogInformation("Correlation demo: step 1 — request received");
+    DoSomeWork(logger);
+    logger.LogInformation("Correlation demo: step 3 — finishing");
+    return Results.Ok(new
+    {
+        CorrelationId = ctx.Items["CorrelationId"]?.ToString(),
+        Hint = "Send X-Correlation-ID on the request to chain across services. " +
+               "Every log line in this handler shares the value; query AI with " +
+               "customDimensions['CorrelationId'] == '<id>' to see the chain."
+    });
+
+    static void DoSomeWork(ILogger logger)
+    {
+        logger.LogInformation("Correlation demo: step 2 — doing work");
+    }
+});
 
 app.MapStaticAssets();
 app.MapRazorComponents<App>()

--- a/Quilt4Net.Toolkit.Blazor.Server.Sample/Quilt4Net.Toolkit.Blazor.Server.Sample.csproj
+++ b/Quilt4Net.Toolkit.Blazor.Server.Sample/Quilt4Net.Toolkit.Blazor.Server.Sample.csproj
@@ -8,6 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\Quilt4Net.Toolkit.Api\Quilt4Net.Toolkit.Api.csproj" />
     <ProjectReference Include="..\Quilt4Net.Toolkit.Blazor\Quilt4Net.Toolkit.Blazor.csproj" />
   </ItemGroup>
 

--- a/Quilt4Net.Toolkit.Blazor.Tests/LogFiltersTests.cs
+++ b/Quilt4Net.Toolkit.Blazor.Tests/LogFiltersTests.cs
@@ -1,0 +1,84 @@
+using FluentAssertions;
+using Quilt4Net.Toolkit.Blazor.Features.Log;
+using Quilt4Net.Toolkit.Features.ApplicationInsights;
+using Xunit;
+
+namespace Quilt4Net.Toolkit.Blazor.Tests;
+
+public class LogFiltersTests
+{
+    [Fact]
+    public void Empty_filter_matches_everything()
+    {
+        var f = LogFilters.Empty;
+
+        f.IsEmpty.Should().BeTrue();
+        f.MatchesSource(LogSource.Trace).Should().BeTrue();
+        f.MatchesLevel(SeverityLevel.Error).Should().BeTrue();
+        f.MatchesApplication("anything").Should().BeTrue();
+        f.MatchesEnvironment("anything").Should().BeTrue();
+    }
+
+    [Fact]
+    public void Populated_dimension_keeps_matching_values_drops_others()
+    {
+        var f = new LogFilters
+        {
+            Sources = [LogSource.Exception],
+            Levels = [SeverityLevel.Warning, SeverityLevel.Error]
+        };
+
+        f.IsEmpty.Should().BeFalse();
+        f.MatchesSource(LogSource.Exception).Should().BeTrue();
+        f.MatchesSource(LogSource.Trace).Should().BeFalse();
+        f.MatchesLevel(SeverityLevel.Error).Should().BeTrue();
+        f.MatchesLevel(SeverityLevel.Warning).Should().BeTrue();
+        f.MatchesLevel(SeverityLevel.Information).Should().BeFalse();
+    }
+
+    [Fact]
+    public void Application_filter_works_against_logical_names_supplied_by_caller()
+    {
+        // The component is responsible for resolving raw → logical before calling Matches.
+        var f = new LogFilters { Applications = ["quilt4net-web"] };
+
+        f.MatchesApplication("quilt4net-web").Should().BeTrue();
+        f.MatchesApplication("Quilt4Net.Server").Should().BeFalse(); // raw name not in filter
+    }
+
+    [Fact]
+    public void Environment_filter_treats_null_or_empty_as_empty_string()
+    {
+        var f = new LogFilters { Environments = [""] };
+
+        f.MatchesEnvironment(null).Should().BeTrue();
+        f.MatchesEnvironment("").Should().BeTrue();
+        f.MatchesEnvironment("Production").Should().BeFalse();
+    }
+
+    [Fact]
+    public void Filters_compose_independently_across_dimensions()
+    {
+        var f = new LogFilters
+        {
+            Sources = [LogSource.Exception],
+            Levels = [SeverityLevel.Error],
+            Applications = ["app-a"],
+            Environments = ["Production"]
+        };
+
+        // Row that matches every dimension
+        (f.MatchesSource(LogSource.Exception)
+            && f.MatchesLevel(SeverityLevel.Error)
+            && f.MatchesApplication("app-a")
+            && f.MatchesEnvironment("Production"))
+            .Should().BeTrue();
+
+        // One mismatched dimension → row is filtered out
+        (f.MatchesSource(LogSource.Trace)
+            && f.MatchesLevel(SeverityLevel.Error)
+            && f.MatchesApplication("app-a")
+            && f.MatchesEnvironment("Production"))
+            .Should().BeFalse();
+    }
+}

--- a/Quilt4Net.Toolkit.Blazor/Features/Log/ApplicationName.razor
+++ b/Quilt4Net.Toolkit.Blazor/Features/Log/ApplicationName.razor
@@ -1,0 +1,39 @@
+@*
+    Renders an application name with alias resolution applied:
+      - empty / null  → "(unknown)" placeholder
+      - raw matches a known logical alias  → renders the logical name with the raw
+        value as a tooltip and a dotted underline (so the actual emitter is one
+        hover away).
+      - no alias map cascaded, or raw is not in the map → renders the raw name as-is.
+
+    Consumes IReadOnlyDictionary<string, string> ApplicationAliasMap from a cascading
+    value set by an entry-point component (LogView / LogDetailView / LogSummaryView).
+*@
+
+@if (string.IsNullOrEmpty(Raw))
+{
+    <span style="color: var(--rz-text-tertiary-color); font-style: italic;">(unknown)</span>
+}
+else
+{
+    var logical = ApplicationAliasMap is { Count: > 0 } map
+        ? map.GetValueOrDefault(Raw, Raw)
+        : Raw;
+
+    if (!string.Equals(Raw, logical, StringComparison.OrdinalIgnoreCase))
+    {
+        <span title="@Raw" style="border-bottom: 1px dotted var(--rz-text-tertiary-color);">@logical</span>
+    }
+    else
+    {
+        @Raw
+    }
+}
+
+@code {
+    [Parameter, EditorRequired]
+    public string Raw { get; set; } = default!;
+
+    [CascadingParameter(Name = "ApplicationAliasMap")]
+    public IReadOnlyDictionary<string, string> ApplicationAliasMap { get; set; }
+}

--- a/Quilt4Net.Toolkit.Blazor/Features/Log/LogCountView.razor
+++ b/Quilt4Net.Toolkit.Blazor/Features/Log/LogCountView.razor
@@ -55,7 +55,9 @@ else
                             </Template>
                         </RadzenDataGridColumn>
                         <RadzenDataGridColumn Title="Message" Property="@nameof(CountData.Message)" />
-                        <RadzenDataGridColumn Title="Application" Property="@nameof(CountData.Application)" />
+                        <RadzenDataGridColumn Title="Application" Property="@nameof(CountData.Application)">
+                            <Template><ApplicationName Raw="@context.Application" /></Template>
+                        </RadzenDataGridColumn>
                         <RadzenDataGridColumn Title="Environment" Property="@nameof(CountData.Environment)" />
                         <RadzenDataGridColumn Title="Count" Property="@nameof(CountData.Count)" Filterable="false" />
                     </Columns>

--- a/Quilt4Net.Toolkit.Blazor/Features/Log/LogDetailContent.razor
+++ b/Quilt4Net.Toolkit.Blazor/Features/Log/LogDetailContent.razor
@@ -79,22 +79,85 @@ else
     <RadzenTabs>
         <Tabs>
             <RadzenTabsItem Text="Details">
-                <p>TODO: Show details in table here.</p>
+                <RadzenStack Orientation="Orientation.Vertical" Gap="0.5rem">
+                    <RadzenStack Orientation="Orientation.Horizontal" Gap="6px">
+                        <RadzenSwitch @bind-Value="_showEmptyValues" />
+                        <RadzenText Text="Show empty values" />
+                    </RadzenStack>
+                    <RadzenDataGrid Data="@DisplayedRows" TItem="DetailRow" AllowPaging="false">
+                        <Columns>
+                            <RadzenDataGridColumn Title="Key" Property="@nameof(DetailRow.Key)" Width="240px" />
+                            <RadzenDataGridColumn Title="Value" Property="@nameof(DetailRow.Value)">
+                                <Template>
+                                    <pre style="margin: 0; white-space: pre-wrap; word-break: break-word; font-family: var(--rz-font-family-monospace, monospace);">@context.Value</pre>
+                                </Template>
+                            </RadzenDataGridColumn>
+                        </Columns>
+                    </RadzenDataGrid>
+                </RadzenStack>
             </RadzenTabsItem>
             <RadzenTabsItem Text="Stack Trace">
-                <RadzenStack Orientation="Orientation.Vertical" Gap="1rem">
-                    <RadzenStack Orientation="Orientation.Horizontal" Gap="6px">
-                        <RadzenSwitch @bind-Value="_showUnknownLines" />
-                        <RadzenText Text="Show unknown lines" />
+                @if (_stackFrames.Count == 0)
+                {
+                    <RadzenAlert AlertStyle="AlertStyle.Info" Shade="Shade.Lighter" AllowClose="false">
+                        No parsed stack trace available for this entry. Stack frames are produced for AppExceptions; trace and request rows have none.
+                    </RadzenAlert>
+                }
+                else
+                {
+                    <RadzenStack Orientation="Orientation.Vertical" Gap="0.5rem">
+                        <RadzenStack Orientation="Orientation.Horizontal" Gap="6px">
+                            <RadzenSwitch @bind-Value="_showUnknownLines" />
+                            <RadzenText Text="Show frames without file/line (system / framework code)" />
+                        </RadzenStack>
+                        <RadzenDataGrid Data="@DisplayedFrames" TItem="StackFrame" AllowPaging="false" AllowSorting="false">
+                            <Columns>
+                                <RadzenDataGridColumn Title="#" Property="@nameof(StackFrame.Level)" Width="60px" />
+                                <RadzenDataGridColumn Title="Assembly" Property="@nameof(StackFrame.Assembly)" Width="180px">
+                                    <Template>
+                                        <span style="font-family: var(--rz-font-family-monospace, monospace);">@context.Assembly</span>
+                                    </Template>
+                                </RadzenDataGridColumn>
+                                <RadzenDataGridColumn Title="Method" Property="@nameof(StackFrame.Method)">
+                                    <Template>
+                                        <span style="font-family: var(--rz-font-family-monospace, monospace);">@context.Method</span>
+                                    </Template>
+                                </RadzenDataGridColumn>
+                                <RadzenDataGridColumn Title="File" Property="@nameof(StackFrame.FileName)" Width="280px">
+                                    <Template>
+                                        @if (!string.IsNullOrEmpty(context.FileName))
+                                        {
+                                            <span title="@context.FileName" style="font-family: var(--rz-font-family-monospace, monospace);">@RenderRelativePath(context)</span>
+                                        }
+                                    </Template>
+                                </RadzenDataGridColumn>
+                                <RadzenDataGridColumn Title="Line" Property="@nameof(StackFrame.Line)" Width="80px">
+                                    <Template>
+                                        @if (context.Line > 0)
+                                        {
+                                            @context.Line
+                                        }
+                                    </Template>
+                                </RadzenDataGridColumn>
+                                <RadzenDataGridColumn Title="" Width="50px" Sortable="false">
+                                    <Template>
+                                        @if (context.HasFileLocation)
+                                        {
+                                            <CopyButton Content="@StackFrameParser.ToResharperPath(context, _sourcePathRoots)" />
+                                        }
+                                    </Template>
+                                </RadzenDataGridColumn>
+                            </Columns>
+                        </RadzenDataGrid>
                     </RadzenStack>
-                </RadzenStack>
-                <p>TODO: Show table with stacktrace. [level, assembly, method, fileName, line, (Copy-button)]</p>
+                }
             </RadzenTabsItem>
             <RadzenTabsItem Text="Raw">
-                <RadzenStack Orientation="Orientation.Vertical" Gap="1rem">
-                    <RadzenStack Orientation="Orientation.Horizontal" Gap="6px">
-                        <RadzenSwitch @bind-Value="_showEmptyValues"/>
-                        <RadzenText Text="Show empty values"/>
+                <RadzenStack Orientation="Orientation.Vertical" Gap="0.5rem">
+                    <RadzenStack Orientation="Orientation.Horizontal" Gap="6px" AlignItems="AlignItems.Center">
+                        <RadzenSwitch @bind-Value="_showEmptyValues" />
+                        <RadzenText Text="Show empty values" />
+                        <CopyButton Content="@DisplayedJson" />
                     </RadzenStack>
                     <pre>@DisplayedJson</pre>
                 </RadzenStack>
@@ -108,8 +171,19 @@ else
     private bool _showUnknownLines;
     private string _configError;
     private IApplicationInsightsService _ais;
+    private IReadOnlyList<StackFrame> _stackFrames = [];
 
-    private string DisplayedJson => _showEmptyValues ? FormatJson(Model.RawJson) : FilterEmptyValues(Model.RawJson);
+    private string DisplayedJson => Model == null ? string.Empty
+        : _showEmptyValues ? FormatJson(Model.RawJson) : FilterEmptyValues(Model.RawJson);
+
+    private IEnumerable<DetailRow> DisplayedRows => Model == null
+        ? []
+        : BuildRows(Model.Raw, _showEmptyValues);
+
+    private IEnumerable<StackFrame> DisplayedFrames => _showUnknownLines
+        ? _stackFrames
+        : _stackFrames.Where(f => f.HasFileLocation);
+
     private LogDetails Model { get; set; }
 
     [Parameter]
@@ -126,6 +200,9 @@ else
 
     [CascadingParameter]
     private LogNavigationOptions _cascadedNavOptions { get; set; }
+
+    [CascadingParameter(Name = "SourcePathRoots")]
+    private string[] _sourcePathRoots { get; set; }
 
     private LogNavigationOptions NavOptions => _cascadedNavOptions ?? new LogNavigationOptions();
 
@@ -153,12 +230,27 @@ else
         if (_configError != null) return;
 
         Model = null;
+        _stackFrames = [];
 
         if (!Source.HasValue || !Range.HasValue) return;
 
         Model = await _ais.GetDetail(Context, Id, Source.Value, Environment, Range.Value);
+        _stackFrames = StackFrameParser.Parse(Model?.Raw);
 
         await base.OnParametersSetAsync();
+    }
+
+    private string RenderRelativePath(StackFrame frame)
+    {
+        if (string.IsNullOrEmpty(frame.FileName)) return string.Empty;
+        if (_sourcePathRoots is { Length: > 0 })
+        {
+            var rel = StackFrameParser.ToResharperPath(frame with { Line = 0 }, _sourcePathRoots);
+            if (!string.IsNullOrEmpty(rel)) return rel;
+        }
+        // Fall back to just the file name if no source root configured.
+        var idx = frame.FileName.LastIndexOfAny(['\\', '/']);
+        return idx >= 0 ? frame.FileName[(idx + 1)..] : frame.FileName;
     }
 
     private async Task OpenSummaryAsync(string fingerprint)
@@ -174,6 +266,37 @@ else
         {
             NavigationManager.NavigateTo($"{NavOptions.SummaryPath}/{fingerprint}?p={p.Encode()}");
         }
+    }
+
+    public sealed record DetailRow(string Key, string Value);
+
+    private static IEnumerable<DetailRow> BuildRows(IReadOnlyDictionary<string, object> raw, bool includeEmpty)
+    {
+        if (raw == null) yield break;
+
+        foreach (var kvp in raw.OrderBy(x => x.Key, StringComparer.OrdinalIgnoreCase))
+        {
+            var rendered = RenderValue(kvp.Value);
+            if (!includeEmpty && string.IsNullOrEmpty(rendered)) continue;
+            yield return new DetailRow(kvp.Key, rendered);
+        }
+    }
+
+    private static string RenderValue(object value)
+    {
+        if (value is null) return string.Empty;
+        if (value is JsonElement el)
+        {
+            return el.ValueKind switch
+            {
+                JsonValueKind.Null or JsonValueKind.Undefined => string.Empty,
+                JsonValueKind.String => el.GetString() ?? string.Empty,
+                JsonValueKind.Object or JsonValueKind.Array => JsonSerializer.Serialize(el, new JsonSerializerOptions { WriteIndented = true }),
+                _ => el.GetRawText()
+            };
+        }
+        var s = value.ToString();
+        return s ?? string.Empty;
     }
 
     private static string FormatJson(string json)

--- a/Quilt4Net.Toolkit.Blazor/Features/Log/LogDetailContent.razor
+++ b/Quilt4Net.Toolkit.Blazor/Features/Log/LogDetailContent.razor
@@ -16,10 +16,6 @@ else
 {
     <RadzenRow>
         <RadzenColumn>
-            <RadzenText Text="Id" TextStyle="TextStyle.Caption" />
-            <RadzenText Text="@Model.Id" />
-        </RadzenColumn>
-        <RadzenColumn>
             <RadzenText Text="Fingerprint" TextStyle="TextStyle.Caption" />
             <div>
                 @if (OnSummaryNavigation.HasDelegate || NavOptions.SummaryPath != null)
@@ -34,21 +30,29 @@ else
                 }
             </div>
         </RadzenColumn>
+        <RadzenColumn Size="4">
+            <RadzenText Text="Level" TextStyle="TextStyle.Caption" />
+            <RadzenText Text="@($"{Model.SeverityLevel}")" />
+        </RadzenColumn>
+        <RadzenColumn>
+            <RadzenText Text="Id" TextStyle="TextStyle.Caption" />
+            <RadzenText Text="@Model.Id" />
+        </RadzenColumn>
+    </RadzenRow>
+    <RadzenRow>
         <RadzenColumn>
             <RadzenText Text="Time Generated" TextStyle="TextStyle.Caption" />
             <div>
                 <span title="@Model.TimeGenerated.ToLocalDateTimeString()">@Model.TimeGenerated.ToLocalDurationString()</span>
             </div>
         </RadzenColumn>
-    </RadzenRow>
-    <RadzenRow>
-        <RadzenColumn Size="4">
-            <RadzenText Text="Level" TextStyle="TextStyle.Caption" />
-            <RadzenText Text="@($"{Model.SeverityLevel}")" />
-        </RadzenColumn>
         <RadzenColumn>
             <RadzenText Text="Correlation Id" TextStyle="TextStyle.Caption" />
             <RadzenText Text="@($"{Model.CorrelationId}")" />
+        </RadzenColumn>
+        <RadzenColumn>
+            <RadzenText Text="Version" TextStyle="TextStyle.Caption" />
+            <RadzenText Text="@($"{Model.Version}")" />
         </RadzenColumn>
     </RadzenRow>
     <RadzenRow>
@@ -58,7 +62,7 @@ else
         </RadzenColumn>
         <RadzenColumn>
             <RadzenText Text="Application" TextStyle="TextStyle.Caption" />
-            <RadzenText Text="@Model.Application" />
+            <div><ApplicationName Raw="@Model.Application" /></div>
         </RadzenColumn>
         <RadzenColumn>
             <RadzenText Text="Source" TextStyle="TextStyle.Caption" />
@@ -72,19 +76,36 @@ else
         </RadzenColumn>
     </RadzenRow>
 
-    <RadzenCard>
-        <RadzenStack Orientation="Orientation.Vertical" Gap="1rem">
-            <RadzenStack Orientation="Orientation.Horizontal" Gap="6px">
-                <RadzenSwitch @bind-Value="_showEmptyValues"/>
-                <RadzenText Text="Show empty values"/>
-            </RadzenStack>
-            <pre>@DisplayedJson</pre>
-        </RadzenStack>
-    </RadzenCard>
+    <RadzenTabs>
+        <Tabs>
+            <RadzenTabsItem Text="Details">
+                <p>TODO: Show details in table here.</p>
+            </RadzenTabsItem>
+            <RadzenTabsItem Text="Stack Trace">
+                <RadzenStack Orientation="Orientation.Vertical" Gap="1rem">
+                    <RadzenStack Orientation="Orientation.Horizontal" Gap="6px">
+                        <RadzenSwitch @bind-Value="_showUnknownLines" />
+                        <RadzenText Text="Show unknown lines" />
+                    </RadzenStack>
+                </RadzenStack>
+                <p>TODO: Show table with stacktrace. [level, assembly, method, fileName, line, (Copy-button)]</p>
+            </RadzenTabsItem>
+            <RadzenTabsItem Text="Raw">
+                <RadzenStack Orientation="Orientation.Vertical" Gap="1rem">
+                    <RadzenStack Orientation="Orientation.Horizontal" Gap="6px">
+                        <RadzenSwitch @bind-Value="_showEmptyValues"/>
+                        <RadzenText Text="Show empty values"/>
+                    </RadzenStack>
+                    <pre>@DisplayedJson</pre>
+                </RadzenStack>
+            </RadzenTabsItem>
+        </Tabs>
+    </RadzenTabs>
 }
 
 @code {
     private bool _showEmptyValues;
+    private bool _showUnknownLines;
     private string _configError;
     private IApplicationInsightsService _ais;
 

--- a/Quilt4Net.Toolkit.Blazor/Features/Log/LogDetailView.razor
+++ b/Quilt4Net.Toolkit.Blazor/Features/Log/LogDetailView.razor
@@ -8,11 +8,13 @@
 {
     <CascadingValue Value="_navOptions">
         <CascadingValue Name="ApplicationAliasMap" Value="@_effectiveAliasMap">
-            <LogDetailContent Id="@Id"
-                              Environment="@_params.Environment"
-                              Range="@_params.GetRange()"
-                              Source="@_params.GetSource()"
-                              Context="@_params.GetContext()" />
+            <CascadingValue Name="SourcePathRoots" Value="@SourcePathRoots">
+                <LogDetailContent Id="@Id"
+                                  Environment="@_params.Environment"
+                                  Range="@_params.GetRange()"
+                                  Source="@_params.GetSource()"
+                                  Context="@_params.GetContext()" />
+            </CascadingValue>
         </CascadingValue>
     </CascadingValue>
 }
@@ -51,6 +53,13 @@
     /// </summary>
     [Parameter]
     public IReadOnlyDictionary<string, string> ApplicationAliasMap { get; set; }
+
+    /// <summary>
+    /// Project / repository folder names that mark the boundary used to shorten file paths
+    /// in the Stack Trace tab. See <c>LogView.SourcePathRoots</c> for the full description.
+    /// </summary>
+    [Parameter]
+    public string[] SourcePathRoots { get; set; }
 
     protected override void OnParametersSet()
     {

--- a/Quilt4Net.Toolkit.Blazor/Features/Log/LogDetailView.razor
+++ b/Quilt4Net.Toolkit.Blazor/Features/Log/LogDetailView.razor
@@ -1,19 +1,26 @@
+@using Microsoft.Extensions.DependencyInjection
+@using Microsoft.Extensions.Options
+@using Quilt4Net.Toolkit
 @using Quilt4Net.Toolkit.Features.ApplicationInsights
+@inject IServiceProvider ServiceProvider
 
 @if (_params != null && _params.GetSource().HasValue && _params.GetRange() != TimeSpan.Zero)
 {
     <CascadingValue Value="_navOptions">
-        <LogDetailContent Id="@Id"
-                          Environment="@_params.Environment"
-                          Range="@_params.GetRange()"
-                          Source="@_params.GetSource()"
-                          Context="@_params.GetContext()" />
+        <CascadingValue Name="ApplicationAliasMap" Value="@_effectiveAliasMap">
+            <LogDetailContent Id="@Id"
+                              Environment="@_params.Environment"
+                              Range="@_params.GetRange()"
+                              Source="@_params.GetSource()"
+                              Context="@_params.GetContext()" />
+        </CascadingValue>
     </CascadingValue>
 }
 
 @code {
     private LogNavParams _params;
     private LogNavigationOptions _navOptions;
+    private IReadOnlyDictionary<string, string> _effectiveAliasMap;
 
     /// <summary>
     /// The ID of the log entry to display.
@@ -36,6 +43,15 @@
     [Parameter]
     public string SummaryPath { get; set; }
 
+    /// <summary>
+    /// Optional <c>raw → logical</c> application alias map. When supplied, the Application
+    /// header (and any embedded list views) renders the logical name with the raw value as
+    /// a tooltip. When null, the toolkit falls back to the static map configured via
+    /// <see cref="ApplicationInsightsOptions.ApplicationAlias"/>.
+    /// </summary>
+    [Parameter]
+    public IReadOnlyDictionary<string, string> ApplicationAliasMap { get; set; }
+
     protected override void OnParametersSet()
     {
         _params = LogNavParams.Decode(Params);
@@ -43,5 +59,12 @@
         {
             SummaryPath = SummaryPath
         };
+        _effectiveAliasMap = ApplicationAliasMap ?? ResolveStaticMap();
+    }
+
+    private IReadOnlyDictionary<string, string> ResolveStaticMap()
+    {
+        var options = ServiceProvider.GetService<IOptions<ApplicationInsightsOptions>>()?.Value;
+        return options?.ApplicationAlias?.ToResolverDictionary();
     }
 }

--- a/Quilt4Net.Toolkit.Blazor/Features/Log/LogFilterBar.razor
+++ b/Quilt4Net.Toolkit.Blazor/Features/Log/LogFilterBar.razor
@@ -1,0 +1,116 @@
+@using System.Text.Json
+@using Blazored.LocalStorage
+@using Microsoft.Extensions.DependencyInjection
+@using Quilt4Net.Toolkit.Features.ApplicationInsights
+@inject IServiceProvider ServiceProvider
+
+<RadzenStack Orientation="Orientation.Vertical" Gap="0.5rem" Style="margin-bottom: 0.5rem;">
+    @if (_sourceOptions.Length > 0)
+    {
+        <RadzenStack Orientation="Orientation.Horizontal" AlignItems="AlignItems.Center" Gap="0.5rem">
+            <RadzenText Text="Source" TextStyle="TextStyle.Caption" Style="min-width: 5rem;" />
+            <RadzenSelectBar Data="@_sourceOptions" Value="@_value.Sources" TValue="LogSource[]" Multiple="true" AllowSelectAll="false"
+                             Change="@(EventCallback.Factory.Create<LogSource[]>(this, OnSourcesChanged))" />
+        </RadzenStack>
+    }
+    @if (_levelOptions.Length > 0)
+    {
+        <RadzenStack Orientation="Orientation.Horizontal" AlignItems="AlignItems.Center" Gap="0.5rem">
+            <RadzenText Text="Level" TextStyle="TextStyle.Caption" Style="min-width: 5rem;" />
+            <RadzenSelectBar Data="@_levelOptions" Value="@_value.Levels" TValue="SeverityLevel[]" Multiple="true" AllowSelectAll="false"
+                             Change="@(EventCallback.Factory.Create<SeverityLevel[]>(this, OnLevelsChanged))" />
+        </RadzenStack>
+    }
+    @if (Applications is { Length: > 0 })
+    {
+        <RadzenStack Orientation="Orientation.Horizontal" AlignItems="AlignItems.Center" Gap="0.5rem" Wrap="FlexWrap.Wrap">
+            <RadzenText Text="Application" TextStyle="TextStyle.Caption" Style="min-width: 5rem;" />
+            <RadzenSelectBar Data="@Applications" Value="@_value.Applications" TValue="string[]" Multiple="true" AllowSelectAll="false"
+                             Change="@(EventCallback.Factory.Create<string[]>(this, OnApplicationsChanged))" />
+        </RadzenStack>
+    }
+    @if (Environments is { Length: > 0 })
+    {
+        <RadzenStack Orientation="Orientation.Horizontal" AlignItems="AlignItems.Center" Gap="0.5rem" Wrap="FlexWrap.Wrap">
+            <RadzenText Text="Environment" TextStyle="TextStyle.Caption" Style="min-width: 5rem;" />
+            <RadzenSelectBar Data="@Environments" Value="@_value.Environments" TValue="string[]" Multiple="true" AllowSelectAll="false"
+                             Change="@(EventCallback.Factory.Create<string[]>(this, OnEnvironmentsChanged))" />
+        </RadzenStack>
+    }
+</RadzenStack>
+
+@code {
+    private static readonly LogSource[] _sourceOptions = Enum.GetValues<LogSource>();
+    private static readonly SeverityLevel[] _levelOptions = Enum.GetValues<SeverityLevel>();
+
+    private LogFilters _value = LogFilters.Empty;
+    private ILocalStorageService _localStorage;
+
+    /// <summary>Distinct application names (post-alias) currently selectable. When empty the row hides.</summary>
+    [Parameter]
+    public string[] Applications { get; set; } = [];
+
+    /// <summary>Distinct environment names currently selectable. When empty the row hides.</summary>
+    [Parameter]
+    public string[] Environments { get; set; } = [];
+
+    /// <summary>
+    /// localStorage key used to persist the selection. When null (default) the filter
+    /// state lives only for the lifetime of the component.
+    /// </summary>
+    [Parameter]
+    public string StorageKey { get; set; }
+
+    /// <summary>Fires whenever the user changes any filter dimension.</summary>
+    [Parameter]
+    public EventCallback<LogFilters> OnChanged { get; set; }
+
+    protected override async Task OnInitializedAsync()
+    {
+        _localStorage = ServiceProvider.GetService<ILocalStorageService>();
+
+        if (!string.IsNullOrEmpty(StorageKey) && _localStorage != null)
+        {
+            try
+            {
+                var stored = await _localStorage.GetItemAsStringAsync(StorageKey);
+                if (!string.IsNullOrEmpty(stored))
+                {
+                    var loaded = JsonSerializer.Deserialize<LogFilters>(stored);
+                    if (loaded != null)
+                    {
+                        _value = loaded;
+                        if (OnChanged.HasDelegate) await OnChanged.InvokeAsync(_value);
+                    }
+                }
+            }
+            catch
+            {
+                // Corrupt entry — ignore and start fresh; the next save overwrites.
+            }
+        }
+    }
+
+    private Task OnSourcesChanged(LogSource[] value) => UpdateAsync(_value with { Sources = value ?? [] });
+    private Task OnLevelsChanged(SeverityLevel[] value) => UpdateAsync(_value with { Levels = value ?? [] });
+    private Task OnApplicationsChanged(string[] value) => UpdateAsync(_value with { Applications = value ?? [] });
+    private Task OnEnvironmentsChanged(string[] value) => UpdateAsync(_value with { Environments = value ?? [] });
+
+    private async Task UpdateAsync(LogFilters next)
+    {
+        _value = next;
+        if (OnChanged.HasDelegate) await OnChanged.InvokeAsync(_value);
+        if (!string.IsNullOrEmpty(StorageKey) && _localStorage != null)
+        {
+            try
+            {
+                await _localStorage.SetItemAsStringAsync(StorageKey, JsonSerializer.Serialize(_value));
+            }
+            catch
+            {
+                // localStorage write failures (quota, private mode) shouldn't break the UI.
+            }
+        }
+    }
+
+}

--- a/Quilt4Net.Toolkit.Blazor/Features/Log/LogFilterBar.razor
+++ b/Quilt4Net.Toolkit.Blazor/Features/Log/LogFilterBar.razor
@@ -9,32 +9,32 @@
     {
         <RadzenStack Orientation="Orientation.Horizontal" AlignItems="AlignItems.Center" Gap="0.5rem">
             <RadzenText Text="Source" TextStyle="TextStyle.Caption" Style="min-width: 5rem;" />
-            <RadzenSelectBar Data="@_sourceOptions" Value="@_value.Sources" TValue="LogSource[]" Multiple="true" AllowSelectAll="false"
-                             Change="@(EventCallback.Factory.Create<LogSource[]>(this, OnSourcesChanged))" />
+            <RadzenSelectBar Data="@_sourceOptions" Value="@_value.Sources" TValue="IEnumerable<LogSource>" Multiple="true" AllowSelectAll="false"
+                             Change="@(EventCallback.Factory.Create<IEnumerable<LogSource>>(this, OnSourcesChanged))" />
         </RadzenStack>
     }
     @if (_levelOptions.Length > 0)
     {
         <RadzenStack Orientation="Orientation.Horizontal" AlignItems="AlignItems.Center" Gap="0.5rem">
             <RadzenText Text="Level" TextStyle="TextStyle.Caption" Style="min-width: 5rem;" />
-            <RadzenSelectBar Data="@_levelOptions" Value="@_value.Levels" TValue="SeverityLevel[]" Multiple="true" AllowSelectAll="false"
-                             Change="@(EventCallback.Factory.Create<SeverityLevel[]>(this, OnLevelsChanged))" />
+            <RadzenSelectBar Data="@_levelOptions" Value="@_value.Levels" TValue="IEnumerable<SeverityLevel>" Multiple="true" AllowSelectAll="false"
+                             Change="@(EventCallback.Factory.Create<IEnumerable<SeverityLevel>>(this, OnLevelsChanged))" />
         </RadzenStack>
     }
     @if (Applications is { Length: > 0 })
     {
         <RadzenStack Orientation="Orientation.Horizontal" AlignItems="AlignItems.Center" Gap="0.5rem" Wrap="FlexWrap.Wrap">
             <RadzenText Text="Application" TextStyle="TextStyle.Caption" Style="min-width: 5rem;" />
-            <RadzenSelectBar Data="@Applications" Value="@_value.Applications" TValue="string[]" Multiple="true" AllowSelectAll="false"
-                             Change="@(EventCallback.Factory.Create<string[]>(this, OnApplicationsChanged))" />
+            <RadzenSelectBar Data="@Applications" Value="@_value.Applications" TValue="IEnumerable<string>" Multiple="true" AllowSelectAll="false"
+                             Change="@(EventCallback.Factory.Create<IEnumerable<string>>(this, OnApplicationsChanged))" />
         </RadzenStack>
     }
     @if (Environments is { Length: > 0 })
     {
         <RadzenStack Orientation="Orientation.Horizontal" AlignItems="AlignItems.Center" Gap="0.5rem" Wrap="FlexWrap.Wrap">
             <RadzenText Text="Environment" TextStyle="TextStyle.Caption" Style="min-width: 5rem;" />
-            <RadzenSelectBar Data="@Environments" Value="@_value.Environments" TValue="string[]" Multiple="true" AllowSelectAll="false"
-                             Change="@(EventCallback.Factory.Create<string[]>(this, OnEnvironmentsChanged))" />
+            <RadzenSelectBar Data="@Environments" Value="@_value.Environments" TValue="IEnumerable<string>" Multiple="true" AllowSelectAll="false"
+                             Change="@(EventCallback.Factory.Create<IEnumerable<string>>(this, OnEnvironmentsChanged))" />
         </RadzenStack>
     }
 </RadzenStack>
@@ -91,10 +91,10 @@
         }
     }
 
-    private Task OnSourcesChanged(LogSource[] value) => UpdateAsync(_value with { Sources = value ?? [] });
-    private Task OnLevelsChanged(SeverityLevel[] value) => UpdateAsync(_value with { Levels = value ?? [] });
-    private Task OnApplicationsChanged(string[] value) => UpdateAsync(_value with { Applications = value ?? [] });
-    private Task OnEnvironmentsChanged(string[] value) => UpdateAsync(_value with { Environments = value ?? [] });
+    private Task OnSourcesChanged(IEnumerable<LogSource> value) => UpdateAsync(_value with { Sources = value?.ToArray() ?? [] });
+    private Task OnLevelsChanged(IEnumerable<SeverityLevel> value) => UpdateAsync(_value with { Levels = value?.ToArray() ?? [] });
+    private Task OnApplicationsChanged(IEnumerable<string> value) => UpdateAsync(_value with { Applications = value?.ToArray() ?? [] });
+    private Task OnEnvironmentsChanged(IEnumerable<string> value) => UpdateAsync(_value with { Environments = value?.ToArray() ?? [] });
 
     private async Task UpdateAsync(LogFilters next)
     {

--- a/Quilt4Net.Toolkit.Blazor/Features/Log/LogFilters.cs
+++ b/Quilt4Net.Toolkit.Blazor/Features/Log/LogFilters.cs
@@ -1,0 +1,33 @@
+using Quilt4Net.Toolkit.Features.ApplicationInsights;
+
+namespace Quilt4Net.Toolkit.Blazor.Features.Log;
+
+/// <summary>
+/// Multi-select filter state for the Log Summary and Search views. An empty array on a
+/// dimension means "no filter on this dimension" (show all values). Used both as the in-memory
+/// state of <see cref="LogFilterBar"/> and as the persisted shape in browser localStorage.
+/// </summary>
+public sealed record LogFilters
+{
+    public LogSource[] Sources { get; init; } = [];
+    public SeverityLevel[] Levels { get; init; } = [];
+
+    /// <summary>Logical application names (post-alias resolution) the user wants to keep.</summary>
+    public string[] Applications { get; init; } = [];
+
+    public string[] Environments { get; init; } = [];
+
+    public static LogFilters Empty { get; } = new();
+
+    public bool IsEmpty
+        => Sources.Length == 0
+           && Levels.Length == 0
+           && Applications.Length == 0
+           && Environments.Length == 0;
+
+    /// <summary>True when <paramref name="value"/> passes this filter on the given dimension.</summary>
+    public bool MatchesSource(LogSource value) => Sources.Length == 0 || Array.IndexOf(Sources, value) >= 0;
+    public bool MatchesLevel(SeverityLevel value) => Levels.Length == 0 || Array.IndexOf(Levels, value) >= 0;
+    public bool MatchesApplication(string logical) => Applications.Length == 0 || Array.IndexOf(Applications, logical ?? string.Empty) >= 0;
+    public bool MatchesEnvironment(string env) => Environments.Length == 0 || Array.IndexOf(Environments, env ?? string.Empty) >= 0;
+}

--- a/Quilt4Net.Toolkit.Blazor/Features/Log/LogMeasureView.razor
+++ b/Quilt4Net.Toolkit.Blazor/Features/Log/LogMeasureView.razor
@@ -58,7 +58,9 @@ else
                             </Template>
                         </RadzenDataGridColumn>
                         <RadzenDataGridColumn Title="Message" Property="@nameof(MeasureData.Message)" />
-                        <RadzenDataGridColumn Title="Application" Property="@nameof(MeasureData.Application)" />
+                        <RadzenDataGridColumn Title="Application" Property="@nameof(MeasureData.Application)">
+                            <Template><ApplicationName Raw="@context.Application" /></Template>
+                        </RadzenDataGridColumn>
                         <RadzenDataGridColumn Title="Environment" Property="@nameof(MeasureData.Environment)" />
                         <RadzenDataGridColumn Title="Elapsed" Property="@nameof(MeasureData.Elapsed)" Filterable="false">
                             <Template>

--- a/Quilt4Net.Toolkit.Blazor/Features/Log/LogSearchView.razor
+++ b/Quilt4Net.Toolkit.Blazor/Features/Log/LogSearchView.razor
@@ -1,4 +1,5 @@
 ﻿@using Quilt4Net.Toolkit.Features.ApplicationInsights
+@using Tharga.Blazor
 @inject IServiceProvider ServiceProvider
 @inject DialogService DialogService
 @inject NavigationManager NavigationManager
@@ -20,9 +21,11 @@
 }
 else if (Model != null)
 {
-    <RadzenDataGrid TItem="LogItem" Data="@Model"
-                    AllowSorting="true"
-                    AllowFiltering="true" FilterMode="FilterMode.Simple" FilterCaseSensitivity="FilterCaseSensitivity.CaseInsensitive"
+    <LogFilterBar Applications="@_distinctApps" Environments="@_distinctEnvs"
+                  StorageKey="@FilterStorageKey" OnChanged="OnFiltersChanged" />
+
+    <RadzenDataGrid TItem="LogItem" Data="@_filtered"
+                    AllowSorting="true" AllowFiltering="false"
                     AllowPaging="true" PageSize="8" PageSizeOptions="[8, 16, 32, 64]"
                     ShowPagingSummary="true" PagingSummaryFormat="{2:N0} log items, page {0} of {1}">
         <Columns>
@@ -35,6 +38,20 @@ else if (Model != null)
             <RadzenDataGridColumn Title="Time" Property="@nameof(LogItem.TimeGenerated)" SortOrder="SortOrder.Descending" Filterable="false">
                 <Template>
                     <DateTimeView Date="@context.TimeGenerated" />
+                </Template>
+            </RadzenDataGridColumn>
+            <RadzenDataGridColumn Title="Correlation" Property="@nameof(LogItem.CorrelationId)" Width="140px" Sortable="false" Filterable="false">
+                <Template>
+                    @if (!string.IsNullOrEmpty(context.CorrelationId))
+                    {
+                        var preview = context.CorrelationId.Length > 8 ? context.CorrelationId[..8] + "…" : context.CorrelationId;
+                        <RadzenStack Orientation="Orientation.Horizontal" AlignItems="AlignItems.Center" Gap="0.25rem">
+                            <span title="@($"{context.CorrelationId} (click to filter)")"
+                                  style="cursor: pointer; text-decoration: underline; font-family: var(--rz-font-family-monospace, monospace);"
+                                  @onclick="@(() => SearchByCorrelationIdAsync(context.CorrelationId))">@preview</span>
+                            <CopyButton Content="@context.CorrelationId" />
+                        </RadzenStack>
+                    }
                 </Template>
             </RadzenDataGridColumn>
             <RadzenDataGridColumn Title="Source" Property="@nameof(LogItem.Source)" />
@@ -54,6 +71,10 @@ else if (Model != null)
     private string _configError;
     private IApplicationInsightsService _ais;
     private LogItem[] Model { get; set; }
+    private LogItem[] _filtered = [];
+    private string[] _distinctApps = [];
+    private string[] _distinctEnvs = [];
+    private LogFilters _filters = LogFilters.Empty;
 
     protected override void OnInitialized()
     {
@@ -66,6 +87,16 @@ else if (Model != null)
 
     [CascadingParameter]
     private LogNavigationOptions _cascadedNavOptions { get; set; }
+
+    [CascadingParameter(Name = "ApplicationAliasMap")]
+    private IReadOnlyDictionary<string, string> _aliasMap { get; set; }
+
+    [CascadingParameter(Name = "FilterStorageScope")]
+    private string _storageScope { get; set; }
+
+    private string FilterStorageKey => string.IsNullOrEmpty(_storageScope)
+        ? null
+        : $"Quilt4Net.Log.Filters.{_storageScope}.search";
 
     private LogNavigationOptions NavOptions => _cascadedNavOptions ?? new LogNavigationOptions();
 
@@ -86,8 +117,60 @@ else if (Model != null)
         var searchText = _searchText ?? string.Empty;
         Model = await _ais.SearchAsync(Context, Environment, searchText, Range).ToArrayAsync();
 
+        RecomputeDistincts();
+        ApplyFilters();
+
         _loading = false;
         StateHasChanged();
+    }
+
+    private Task OnFiltersChanged(LogFilters next)
+    {
+        _filters = next;
+        ApplyFilters();
+        return Task.CompletedTask;
+    }
+
+    private void RecomputeDistincts()
+    {
+        if (Model == null) { _distinctApps = []; _distinctEnvs = []; return; }
+        _distinctApps = Model
+            .Select(x => Resolve(x.Application))
+            .Where(x => !string.IsNullOrEmpty(x))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .OrderBy(x => x, StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+        _distinctEnvs = Model
+            .Select(x => x.Environment ?? string.Empty)
+            .Where(x => !string.IsNullOrEmpty(x))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .OrderBy(x => x, StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+    }
+
+    private void ApplyFilters()
+    {
+        if (Model == null) { _filtered = []; return; }
+        _filtered = Model
+            .Where(x =>
+                _filters.MatchesSource(x.Source)
+                && _filters.MatchesLevel(x.SeverityLevel)
+                && _filters.MatchesApplication(Resolve(x.Application))
+                && _filters.MatchesEnvironment(x.Environment))
+            .ToArray();
+        StateHasChanged();
+    }
+
+    private string Resolve(string raw)
+    {
+        if (string.IsNullOrEmpty(raw)) return string.Empty;
+        return _aliasMap is { Count: > 0 } map ? map.GetValueOrDefault(raw, raw) : raw;
+    }
+
+    private Task SearchByCorrelationIdAsync(string correlationId)
+    {
+        _searchText = correlationId;
+        return Search();
     }
 
     private async Task OpenDetailAsync(string id, LogSource source)

--- a/Quilt4Net.Toolkit.Blazor/Features/Log/LogSearchView.razor
+++ b/Quilt4Net.Toolkit.Blazor/Features/Log/LogSearchView.razor
@@ -40,7 +40,9 @@ else if (Model != null)
             <RadzenDataGridColumn Title="Source" Property="@nameof(LogItem.Source)" />
             <RadzenDataGridColumn Title="Level" Property="@nameof(LogItem.SeverityLevel)" />
             <RadzenDataGridColumn Title="Message" Property="@nameof(LogItem.Message)" />
-            <RadzenDataGridColumn Title="Application" Property="@nameof(LogItem.Application)" />
+            <RadzenDataGridColumn Title="Application" Property="@nameof(LogItem.Application)">
+                <Template><ApplicationName Raw="@context.Application" /></Template>
+            </RadzenDataGridColumn>
             <RadzenDataGridColumn Title="Environment" Property="@nameof(LogItem.Environment)" />
         </Columns>
     </RadzenDataGrid>

--- a/Quilt4Net.Toolkit.Blazor/Features/Log/LogSearchView.razor
+++ b/Quilt4Net.Toolkit.Blazor/Features/Log/LogSearchView.razor
@@ -1,5 +1,4 @@
 ﻿@using Quilt4Net.Toolkit.Features.ApplicationInsights
-@using Tharga.Blazor
 @inject IServiceProvider ServiceProvider
 @inject DialogService DialogService
 @inject NavigationManager NavigationManager

--- a/Quilt4Net.Toolkit.Blazor/Features/Log/LogSummaryContent.razor
+++ b/Quilt4Net.Toolkit.Blazor/Features/Log/LogSummaryContent.razor
@@ -33,6 +33,8 @@ else
             <RadzenText Text="Level" TextStyle="TextStyle.Caption" />
             <RadzenText Text="@($"{Model.SeverityLevel}")" />
         </RadzenColumn>
+        <RadzenColumn>
+        </RadzenColumn>
     </RadzenRow>
     <RadzenRow>
         <RadzenColumn>
@@ -41,7 +43,7 @@ else
         </RadzenColumn>
         <RadzenColumn>
             <RadzenText Text="Application" TextStyle="TextStyle.Caption" />
-            <RadzenText Text="@Model.Application" />
+            <div><ApplicationName Raw="@Model.Application" /></div>
         </RadzenColumn>
         <RadzenColumn>
             <RadzenText Text="Source" TextStyle="TextStyle.Caption" />

--- a/Quilt4Net.Toolkit.Blazor/Features/Log/LogSummaryListView.razor
+++ b/Quilt4Net.Toolkit.Blazor/Features/Log/LogSummaryListView.razor
@@ -34,7 +34,9 @@ else
             <RadzenDataGridColumn Title="Source" Property="@nameof(SummarySubset.Source)"/>
             <RadzenDataGridColumn Title="Level" Property="@nameof(SummarySubset.SeverityLevel)"/>
             <RadzenDataGridColumn Title="Message" Property="@nameof(SummarySubset.Message)"/>
-            <RadzenDataGridColumn Title="Application" Property="@nameof(SummarySubset.Application)"/>
+            <RadzenDataGridColumn Title="Application" Property="@nameof(SummarySubset.Application)">
+                <Template><ApplicationName Raw="@context.Application" /></Template>
+            </RadzenDataGridColumn>
             <RadzenDataGridColumn Title="Environment" Property="@nameof(SummarySubset.Environment)"/>
         </Columns>
     </RadzenDataGrid>

--- a/Quilt4Net.Toolkit.Blazor/Features/Log/LogSummaryListView.razor
+++ b/Quilt4Net.Toolkit.Blazor/Features/Log/LogSummaryListView.razor
@@ -1,4 +1,4 @@
-﻿@using Quilt4Net.Toolkit.Features.ApplicationInsights
+@using Quilt4Net.Toolkit.Features.ApplicationInsights
 @inject IServiceProvider ServiceProvider
 @inject DialogService DialogService
 @inject NavigationManager NavigationManager
@@ -13,9 +13,11 @@ else if (Model == null)
 }
 else
 {
-    <RadzenDataGrid Data="Model" TItem="SummarySubset"
-                    AllowSorting="true"
-                    AllowFiltering="true" FilterMode="FilterMode.Simple" FilterCaseSensitivity="FilterCaseSensitivity.CaseInsensitive"
+    <LogFilterBar Applications="@_distinctApps" Environments="@_distinctEnvs"
+                  StorageKey="@FilterStorageKey" OnChanged="OnFiltersChanged" />
+
+    <RadzenDataGrid Data="@_filtered" TItem="SummarySubset"
+                    AllowSorting="true" AllowFiltering="false"
                     AllowPaging="true" PageSize="8" PageSizeOptions="[8, 16, 32, 64]"
                     ShowPagingSummary="true" PagingSummaryFormat="{2:N0} summary items, page {0} of {1}">
         <Columns>
@@ -25,12 +27,12 @@ else
                                   Click="@(() => OpenSummaryAsync(context.Fingerprint, context.Source))" />
                 </Template>
             </RadzenDataGridColumn>
-            <RadzenDataGridColumn Title="Last Time" Property="@nameof(SummarySubset.LastTimeGenerated)" Filterable="false">
+            <RadzenDataGridColumn Title="Last Time" Property="@nameof(SummarySubset.LastTimeGenerated)">
                 <Template>
                     <DateTimeView Date="@context.LastTimeGenerated"/>
                 </Template>
             </RadzenDataGridColumn>
-            <RadzenDataGridColumn Title="Count" Property="@nameof(SummarySubset.Count)" SortOrder="SortOrder.Descending" Filterable="false" />
+            <RadzenDataGridColumn Title="Count" Property="@nameof(SummarySubset.Count)" SortOrder="SortOrder.Descending" />
             <RadzenDataGridColumn Title="Source" Property="@nameof(SummarySubset.Source)"/>
             <RadzenDataGridColumn Title="Level" Property="@nameof(SummarySubset.SeverityLevel)"/>
             <RadzenDataGridColumn Title="Message" Property="@nameof(SummarySubset.Message)"/>
@@ -44,6 +46,10 @@ else
 
 @code {
     private SummarySubset[] Model { get; set; }
+    private SummarySubset[] _filtered = [];
+    private string[] _distinctApps = [];
+    private string[] _distinctEnvs = [];
+    private LogFilters _filters = LogFilters.Empty;
     private string _configError;
     private IApplicationInsightsService _ais;
 
@@ -58,6 +64,16 @@ else
 
     [CascadingParameter]
     private LogNavigationOptions _cascadedNavOptions { get; set; }
+
+    [CascadingParameter(Name = "ApplicationAliasMap")]
+    private IReadOnlyDictionary<string, string> _aliasMap { get; set; }
+
+    [CascadingParameter(Name = "FilterStorageScope")]
+    private string _storageScope { get; set; }
+
+    private string FilterStorageKey => string.IsNullOrEmpty(_storageScope)
+        ? null
+        : $"Quilt4Net.Log.Filters.{_storageScope}.summary";
 
     private LogNavigationOptions NavOptions => _cascadedNavOptions ?? new LogNavigationOptions();
 
@@ -78,6 +94,57 @@ else
         Model = await _ais
             .GetSummaries(Context, Environment, Range)
             .ToArrayAsync();
+
+        RecomputeDistincts();
+        ApplyFilters();
+    }
+
+    private Task OnFiltersChanged(LogFilters next)
+    {
+        _filters = next;
+        ApplyFilters();
+        return Task.CompletedTask;
+    }
+
+    private void RecomputeDistincts()
+    {
+        if (Model == null)
+        {
+            _distinctApps = [];
+            _distinctEnvs = [];
+            return;
+        }
+        _distinctApps = Model
+            .Select(x => Resolve(x.Application))
+            .Where(x => !string.IsNullOrEmpty(x))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .OrderBy(x => x, StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+        _distinctEnvs = Model
+            .Select(x => x.Environment ?? string.Empty)
+            .Where(x => !string.IsNullOrEmpty(x))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .OrderBy(x => x, StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+    }
+
+    private void ApplyFilters()
+    {
+        if (Model == null) { _filtered = []; return; }
+        _filtered = Model
+            .Where(x =>
+                _filters.MatchesSource(x.Source)
+                && _filters.MatchesLevel(x.SeverityLevel)
+                && _filters.MatchesApplication(Resolve(x.Application))
+                && _filters.MatchesEnvironment(x.Environment))
+            .ToArray();
+        StateHasChanged();
+    }
+
+    private string Resolve(string raw)
+    {
+        if (string.IsNullOrEmpty(raw)) return string.Empty;
+        return _aliasMap is { Count: > 0 } map ? map.GetValueOrDefault(raw, raw) : raw;
     }
 
     private async Task OpenSummaryAsync(string fingerprint, LogSource source)

--- a/Quilt4Net.Toolkit.Blazor/Features/Log/LogSummaryView.razor
+++ b/Quilt4Net.Toolkit.Blazor/Features/Log/LogSummaryView.razor
@@ -8,11 +8,13 @@
 {
     <CascadingValue Value="_navOptions">
         <CascadingValue Name="ApplicationAliasMap" Value="@_effectiveAliasMap">
-            <LogSummaryContent Fingerprint="@Fingerprint"
-                               Environment="@_params.Environment"
-                               Range="@_params.GetRange()"
-                               Source="@_params.GetSource()"
-                               Context="@_params.GetContext()" />
+            <CascadingValue Name="SourcePathRoots" Value="@SourcePathRoots">
+                <LogSummaryContent Fingerprint="@Fingerprint"
+                                   Environment="@_params.Environment"
+                                   Range="@_params.GetRange()"
+                                   Source="@_params.GetSource()"
+                                   Context="@_params.GetContext()" />
+            </CascadingValue>
         </CascadingValue>
     </CascadingValue>
 }
@@ -50,6 +52,14 @@
     /// </summary>
     [Parameter]
     public IReadOnlyDictionary<string, string> ApplicationAliasMap { get; set; }
+
+    /// <summary>
+    /// Project / repository folder names that mark the boundary used to shorten file paths
+    /// in the Stack Trace tab of the embedded LogDetailContent. See
+    /// <c>LogView.SourcePathRoots</c> for the full description.
+    /// </summary>
+    [Parameter]
+    public string[] SourcePathRoots { get; set; }
 
     protected override void OnParametersSet()
     {

--- a/Quilt4Net.Toolkit.Blazor/Features/Log/LogSummaryView.razor
+++ b/Quilt4Net.Toolkit.Blazor/Features/Log/LogSummaryView.razor
@@ -1,19 +1,26 @@
+@using Microsoft.Extensions.DependencyInjection
+@using Microsoft.Extensions.Options
+@using Quilt4Net.Toolkit
 @using Quilt4Net.Toolkit.Features.ApplicationInsights
+@inject IServiceProvider ServiceProvider
 
 @if (_params != null && _params.GetSource().HasValue && _params.GetRange() != TimeSpan.Zero)
 {
     <CascadingValue Value="_navOptions">
-        <LogSummaryContent Fingerprint="@Fingerprint"
-                           Environment="@_params.Environment"
-                           Range="@_params.GetRange()"
-                           Source="@_params.GetSource()"
-                           Context="@_params.GetContext()" />
+        <CascadingValue Name="ApplicationAliasMap" Value="@_effectiveAliasMap">
+            <LogSummaryContent Fingerprint="@Fingerprint"
+                               Environment="@_params.Environment"
+                               Range="@_params.GetRange()"
+                               Source="@_params.GetSource()"
+                               Context="@_params.GetContext()" />
+        </CascadingValue>
     </CascadingValue>
 }
 
 @code {
     private LogNavParams _params;
     private LogNavigationOptions _navOptions;
+    private IReadOnlyDictionary<string, string> _effectiveAliasMap;
 
     /// <summary>
     /// The fingerprint identifying the log summary group.
@@ -36,6 +43,14 @@
     [Parameter]
     public string DetailPath { get; set; }
 
+    /// <summary>
+    /// Optional <c>raw → logical</c> application alias map applied to Application cells in
+    /// the embedded summary view. When null, the toolkit falls back to the static map
+    /// configured via <see cref="ApplicationInsightsOptions.ApplicationAlias"/>.
+    /// </summary>
+    [Parameter]
+    public IReadOnlyDictionary<string, string> ApplicationAliasMap { get; set; }
+
     protected override void OnParametersSet()
     {
         _params = LogNavParams.Decode(Params);
@@ -43,5 +58,12 @@
         {
             DetailPath = DetailPath
         };
+        _effectiveAliasMap = ApplicationAliasMap ?? ResolveStaticMap();
+    }
+
+    private IReadOnlyDictionary<string, string> ResolveStaticMap()
+    {
+        var options = ServiceProvider.GetService<IOptions<ApplicationInsightsOptions>>()?.Value;
+        return options?.ApplicationAlias?.ToResolverDictionary();
     }
 }

--- a/Quilt4Net.Toolkit.Blazor/Features/Log/LogTriggerView.razor
+++ b/Quilt4Net.Toolkit.Blazor/Features/Log/LogTriggerView.razor
@@ -1,21 +1,36 @@
-﻿@using Microsoft.AspNetCore.Components.Web
+@using Microsoft.AspNetCore.Components.Web
 @using Microsoft.Extensions.Logging
 @using Quilt4Net.Toolkit.Features.ApplicationInsights
+@using Tharga.Blazor
 @inject ILogger<LogTriggerView> Logger
 @inject NotificationService NotificationService
 
-<RadzenDropDown Data="@_levels"
-                @bind-Value="_level"
-                TextProperty="Text"
-                ValueProperty="Value"
-                Style="width:200px" />
-<RadzenButton Text="Exception" Icon="error_med" Click="ThrowAsync" />
-<RadzenButton Text="Trace" Icon="barefoot" Click="TraceAsync" />
-<br/>
-<RadzenButton Text="Boundary Exception" Icon="error_med" Click="@(e => { throw new InvalidOperationException("Some exception that should be caught byt Error Boundary."); })" Style="margin-top: 6px;" />
+<CustomErrorBoundary>
+    <ChildContent>
+        <RadzenStack Orientation="Orientation.Vertical" Gap="0.75rem">
+            <RadzenStack Orientation="Orientation.Horizontal" AlignItems="AlignItems.Center" Gap="0.5rem">
+                <RadzenText Text="Level" />
+                <RadzenDropDown Data="@_levels" @bind-Value="_level"
+                                TextProperty="Text" ValueProperty="Value" Style="width:200px" />
+            </RadzenStack>
+
+            <RadzenStack Orientation="Orientation.Horizontal" Gap="0.5rem" Wrap="FlexWrap.Wrap">
+                <RadzenButton Text="Log Trace" Icon="barefoot" Click="LogTrace" />
+                <RadzenButton Text="Log Exception (caught)" Icon="error_med" Click="LogException" />
+                <RadzenButton Text="Throw uncaught" Icon="bolt" ButtonStyle="ButtonStyle.Warning" Click="ThrowUncaught" />
+            </RadzenStack>
+
+            <RadzenText TextStyle="TextStyle.Caption">
+                <strong>Log Trace</strong>: writes a regular <code>ILogger.Log({Level})</code> entry.<br />
+                <strong>Log Exception (caught)</strong>: throws inside a try/catch and logs the caught exception at <code>{Level}</code>.<br />
+                <strong>Throw uncaught</strong>: throws and lets the surrounding <code>Tharga.Blazor.CustomErrorBoundary</code> catch it. The boundary mints a fresh GUID, attaches it via <code>BeginScope</code> so it lands in the log entry as <code>customDimensions["CorrelationId"]</code>, and surfaces it in the recovery banner.
+            </RadzenText>
+        </RadzenStack>
+    </ChildContent>
+</CustomErrorBoundary>
 
 @code {
-    private LogLevel _level;
+    private LogLevel _level = LogLevel.Information;
     private readonly IEnumerable<object> _levels = Enum
         .GetValues<LogLevel>()
         .Select(level => new
@@ -27,24 +42,28 @@
     [Parameter]
     public IApplicationInsightsContext Context { get; set; }
 
-    private async Task ThrowAsync(MouseEventArgs arg)
+    private void LogTrace(MouseEventArgs _)
+    {
+        Logger.Log(_level, "Manual test trace at {Level}.", _level);
+        NotificationService.Notify(new NotificationMessage { Severity = NotificationSeverity.Info, Summary = $"Trace logged at {_level}" });
+    }
+
+    private void LogException(MouseEventArgs _)
     {
         try
         {
-            throw new InvalidOperationException("Manual trigger exception.");
+            throw new InvalidOperationException($"Manual test exception at {_level}.");
         }
         catch (Exception e)
         {
             Logger.Log(_level, e, e.Message);
         }
 
-        NotificationService.Notify(new NotificationMessage { Summary = "Logged" });
+        NotificationService.Notify(new NotificationMessage { Severity = NotificationSeverity.Info, Summary = $"Exception logged at {_level}" });
     }
 
-    private async Task TraceAsync(MouseEventArgs arg)
+    private void ThrowUncaught(MouseEventArgs _)
     {
-        Logger.Log(_level, "Manual trigger trace.");
-        NotificationService.Notify(new NotificationMessage { Summary = "Logged" });
+        throw new InvalidOperationException("Uncaught test exception — should be caught by the surrounding Tharga.Blazor.CustomErrorBoundary.");
     }
-
 }

--- a/Quilt4Net.Toolkit.Blazor/Features/Log/LogView.razor
+++ b/Quilt4Net.Toolkit.Blazor/Features/Log/LogView.razor
@@ -18,6 +18,7 @@
 <CascadingValue Value="_navOptions">
 <CascadingValue Name="ApplicationAliasMap" Value="@_effectiveAliasMap">
 <CascadingValue Name="FilterStorageScope" Value="@FilterStorageScope">
+<CascadingValue Name="SourcePathRoots" Value="@SourcePathRoots">
     <RadzenRow Style="margin-bottom: 6px;" Visible="@(ShowRangeSelector || ShowEnvironmentSelector)">
         <RadzenColumn Visible="@ShowRangeSelector">
             <RadzenStack Orientation="Orientation.Vertical" Gap="0">
@@ -61,6 +62,7 @@
             </RadzenAlert>
         </ErrorContent>
     </LoggingErrorBoundary>
+</CascadingValue>
 </CascadingValue>
 </CascadingValue>
 </CascadingValue>
@@ -141,6 +143,17 @@
     /// </summary>
     [Parameter]
     public string FilterStorageScope { get; set; }
+
+    /// <summary>
+    /// Project / repository folder names used to shorten file paths in the LogDetailContent
+    /// Stack Trace tab. When a path contains any of these names, everything up to (and
+    /// including) the rightmost match is stripped — leaving a leading-slash relative path
+    /// like <c>\Features\Team\UserService.cs:line 24</c> that Resharper / Rider can resolve
+    /// from any open solution containing that file. Typical Server use:
+    /// <c>SourcePathRoots="@(new[] { "Quilt4Net.Server" })"</c>.
+    /// </summary>
+    [Parameter]
+    public string[] SourcePathRoots { get; set; }
 
     /// <summary>
     /// Fires when the user switches tabs, passing the new tab name (lowercase).

--- a/Quilt4Net.Toolkit.Blazor/Features/Log/LogView.razor
+++ b/Quilt4Net.Toolkit.Blazor/Features/Log/LogView.razor
@@ -17,6 +17,7 @@
 
 <CascadingValue Value="_navOptions">
 <CascadingValue Name="ApplicationAliasMap" Value="@_effectiveAliasMap">
+<CascadingValue Name="FilterStorageScope" Value="@FilterStorageScope">
     <RadzenRow Style="margin-bottom: 6px;" Visible="@(ShowRangeSelector || ShowEnvironmentSelector)">
         <RadzenColumn Visible="@ShowRangeSelector">
             <RadzenStack Orientation="Orientation.Vertical" Gap="0">
@@ -60,6 +61,7 @@
             </RadzenAlert>
         </ErrorContent>
     </LoggingErrorBoundary>
+</CascadingValue>
 </CascadingValue>
 </CascadingValue>
 
@@ -129,6 +131,16 @@
     /// </summary>
     [Parameter]
     public IReadOnlyDictionary<string, string> ApplicationAliasMap { get; set; }
+
+    /// <summary>
+    /// Optional scope key for browser-localStorage persistence of the per-tab filter bar
+    /// state (Source / Level / Application / Environment multi-selects on the Summary
+    /// and Search tabs). When supplied, filter state survives reloads and is keyed under
+    /// <c>Quilt4Net.Log.Filters.{scope}.{tab}</c>. Hosts that want per-team scoping
+    /// (e.g. Quilt4Net.Server) pass the team key. When null, filters reset on reload.
+    /// </summary>
+    [Parameter]
+    public string FilterStorageScope { get; set; }
 
     /// <summary>
     /// Fires when the user switches tabs, passing the new tab name (lowercase).

--- a/Quilt4Net.Toolkit.Blazor/Features/Log/LogView.razor
+++ b/Quilt4Net.Toolkit.Blazor/Features/Log/LogView.razor
@@ -1,6 +1,7 @@
 @using Microsoft.AspNetCore.Components.Web
 @using Microsoft.Extensions.DependencyInjection
 @using Microsoft.Extensions.Options
+@using Quilt4Net.Toolkit
 @using Quilt4Net.Toolkit.Features.ApplicationInsights
 @using Tharga.Blazor.Features.BreadCrumbs
 @inject NavigationManager NavigationManager
@@ -15,6 +16,7 @@
 }
 
 <CascadingValue Value="_navOptions">
+<CascadingValue Name="ApplicationAliasMap" Value="@_effectiveAliasMap">
     <RadzenRow Style="margin-bottom: 6px;" Visible="@(ShowRangeSelector || ShowEnvironmentSelector)">
         <RadzenColumn Visible="@ShowRangeSelector">
             <RadzenStack Orientation="Orientation.Vertical" Gap="0">
@@ -46,7 +48,7 @@
                     <RadzenTabsItem Text="Count">
                         <LogCountView Range="@RangeToUse" Environment="@EnvironmentToUse" Context="Context" />
                     </RadzenTabsItem>
-                    <RadzenTabsItem Text="Trigger" Visible="@(Context == null)">
+                    <RadzenTabsItem Text="Test" Visible="@ShowTestTab">
                         <LogTriggerView Context="Context" />
                     </RadzenTabsItem>
                 </Tabs>
@@ -59,13 +61,15 @@
         </ErrorContent>
     </LoggingErrorBoundary>
 </CascadingValue>
+</CascadingValue>
 
 @code {
-    private static readonly string[] TabNames = ["search", "summary", "measure", "count", "trigger"];
+    private static readonly string[] TabNames = ["search", "summary", "measure", "count", "test"];
 
     private LogRangeSelector.TimeRangeOption _range;
     private EnvironmentOption _environment;
     private LogNavigationOptions _navOptions;
+    private IReadOnlyDictionary<string, string> _effectiveAliasMap;
     private int _tabIndex;
     private string _configError;
     private LoggingErrorBoundary _errorBoundary;
@@ -105,6 +109,26 @@
     /// </summary>
     [Parameter]
     public string Tab { get; set; }
+
+    /// <summary>
+    /// Show the developer-facing "Test" tab that triggers logs / exceptions at every
+    /// <see cref="Microsoft.Extensions.Logging.LogLevel"/> via <c>ILogger</c>, plus an
+    /// uncaught throw caught by a local <see cref="LoggingErrorBoundary"/> so the
+    /// correlation Incident id is visible. Defaults to false so external consumers
+    /// don't expose log-injection controls accidentally; opt in from developer pages.
+    /// </summary>
+    [Parameter]
+    public bool ShowTestTab { get; set; }
+
+    /// <summary>
+    /// Optional <c>raw → logical</c> application alias map applied to every cell that
+    /// renders an Application name across the contained tabs. When supplied, the
+    /// logical name shows with the raw name as a hover tooltip (and a dotted underline
+    /// when they differ). When null, the toolkit falls back to the static map
+    /// configured via <see cref="ApplicationInsightsOptions.ApplicationAlias"/>.
+    /// </summary>
+    [Parameter]
+    public IReadOnlyDictionary<string, string> ApplicationAliasMap { get; set; }
 
     /// <summary>
     /// Fires when the user switches tabs, passing the new tab name (lowercase).
@@ -153,10 +177,18 @@
             SummaryPath = SummaryPath
         };
 
+        _effectiveAliasMap = ApplicationAliasMap ?? ResolveStaticMap();
+
         var idx = Array.IndexOf(TabNames, Tab?.ToLower() ?? string.Empty);
         _tabIndex = idx >= 0 ? idx : 0;
 
         _errorBoundary?.Recover();
+    }
+
+    private IReadOnlyDictionary<string, string> ResolveStaticMap()
+    {
+        var options = ServiceProvider.GetService<IOptions<ApplicationInsightsOptions>>()?.Value;
+        return options?.ApplicationAlias?.ToResolverDictionary();
     }
 
     private async Task OnTabChange(int index)

--- a/Quilt4Net.Toolkit.Blazor/README.md
+++ b/Quilt4Net.Toolkit.Blazor/README.md
@@ -219,16 +219,20 @@ View and search Application Insights logs with the `LogView` component. Requires
 | `SummaryPath` | `null` | Path for the summary page (see below). |
 | `Tab` | `null` | Initially selected tab name (e.g. `"summary"`). Typically bound from a `?tab=` query parameter. |
 | `OnTabChanged` | — | Fires with the new tab name (lowercase) when the user switches tabs. |
+| `ShowTestTab` | `false` | Show the developer-only **Test** tab that triggers logs / exceptions / uncaught throws via `ILogger`. Opt-in so external consumers don't expose log-injection controls accidentally. |
+| `ApplicationAliasMap` | `null` | Optional `raw → logical` dictionary applied to every cell that renders an Application name across the embedded tabs. When null, falls back to `ApplicationInsightsOptions.ApplicationAlias`. See **Application alias rendering** below. |
+| `FilterStorageScope` | `null` | Optional scope key for browser-`localStorage` persistence of the per-tab filter bar selection. When set, state survives reloads under `Quilt4Net.Log.Filters.{scope}.{tab}`. Hosts that want per-team scoping pass the team key. |
+| `SourcePathRoots` | `null` | Project / repository folder names used to shorten file paths on the **Stack Trace** sub-tab in the Detail view. See **Stack Trace + Resharper-friendly file:line** below. |
 
 ### Tabs
 
 | Tab | Description |
 |-----|-------------|
-| **Search** | Free-text search across log entries. |
+| **Search** | Free-text search across log entries. Also surfaces a CorrelationId column with click-to-self-search and a copy button — see **CorrelationId column on Search** below. |
 | **Summary** | Grouped view by error fingerprint with count and last occurrence. |
 | **Measure** | Performance measurements with line charts (elapsed time by action). |
 | **Count** | Log count statistics with column charts. |
-| **Trigger** | Development utility for manually triggering log entries. |
+| **Test** | Opt-in dev utility (set `ShowTestTab="true"`) — triggers traces / exceptions at every `LogLevel`, plus an uncaught throw caught by `Tharga.Blazor.CustomErrorBoundary` so the correlation guid surfaces in `customDimensions["CorrelationId"]` and in the in-page recovery banner. |
 
 ### Navigation
 
@@ -297,9 +301,57 @@ Use `LogDetailView` and `LogSummaryView` to build your own dedicated pages that 
 | `LogDetailView` | `Id` | Log entry ID from the route. |
 | | `Params` | Encoded navigation params from the `p` query string. |
 | | `SummaryPath` | Path to navigate back to the summary page. When null, the fingerprint is shown as plain text. |
+| | `ApplicationAliasMap` | Optional `raw → logical` map (see **Application alias rendering**). |
+| | `SourcePathRoots` | Optional folder names that bound where file paths get stripped (see **Stack Trace + Resharper-friendly file:line**). |
 | `LogSummaryView` | `Fingerprint` | Fingerprint from the route. |
 | | `Params` | Encoded navigation params from the `p` query string. |
 | | `DetailPath` | Path to navigate to a detail page. When null, clicking a row opens an inline detail view. |
+| | `ApplicationAliasMap` | Same as on `LogDetailView`. |
+| | `SourcePathRoots` | Same as on `LogDetailView`. |
+
+### Application alias rendering
+
+The Detail header, the Summary header, and the Application column on the Search / Summary / Count / Measure tabs all render through `<ApplicationName Raw="..." />`. When an `ApplicationAliasMap` is supplied (parameter on `LogView` / `LogDetailView` / `LogSummaryView`, or `ApplicationInsightsOptions.ApplicationAlias` from the core toolkit), each cell shows the logical alias name with the raw `cloud_RoleName` available as a hover tooltip and a dotted underline when they differ. When no map is supplied, the raw name renders as-is.
+
+```razor
+<LogView ApplicationAliasMap="@(new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+    {
+        ["MyApp.Server"] = "myapp-web",
+        ["MyApp.Server.Client"] = "myapp-web"
+    })" />
+```
+
+For per-tenant / per-team alias maps loaded from a database, build the dictionary on the hosting page and pass it. For static maps shared across the whole app, set `ApplicationInsightsOptions.ApplicationAlias` once at startup and the toolkit picks it up automatically (no parameter needed).
+
+### Filter bar (Source / Level / Application / Environment)
+
+The Search and Summary tabs each show a `<LogFilterBar>` above the grid — four `RadzenSelectBar Multi="true"` rows. Source and Level options come from the `LogSource` / `SeverityLevel` enums; Application and Environment options are populated from the loaded data's distinct values (with alias resolution applied to applications). Filtering replaces Radzen's per-column filter inputs.
+
+When `FilterStorageScope` is set on `LogView`, the bar persists each tab's selection to `localStorage` under `Quilt4Net.Log.Filters.{scope}.{tab}` so the user's choices survive page reloads. Pass the team key, the workspace id, or any other identifier that should isolate persistence.
+
+```razor
+<LogView FilterStorageScope="@team.Key" />
+```
+
+> **Filter scope:** Summary applies the bar's selection client-side to the loaded model (cached). Search currently also applies the bar client-side after the existing server-side `text` / `Range` / `Environment` query — pushing the multi-select into KQL is a possible follow-up for very large result sets.
+
+### CorrelationId column on Search
+
+The Search tab renders a 140 px **Correlation** column showing the first 8 characters of the GUID + `…` in a monospace font, with the full guid available on hover and a `Tharga.Blazor.CopyButton` next to it. Clicking the preview re-runs Search with the full guid as the search text, so "show me every entry sharing this correlation id" is one click.
+
+For the column to be populated, your apps must emit the correlation id as a per-record property. `Quilt4Net.Toolkit.Api`'s `CorrelationIdMiddleware` does this automatically via a logging scope; see the Api package README.
+
+### Stack Trace + Resharper-friendly file:line
+
+The Detail view's **Stack Trace** sub-tab parses `AppExceptions.Details[].parsedStack` into a grid: `# / Assembly / Method / File / Line / Copy`. A "Show frames without file/line" toggle hides system / framework frames by default. Per-row CopyButton produces a `:line N`-suffixed path; when `SourcePathRoots` is supplied, the path is shortened so Resharper / Rider can resolve it from any open solution containing the file:
+
+```razor
+<LogView SourcePathRoots="@(new[] { "MyApp.Server" })" />
+```
+
+With that root configured, a frame whose `fileName` is `D:\a\1\s\MyApp.Server\Features\Team\UserService.cs` line 24 yields the clipboard text `\Features\Team\UserService.cs:line 24` — paste-ready into the IDE's "Find file" prompt or a chat / ticket. Without `SourcePathRoots` configured, the column shows just the filename and the copy gives the full path.
+
+The Stack Trace tab is exception-only; trace and request rows show a friendly "no parsed stack trace available" alert.
 
 ### Breadcrumb integration
 

--- a/Quilt4Net.Toolkit.Tests/EnvironmentProjectionTests.cs
+++ b/Quilt4Net.Toolkit.Tests/EnvironmentProjectionTests.cs
@@ -1,0 +1,36 @@
+using FluentAssertions;
+using Quilt4Net.Toolkit.Features.ApplicationInsights;
+using Xunit;
+
+namespace Quilt4Net.Toolkit.Tests;
+
+public class EnvironmentProjectionTests
+{
+    [Fact]
+    public void Reads_OTel_resource_attribute_first()
+    {
+        // AddQuilt4NetLogging emits "deployment.environment" via OpenTelemetry resource
+        // attributes; that path should win when both keys are present.
+        var deploymentIdx = ApplicationInsightsService.EnvironmentProjection.IndexOf("\"deployment.environment\"", System.StringComparison.Ordinal);
+        var aspNetCoreIdx = ApplicationInsightsService.EnvironmentProjection.IndexOf("\"AspNetCoreEnvironment\"", System.StringComparison.Ordinal);
+
+        deploymentIdx.Should().BeGreaterThan(0, "deployment.environment must appear in the projection");
+        aspNetCoreIdx.Should().BeGreaterThan(0, "AspNetCoreEnvironment must appear as a fallback");
+        deploymentIdx.Should().BeLessThan(aspNetCoreIdx, "OTel resource attribute must be coalesced before the legacy key");
+    }
+
+    [Fact]
+    public void Uses_coalesce_so_either_key_resolves_a_value()
+    {
+        ApplicationInsightsService.EnvironmentProjection
+            .Should().StartWith("coalesce(", "the projection must coalesce both keys, not pick only one");
+    }
+
+    [Fact]
+    public void Casts_each_key_to_string_for_safe_KQL_consumption()
+    {
+        ApplicationInsightsService.EnvironmentProjection
+            .Should().Contain("tostring(_p[\"deployment.environment\"])")
+            .And.Contain("tostring(_p[\"AspNetCoreEnvironment\"])");
+    }
+}

--- a/Quilt4Net.Toolkit.Tests/StackFrameParserTests.cs
+++ b/Quilt4Net.Toolkit.Tests/StackFrameParserTests.cs
@@ -1,0 +1,144 @@
+using System.Text.Json;
+using FluentAssertions;
+using Quilt4Net.Toolkit.Features.ApplicationInsights;
+using Xunit;
+
+namespace Quilt4Net.Toolkit.Tests;
+
+public class StackFrameParserTests
+{
+    private const string SampleDetails = @"
+[
+  {
+    ""parsedStack"": [
+      { ""level"": 0, ""method"": ""Quilt4Net.Server.Features.Team.UserService.GetAsync"", ""assembly"": ""Quilt4Net.Server"", ""fileName"": ""D:\\a\\1\\s\\Quilt4Net.Server\\Features\\Team\\UserService.cs"", ""line"": 24 },
+      { ""level"": 1, ""method"": ""System.Threading.Tasks.Task.Run"", ""assembly"": ""System.Private.CoreLib"" }
+    ]
+  }
+]";
+
+    [Fact]
+    public void Parse_returns_empty_when_raw_or_details_is_null()
+    {
+        StackFrameParser.Parse(null).Should().BeEmpty();
+        StackFrameParser.Parse(new Dictionary<string, object>()).Should().BeEmpty();
+        StackFrameParser.Parse(new Dictionary<string, object> { ["Details"] = null }).Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Parse_handles_string_payload_and_extracts_frames()
+    {
+        var raw = new Dictionary<string, object> { ["Details"] = SampleDetails };
+
+        var frames = StackFrameParser.Parse(raw);
+
+        frames.Should().HaveCount(2);
+        frames[0].Level.Should().Be(0);
+        frames[0].Method.Should().Be("Quilt4Net.Server.Features.Team.UserService.GetAsync");
+        frames[0].Assembly.Should().Be("Quilt4Net.Server");
+        frames[0].FileName.Should().Contain("UserService.cs");
+        frames[0].Line.Should().Be(24);
+        frames[0].HasFileLocation.Should().BeTrue();
+        frames[1].HasFileLocation.Should().BeFalse(); // missing fileName + line
+    }
+
+    [Fact]
+    public void Parse_handles_pre_deserialized_JsonElement()
+    {
+        using var doc = JsonDocument.Parse(SampleDetails);
+        var raw = new Dictionary<string, object> { ["Details"] = doc.RootElement };
+
+        var frames = StackFrameParser.Parse(raw);
+
+        frames.Should().HaveCount(2);
+    }
+
+    [Fact]
+    public void Parse_returns_empty_on_malformed_json_string()
+    {
+        var raw = new Dictionary<string, object> { ["Details"] = "{ this is not json" };
+
+        StackFrameParser.Parse(raw).Should().BeEmpty();
+    }
+
+    [Fact]
+    public void ToResharperPath_strips_path_up_to_and_including_a_known_root()
+    {
+        var frame = new StackFrame
+        {
+            FileName = @"D:\a\1\s\Quilt4Net.Server\Features\Team\UserService.cs",
+            Line = 24
+        };
+
+        var result = StackFrameParser.ToResharperPath(frame, ["Quilt4Net.Server"]);
+
+        result.Should().Be(@"\Features\Team\UserService.cs:line 24");
+    }
+
+    [Fact]
+    public void ToResharperPath_works_with_forward_slashes()
+    {
+        var frame = new StackFrame
+        {
+            FileName = "/home/runner/work/quilt4net/quilt4net/Quilt4Net.Server/Features/Team/UserService.cs",
+            Line = 24
+        };
+
+        var result = StackFrameParser.ToResharperPath(frame, ["Quilt4Net.Server"]);
+
+        result.Should().Be(@"\Features\Team\UserService.cs:line 24");
+    }
+
+    [Fact]
+    public void ToResharperPath_returns_full_path_when_no_root_matches()
+    {
+        var frame = new StackFrame
+        {
+            FileName = @"C:\code\OtherProject\Foo.cs",
+            Line = 5
+        };
+
+        var result = StackFrameParser.ToResharperPath(frame, ["Quilt4Net.Server"]);
+
+        result.Should().Be(@"C:\code\OtherProject\Foo.cs:line 5");
+    }
+
+    [Fact]
+    public void ToResharperPath_omits_line_suffix_when_line_is_zero()
+    {
+        var frame = new StackFrame
+        {
+            FileName = @"D:\a\1\s\Quilt4Net.Server\Foo.cs",
+            Line = 0
+        };
+
+        var result = StackFrameParser.ToResharperPath(frame, ["Quilt4Net.Server"]);
+
+        result.Should().Be(@"\Foo.cs");
+    }
+
+    [Fact]
+    public void ToResharperPath_returns_empty_for_a_frame_without_a_filename()
+    {
+        var frame = new StackFrame { FileName = string.Empty, Line = 24 };
+
+        StackFrameParser.ToResharperPath(frame, ["Quilt4Net.Server"]).Should().BeEmpty();
+    }
+
+    [Fact]
+    public void ToResharperPath_uses_the_rightmost_matching_root_when_path_contains_a_collision()
+    {
+        // Pathological: root name appears twice (e.g., a folder structure where the project
+        // name is also the name of an inner folder). Expect the rightmost match wins so the
+        // shortest sensible relative path comes out.
+        var frame = new StackFrame
+        {
+            FileName = @"C:\repos\Quilt4Net.Server\backup\Quilt4Net.Server\Features\Foo.cs",
+            Line = 1
+        };
+
+        var result = StackFrameParser.ToResharperPath(frame, ["Quilt4Net.Server"]);
+
+        result.Should().Be(@"\Features\Foo.cs:line 1");
+    }
+}

--- a/Quilt4Net.Toolkit.Tests/TelemetryIdentityEnrichmentTests.cs
+++ b/Quilt4Net.Toolkit.Tests/TelemetryIdentityEnrichmentTests.cs
@@ -123,11 +123,13 @@ public class TelemetryIdentityEnrichmentTests
         public override void OnEnd(LogRecord data) => _capture(data);
     }
 
-    private sealed class SeedProcessor : BaseProcessor<LogRecord>
+    // The Tests project doesn't enable nullable annotations so we erase to non-nullable
+    // before assigning to LogRecord.Attributes (its declared type uses object? but the
+    // runtime accepts the equivalent non-annotated payload — the cast is safe and the
+    // alternative spelling avoids CS8632 in this project).
+    private sealed class SeedProcessor(IList<KeyValuePair<string, object>> attrs) : BaseProcessor<LogRecord>
     {
-        private readonly IReadOnlyList<KeyValuePair<string, object?>> _attrs;
-        public SeedProcessor(IList<KeyValuePair<string, object>> attrs) =>
-            _attrs = attrs.Select(kv => new KeyValuePair<string, object?>(kv.Key, kv.Value)).ToList();
-        public override void OnEnd(LogRecord data) => data.Attributes = _attrs;
+        public override void OnEnd(LogRecord data)
+            => data.Attributes = (IReadOnlyList<KeyValuePair<string, object>>)attrs;
     }
 }

--- a/Quilt4Net.Toolkit.Tests/TelemetryIdentityEnrichmentTests.cs
+++ b/Quilt4Net.Toolkit.Tests/TelemetryIdentityEnrichmentTests.cs
@@ -1,0 +1,133 @@
+using System.Diagnostics;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using OpenTelemetry;
+using OpenTelemetry.Logs;
+using Quilt4Net.Toolkit.Features.Logging;
+using Xunit;
+
+namespace Quilt4Net.Toolkit.Tests;
+
+public class TelemetryIdentityEnrichmentTests
+{
+    private static readonly TelemetryIdentity FullIdentity = new(
+        Environment: "Production",
+        ApplicationName: "MyApp",
+        Version: "1.2.3",
+        MachineName: "host-42",
+        MonitorName: "Quilt4Net");
+
+    [Fact]
+    public void LogProcessor_attaches_all_five_attributes_to_a_record()
+    {
+        var record = BuildLogRecord();
+
+        new TelemetryIdentityLogProcessor(FullIdentity).OnEnd(record);
+
+        record.Attributes.Should().Contain(new KeyValuePair<string, object>("deployment.environment", "Production"));
+        record.Attributes.Should().Contain(new KeyValuePair<string, object>("service.name", "MyApp"));
+        record.Attributes.Should().Contain(new KeyValuePair<string, object>("service.version", "1.2.3"));
+        record.Attributes.Should().Contain(new KeyValuePair<string, object>("host.name", "host-42"));
+        record.Attributes.Should().Contain(new KeyValuePair<string, object>("quilt4net.monitor", "Quilt4Net"));
+    }
+
+    [Fact]
+    public void LogProcessor_skips_attributes_whose_identity_value_is_empty()
+    {
+        var partial = FullIdentity with { Environment = null, MonitorName = "" };
+        var record = BuildLogRecord();
+
+        new TelemetryIdentityLogProcessor(partial).OnEnd(record);
+
+        record.Attributes.Should().NotContain(kv => kv.Key == "deployment.environment");
+        record.Attributes.Should().NotContain(kv => kv.Key == "quilt4net.monitor");
+        record.Attributes.Should().Contain(kv => kv.Key == "service.name" && kv.Value!.Equals("MyApp"));
+    }
+
+    [Fact]
+    public void LogProcessor_preserves_pre_existing_attributes()
+    {
+        var seed = new List<KeyValuePair<string, object>> { new("custom-key", "custom-value") };
+        var record = BuildLogRecord(seed);
+
+        new TelemetryIdentityLogProcessor(FullIdentity).OnEnd(record);
+
+        record.Attributes.Should().Contain(kv => kv.Key == "custom-key" && kv.Value!.Equals("custom-value"));
+        record.Attributes.Should().Contain(kv => kv.Key == "deployment.environment");
+    }
+
+    [Fact]
+    public void ActivityProcessor_attaches_all_five_tags_to_an_activity()
+    {
+        using var source = new ActivitySource(nameof(TelemetryIdentityEnrichmentTests));
+        using var listener = new ActivityListener
+        {
+            ShouldListenTo = _ => true,
+            Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllData
+        };
+        ActivitySource.AddActivityListener(listener);
+        using var activity = source.StartActivity("test")!;
+
+        new TelemetryIdentityActivityProcessor(FullIdentity).OnEnd(activity);
+
+        activity.GetTagItem("deployment.environment").Should().Be("Production");
+        activity.GetTagItem("service.name").Should().Be("MyApp");
+        activity.GetTagItem("service.version").Should().Be("1.2.3");
+        activity.GetTagItem("host.name").Should().Be("host-42");
+        activity.GetTagItem("quilt4net.monitor").Should().Be("Quilt4Net");
+    }
+
+    [Fact]
+    public void ActivityProcessor_skips_tags_whose_identity_value_is_empty()
+    {
+        using var source = new ActivitySource(nameof(TelemetryIdentityEnrichmentTests));
+        using var listener = new ActivityListener
+        {
+            ShouldListenTo = _ => true,
+            Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllData
+        };
+        ActivitySource.AddActivityListener(listener);
+        using var activity = source.StartActivity("test")!;
+
+        var partial = FullIdentity with { Environment = null, MonitorName = "" };
+        new TelemetryIdentityActivityProcessor(partial).OnEnd(activity);
+
+        activity.GetTagItem("deployment.environment").Should().BeNull();
+        activity.GetTagItem("quilt4net.monitor").Should().BeNull();
+        activity.GetTagItem("service.name").Should().Be("MyApp");
+    }
+
+    /// <summary>
+    /// LogRecord has no public constructor — emit a real one through the OTel SDK pipeline
+    /// and capture the post-enrichment state so the test can assert on attributes.
+    /// </summary>
+    private static LogRecord BuildLogRecord(IList<KeyValuePair<string, object>> seedAttributes = null)
+    {
+        LogRecord captured = null!;
+        using var loggerFactory = LoggerFactory.Create(b =>
+        {
+            b.AddOpenTelemetry(o =>
+            {
+                if (seedAttributes != null) o.AddProcessor(new SeedProcessor(seedAttributes));
+                o.AddProcessor(new CaptureProcessor(r => captured = r));
+            });
+        });
+        loggerFactory.CreateLogger("test").LogInformation("hello");
+        return captured;
+    }
+
+    private sealed class CaptureProcessor : BaseProcessor<LogRecord>
+    {
+        private readonly Action<LogRecord> _capture;
+        public CaptureProcessor(Action<LogRecord> capture) => _capture = capture;
+        public override void OnEnd(LogRecord data) => _capture(data);
+    }
+
+    private sealed class SeedProcessor : BaseProcessor<LogRecord>
+    {
+        private readonly IReadOnlyList<KeyValuePair<string, object?>> _attrs;
+        public SeedProcessor(IList<KeyValuePair<string, object>> attrs) =>
+            _attrs = attrs.Select(kv => new KeyValuePair<string, object?>(kv.Key, kv.Value)).ToList();
+        public override void OnEnd(LogRecord data) => data.Attributes = _attrs;
+    }
+}

--- a/Quilt4Net.Toolkit/Features/ApplicationInsights/ApplicationAliasMap.cs
+++ b/Quilt4Net.Toolkit/Features/ApplicationInsights/ApplicationAliasMap.cs
@@ -3,7 +3,8 @@ namespace Quilt4Net.Toolkit.Features.ApplicationInsights;
 /// <summary>
 /// Static map entry for grouping multiple raw application names (cloud_RoleName)
 /// under one logical name. Configured via <see cref="ApplicationInsightsOptions.ApplicationAlias"/>;
-/// applied by <see cref="VersionMatrixDisplay"/> when no per-component AliasFolder is supplied.
+/// applied by <c>VersionMatrixDisplay</c> (in <c>Quilt4Net.Toolkit.Blazor</c>) when no
+/// per-component <c>AliasFolder</c> delegate is supplied.
 /// </summary>
 public sealed record ApplicationAliasMap
 {

--- a/Quilt4Net.Toolkit/Features/ApplicationInsights/ApplicationAliasMapExtensions.cs
+++ b/Quilt4Net.Toolkit/Features/ApplicationInsights/ApplicationAliasMapExtensions.cs
@@ -1,0 +1,25 @@
+namespace Quilt4Net.Toolkit.Features.ApplicationInsights;
+
+public static class ApplicationAliasMapExtensions
+{
+    /// <summary>
+    /// Flatten an <see cref="ApplicationAliasMap"/> list into a case-insensitive
+    /// <c>raw → logical</c> dictionary suitable for per-row alias resolution in log
+    /// views (where rows are not folded together — each row's raw application name
+    /// just needs to be displayed under its logical name).
+    /// </summary>
+    public static IReadOnlyDictionary<string, string> ToResolverDictionary(this IReadOnlyList<ApplicationAliasMap> aliases)
+    {
+        var dict = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        if (aliases is null) return dict;
+        foreach (var alias in aliases)
+        {
+            if (string.IsNullOrEmpty(alias?.LogicalName)) continue;
+            foreach (var src in alias.SourceNames ?? [])
+            {
+                if (!string.IsNullOrWhiteSpace(src)) dict[src] = alias.LogicalName;
+            }
+        }
+        return dict;
+    }
+}

--- a/Quilt4Net.Toolkit/Features/ApplicationInsights/ApplicationInsightsService.cs
+++ b/Quilt4Net.Toolkit/Features/ApplicationInsights/ApplicationInsightsService.cs
@@ -13,6 +13,15 @@ namespace Quilt4Net.Toolkit.Features.ApplicationInsights;
 
 internal class ApplicationInsightsService : IApplicationInsightsService
 {
+    /// <summary>
+    /// Canonical KQL fragment for projecting the Environment column from any AppTraces /
+    /// AppExceptions / AppRequests row. Reads OTel resource attribute first (what
+    /// <c>AddQuilt4NetLogging</c> emits), then the legacy <c>AspNetCoreEnvironment</c>
+    /// scope tag. Centralised so all log queries stay in sync.
+    /// </summary>
+    internal const string EnvironmentProjection =
+        "coalesce(tostring(_p[\"deployment.environment\"]), tostring(_p[\"AspNetCoreEnvironment\"]))";
+
     private static readonly LogsQueryOptions _probeOptions = new() { ServerTimeout = TimeSpan.FromSeconds(5) };
     private readonly ConcurrentDictionary<ClientKey, LogsQueryClient> _clientCache = new();
     private readonly ITimeToLiveCache _timeToLiveCache;
@@ -95,22 +104,22 @@ internal class ApplicationInsightsService : IApplicationInsightsService
         var from = DateTimeOffset.UtcNow.AddDays(-Math.Max(1, lookbackDays));
         var to = DateTimeOffset.UtcNow;
 
-        var query = @"
+        var query = $@"
 union
 (
     AppTraces
     | extend _p = todynamic(Properties)
-    | project Environment = tostring(_p[""AspNetCoreEnvironment""])
+    | project Environment = {EnvironmentProjection}
 ),
 (
     AppExceptions
     | extend _p = todynamic(Properties)
-    | project Environment = tostring(_p[""AspNetCoreEnvironment""])
+    | project Environment = {EnvironmentProjection}
 ),
 (
     AppRequests
     | extend _p = todynamic(Properties)
-    | project Environment = tostring(_p[""AspNetCoreEnvironment""])
+    | project Environment = {EnvironmentProjection}
 )
 | extend Environment = trim(' ', Environment)
 | where isnotempty(Environment)
@@ -204,7 +213,7 @@ AppExceptions
 | extend _p = todynamic(Properties)
 | extend
     CorrelationId = tostring(_p[""CorrelationId""]),
-    Environment = tostring(_p[""AspNetCoreEnvironment""]),
+    Environment = {EnvironmentProjection},
     ApplicationName = coalesce(tostring(_p[""ApplicationName""]), tostring(AppRoleName)),
     Message = tostring(OuterMessage)
 {envFilter}
@@ -263,7 +272,7 @@ AppTraces
 | extend _p = todynamic(Properties)
 | extend
     CorrelationId = tostring(_p[""CorrelationId""]),
-    Environment = tostring(_p[""AspNetCoreEnvironment""]),
+    Environment = {EnvironmentProjection},
     ApplicationName = coalesce(tostring(_p[""ApplicationName""]), tostring(AppRoleName)),
     OriginalFormat = tostring(_p[""OriginalFormat""])
 {envFilter}
@@ -324,7 +333,7 @@ AppRequests
 | extend _p = todynamic(Properties)
 | extend
     CorrelationId = tostring(_p[""CorrelationId""]),
-    Environment = tostring(_p[""AspNetCoreEnvironment""]),
+    Environment = {EnvironmentProjection},
     ApplicationName = coalesce(tostring(_p[""ApplicationName""]), tostring(AppRoleName)),
     Message = tostring(Name)
 {envFilter}
@@ -429,7 +438,7 @@ AppTraces
 | extend
     Action = tostring(_p[""Action""]),
     ApplicationName = coalesce(tostring(_p[""ApplicationName""]), tostring(AppRoleName)),
-    Environment = trim(' ', tostring(_p[""AspNetCoreEnvironment""])),
+    Environment = trim(' ', {EnvironmentProjection}),
     OriginalFormat = trim(' ', tostring(_p[""OriginalFormat""])),
     ElapsedRaw = extract(@""in ([0-9:\.]+) ms"", 1, tostring(Message))
 {envFilter}
@@ -536,7 +545,7 @@ AppTraces
 | extend
     Action = tostring(_p[""Action""]),
     ApplicationName = coalesce(tostring(_p[""ApplicationName""]), tostring(AppRoleName)),
-    Environment = trim(' ', tostring(_p[""AspNetCoreEnvironment""])),
+    Environment = trim(' ', {EnvironmentProjection}),
     OriginalFormat = trim(' ', tostring(_p[""OriginalFormat""])),
     CountRaw = tostring(DetailsJson[""Count""])
 {envFilter}
@@ -605,7 +614,7 @@ AppExceptions
 | extend _p = todynamic(Properties)
 | extend
     CorrelationId = tostring(_p[""CorrelationId""]),
-    Environment = tostring(_p[""AspNetCoreEnvironment""]),
+    Environment = {EnvironmentProjection},
     Application = coalesce(tostring(_p[""ApplicationName""]), tostring(AppRoleName)),
     Message = tostring(OuterMessage),
     Fingerprint = base64_encode_tostring(tostring(hash(ProblemId))),
@@ -621,7 +630,7 @@ AppTraces
 | extend
     OriginalFormat = tostring(_p[""OriginalFormat""]),
     CorrelationId = tostring(_p[""CorrelationId""]),
-    Environment = tostring(_p[""AspNetCoreEnvironment""]),
+    Environment = {EnvironmentProjection},
     Application = coalesce(tostring(_p[""ApplicationName""]), tostring(AppRoleName)),
     Message = tostring(Message),
     SeverityLevel = toint(SeverityLevel),
@@ -637,7 +646,7 @@ AppRequests
 | extend _p = todynamic(Properties)
 | extend
     CorrelationId = tostring(_p[""CorrelationId""]),
-    Environment = tostring(_p[""AspNetCoreEnvironment""]),
+    Environment = {EnvironmentProjection},
     Application = coalesce(tostring(_p[""ApplicationName""]), tostring(AppRoleName)),
     Message = tostring(Name),
     Fingerprint = base64_encode_tostring(tostring(hash(Name))),
@@ -726,7 +735,7 @@ AppExceptions
 | extend
     Fingerprint = base64_encode_tostring(tostring(hash(ProblemId))),
     Message = tostring(OuterMessage),
-    Environment = tostring(_p[""AspNetCoreEnvironment""]),
+    Environment = {EnvironmentProjection},
     Application = coalesce(tostring(_p[""ApplicationName""]), tostring(AppRoleName)),
     Id = _ItemId
 | where Fingerprint == ""{fingerprint}""
@@ -739,7 +748,7 @@ AppTraces
 | extend
     OriginalFormat = tostring(_p[""OriginalFormat""]),
     Message = tostring(Message),
-    Environment = tostring(_p[""AspNetCoreEnvironment""]),
+    Environment = {EnvironmentProjection},
     Application = coalesce(tostring(_p[""ApplicationName""]), tostring(AppRoleName)),
     Id = _ItemId
 | extend
@@ -756,7 +765,7 @@ AppRequests
 | extend
     Message = tostring(Name),
     Fingerprint = base64_encode_tostring(tostring(hash(Name))),
-    Environment = tostring(_p[""AspNetCoreEnvironment""]),
+    Environment = {EnvironmentProjection},
     Application = coalesce(tostring(_p[""ApplicationName""]), tostring(AppRoleName)),
     SeverityLevel = iif(tobool(Success), 1, 3),
     Id = _ItemId
@@ -851,7 +860,7 @@ AppExceptions
     TimeGenerated,
     Fingerprint = base64_encode_tostring(tostring(hash(ProblemId))),
     Message = tostring(OuterMessage),
-    Environment = trim(' ', tostring(_p[""AspNetCoreEnvironment""])),
+    Environment = trim(' ', {EnvironmentProjection}),
     Application = coalesce(tostring(_p[""ApplicationName""]), tostring(AppRoleName)),
     SeverityLevel = toint(SeverityLevel)
 {envFilter}
@@ -870,7 +879,7 @@ AppTraces
     TimeGenerated,
     Fingerprint = base64_encode_tostring(tostring(hash(FingerprintSource))),
     Message = tostring(Message),
-    Environment = trim(' ', tostring(_p[""AspNetCoreEnvironment""])),
+    Environment = trim(' ', {EnvironmentProjection}),
     Application = coalesce(tostring(_p[""ApplicationName""]), tostring(AppRoleName)),
     SeverityLevel = toint(SeverityLevel)
 {envFilter}
@@ -887,7 +896,7 @@ AppRequests
     TimeGenerated,
     Fingerprint = base64_encode_tostring(tostring(hash(Name))),
     Message = tostring(Name),
-    Environment = trim(' ', tostring(_p[""AspNetCoreEnvironment""])),
+    Environment = trim(' ', {EnvironmentProjection}),
     Application = coalesce(tostring(_p[""ApplicationName""]), tostring(AppRoleName)),
     SeverityLevel = iif(tobool(coalesce(Success, true)), 1, 3)
 {envFilter}
@@ -968,7 +977,7 @@ AppRequests
         var client = GetClient(context);
         var workspaceId = context?.WorkspaceId ?? _options.WorkspaceId;
 
-        var query = @"
+        var query = $@"
 let startup = AppTraces
 | extend _p = todynamic(Properties)
 | where tostring(_p[""Quilt4NetStartup""]) == ""true""
@@ -982,7 +991,7 @@ let fallback = union AppTraces, AppExceptions, AppRequests
 | extend _p = todynamic(Properties)
 | extend
     ApplicationName = coalesce(tostring(_p[""ApplicationName""]), tostring(AppRoleName)),
-    Environment = coalesce(tostring(_p[""AspNetCoreEnvironment""]), tostring(_p[""deployment.environment""])),
+    Environment = {EnvironmentProjection},
     Version = coalesce(tostring(_p[""application_Version""]), tostring(_p[""service.version""]), tostring(AppVersion))
 | where isnotempty(ApplicationName) and isnotempty(Version)
 | project TimeGenerated, ApplicationName, Environment, Version, Source = ""Log"";
@@ -1045,7 +1054,7 @@ union withsource=_Source AppTraces, AppExceptions, AppRequests
 | extend _p = todynamic(Properties)
 | where {wherePredicate}
 | extend
-    Environment = tostring(_p[""AspNetCoreEnvironment""]),
+    Environment = {EnvironmentProjection},
     Application = coalesce(tostring(_p[""ApplicationName""]), tostring(AppRoleName)),
     Message = coalesce(tostring(Message), tostring(OuterMessage), tostring(Name)),
     FingerprintSource = coalesce(tostring(ProblemId), tostring(_p[""OriginalFormat""]), tostring(Message), tostring(Name)),

--- a/Quilt4Net.Toolkit/Features/ApplicationInsights/ApplicationInsightsService.cs
+++ b/Quilt4Net.Toolkit/Features/ApplicationInsights/ApplicationInsightsService.cs
@@ -1,6 +1,5 @@
 ﻿using System.Collections.Concurrent;
 using System.Diagnostics;
-using Azure.Identity;
 using Azure.Monitor.Query.Logs;
 using Azure.Monitor.Query.Logs.Models;
 using Microsoft.Extensions.Logging;
@@ -21,6 +20,15 @@ internal class ApplicationInsightsService : IApplicationInsightsService
     /// </summary>
     internal const string EnvironmentProjection =
         "coalesce(tostring(_p[\"deployment.environment\"]), tostring(_p[\"AspNetCoreEnvironment\"]))";
+
+    /// <summary>
+    /// Canonical KQL fragment for projecting the Version column from any AppTraces /
+    /// AppExceptions / AppRequests row. Reads OTel attribute first (what the per-record
+    /// processor in <c>AddQuilt4NetLogging</c> writes), then a legacy <c>Version</c>
+    /// scope key, then the AI built-in <c>AppVersion</c> column.
+    /// </summary>
+    internal const string VersionProjection =
+        "coalesce(tostring(_p[\"service.version\"]), tostring(_p[\"Version\"]), tostring(AppVersion))";
 
     private static readonly LogsQueryOptions _probeOptions = new() { ServerTimeout = TimeSpan.FromSeconds(5) };
     private readonly ConcurrentDictionary<ClientKey, LogsQueryClient> _clientCache = new();
@@ -616,11 +624,12 @@ AppExceptions
     CorrelationId = tostring(_p[""CorrelationId""]),
     Environment = {EnvironmentProjection},
     Application = coalesce(tostring(_p[""ApplicationName""]), tostring(AppRoleName)),
+    Version = {VersionProjection},
     Message = tostring(OuterMessage),
     Fingerprint = base64_encode_tostring(tostring(hash(ProblemId))),
     SeverityLevel = toint(SeverityLevel),
     Raw = pack_all()
-| project TimeGenerated, Message, Environment, Application, Fingerprint, SeverityLevel, CorrelationId, Raw
+| project TimeGenerated, Message, Environment, Application, Version, Fingerprint, SeverityLevel, CorrelationId, Raw
 | take 1",
 
             LogSource.Trace => $@"
@@ -632,12 +641,13 @@ AppTraces
     CorrelationId = tostring(_p[""CorrelationId""]),
     Environment = {EnvironmentProjection},
     Application = coalesce(tostring(_p[""ApplicationName""]), tostring(AppRoleName)),
+    Version = {VersionProjection},
     Message = tostring(Message),
     SeverityLevel = toint(SeverityLevel),
     Raw = pack_all()
 | extend
     Fingerprint = base64_encode_tostring(tostring(hash(OriginalFormat)))
-| project TimeGenerated, Message, Environment, Application, Fingerprint, SeverityLevel, CorrelationId, Raw
+| project TimeGenerated, Message, Environment, Application, Version, Fingerprint, SeverityLevel, CorrelationId, Raw
 | take 1",
 
             LogSource.Request => $@"
@@ -648,11 +658,12 @@ AppRequests
     CorrelationId = tostring(_p[""CorrelationId""]),
     Environment = {EnvironmentProjection},
     Application = coalesce(tostring(_p[""ApplicationName""]), tostring(AppRoleName)),
+    Version = {VersionProjection},
     Message = tostring(Name),
     Fingerprint = base64_encode_tostring(tostring(hash(Name))),
     SeverityLevel = iif(tobool(Success), 1, 3),
     Raw = pack_all()
-| project TimeGenerated, Message, Environment, Application, Fingerprint, SeverityLevel, CorrelationId, Raw
+| project TimeGenerated, Message, Environment, Application, Version, Fingerprint, SeverityLevel, CorrelationId, Raw
 | take 1",
 
             _ => throw new ArgumentOutOfRangeException(nameof(source))
@@ -676,6 +687,7 @@ AppRequests
         var messageIndex = GetColumnIndex(table, "Message");
         var envIndex = GetColumnIndex(table, "Environment");
         var appIndex = GetColumnIndex(table, "Application");
+        var versionIndex = GetColumnIndex(table, "Version");
         var fpIndex = GetColumnIndex(table, "Fingerprint");
         var severityIndex = GetColumnIndex(table, "SeverityLevel");
         var correlationIndex = GetColumnIndex(table, "CorrelationId");
@@ -706,6 +718,7 @@ AppRequests
             Source = source,
             SeverityLevel = (SeverityLevel)GetInt(row, severityIndex),
             CorrelationId = row[correlationIndex]?.ToString() ?? string.Empty,
+            Version = row[versionIndex]?.ToString() ?? string.Empty,
             Fingerprint = row[fpIndex]?.ToString()!,
             TimeGenerated = GetDateTime(row, timeIndex),
             Message = row[messageIndex]?.ToString()!,

--- a/Quilt4Net.Toolkit/Features/ApplicationInsights/ApplicationInsightsService.cs
+++ b/Quilt4Net.Toolkit/Features/ApplicationInsights/ApplicationInsightsService.cs
@@ -238,6 +238,7 @@ AppExceptions
     SeverityLevel,
     Id,
     Fingerprint,
+    CorrelationId,
     OperationId
 | order by TimeGenerated desc";
 
@@ -255,6 +256,7 @@ AppExceptions
             var messageIndex = GetColumnIndex(table, "Message");
             var environmentIndex = GetColumnIndex(table, "Environment");
             var applicationIndex = GetColumnIndex(table, "ApplicationName");
+            var correlationIndex = GetColumnIndex(table, "CorrelationId");
 
             foreach (var row in table.Rows)
             {
@@ -267,7 +269,8 @@ AppExceptions
                     SeverityLevel = (SeverityLevel)GetInt(row, severityIndex),
                     Message = row[messageIndex]?.ToString(),
                     Environment = row[environmentIndex]?.ToString(),
-                    Application = row[applicationIndex]?.ToString()
+                    Application = row[applicationIndex]?.ToString(),
+                    CorrelationId = row[correlationIndex]?.ToString() ?? string.Empty
                 };
             }
         }
@@ -299,6 +302,7 @@ AppTraces
     SeverityLevel,
     Id,
     Fingerprint,
+    CorrelationId,
     OperationId
 | order by TimeGenerated desc";
 
@@ -316,6 +320,7 @@ AppTraces
             var messageIndex = GetColumnIndex(table, "Message");
             var environmentIndex = GetColumnIndex(table, "Environment");
             var applicationIndex = GetColumnIndex(table, "ApplicationName");
+            var correlationIndex = GetColumnIndex(table, "CorrelationId");
 
             foreach (var row in table.Rows)
             {
@@ -328,7 +333,8 @@ AppTraces
                     SeverityLevel = (SeverityLevel)GetInt(row, severityIndex),
                     Message = row[messageIndex]?.ToString(),
                     Environment = row[environmentIndex]?.ToString(),
-                    Application = row[applicationIndex]?.ToString()
+                    Application = row[applicationIndex]?.ToString(),
+                    CorrelationId = row[correlationIndex]?.ToString() ?? string.Empty
                 };
             }
         }
@@ -360,6 +366,7 @@ AppRequests
     SeverityLevel,
     Id,
     Fingerprint,
+    CorrelationId,
     OperationId,
     ResultCode,
     Success
@@ -379,6 +386,7 @@ AppRequests
             var messageIndex = GetColumnIndex(table, "Message");
             var environmentIndex = GetColumnIndex(table, "Environment");
             var applicationIndex = GetColumnIndex(table, "ApplicationName");
+            var correlationIndex = GetColumnIndex(table, "CorrelationId");
 
             foreach (var row in table.Rows)
             {
@@ -391,7 +399,8 @@ AppRequests
                     SeverityLevel = (SeverityLevel)GetInt(row, severityIndex),
                     Message = row[messageIndex]?.ToString(),
                     Environment = row[environmentIndex]?.ToString(),
-                    Application = row[applicationIndex]?.ToString()
+                    Application = row[applicationIndex]?.ToString(),
+                    CorrelationId = row[correlationIndex]?.ToString() ?? string.Empty
                 };
             }
         }

--- a/Quilt4Net.Toolkit/Features/ApplicationInsights/LogDetails.cs
+++ b/Quilt4Net.Toolkit/Features/ApplicationInsights/LogDetails.cs
@@ -5,6 +5,7 @@ public record LogDetails : LogItemBase
     public required LogSource Source { get; init; }
     public required SeverityLevel SeverityLevel { get; init; }
     public required string CorrelationId { get; init; }
+    public required string Version { get; init; }
     public required IReadOnlyDictionary<string, object> Raw { get; init; }
     public required string RawJson { get; init; }
 }

--- a/Quilt4Net.Toolkit/Features/ApplicationInsights/LogDetails.cs
+++ b/Quilt4Net.Toolkit/Features/ApplicationInsights/LogDetails.cs
@@ -4,8 +4,32 @@ public record LogDetails : LogItemBase
 {
     public required LogSource Source { get; init; }
     public required SeverityLevel SeverityLevel { get; init; }
+
+    /// <summary>
+    /// Per-record correlation id read from the row's <c>customDimensions["CorrelationId"]</c>.
+    /// Populated automatically by <c>Quilt4Net.Toolkit.Api.CorrelationIdMiddleware</c> when an
+    /// upstream caller sets the <c>X-Correlation-ID</c> header (or the middleware mints one).
+    /// Empty string when the row has no correlation id.
+    /// </summary>
     public required string CorrelationId { get; init; }
+
+    /// <summary>
+    /// Application version read with the same coalesce as the read-side environment lookup:
+    /// OTel resource attribute <c>service.version</c> first (set by <c>AddQuilt4NetLogging</c>),
+    /// then a legacy <c>Version</c> scope tag, then the AI built-in <c>AppVersion</c> column.
+    /// </summary>
     public required string Version { get; init; }
+
+    /// <summary>
+    /// The full row from <c>pack_all()</c>, deserialised into a dictionary. Used by the
+    /// <c>LogDetailContent</c> Details and Stack Trace tabs to render structured key/value
+    /// pairs and the parsed stack frames respectively.
+    /// </summary>
     public required IReadOnlyDictionary<string, object> Raw { get; init; }
+
+    /// <summary>
+    /// The same row as <see cref="Raw"/> but as a JSON string — what the <c>LogDetailContent</c>
+    /// Raw tab renders inside its <c>&lt;pre&gt;</c> block (and what its CopyButton copies).
+    /// </summary>
     public required string RawJson { get; init; }
 }

--- a/Quilt4Net.Toolkit/Features/ApplicationInsights/LogItem.cs
+++ b/Quilt4Net.Toolkit/Features/ApplicationInsights/LogItem.cs
@@ -9,4 +9,12 @@ public record LogItem : LogItemBase
 
     [JsonConverter(typeof(JsonStringEnumConverter))]
     public required SeverityLevel SeverityLevel { get; init; }
+
+    /// <summary>
+    /// Per-record correlation id read from the log entry's <c>customDimensions["CorrelationId"]</c>.
+    /// Empty string when the row has no correlation id (typical for telemetry from outside the
+    /// Quilt4Net pipeline). For Quilt4Net-instrumented apps, populated automatically by
+    /// <c>CorrelationIdMiddleware</c>'s logging scope.
+    /// </summary>
+    public string CorrelationId { get; init; } = string.Empty;
 }

--- a/Quilt4Net.Toolkit/Features/ApplicationInsights/StackFrameParser.cs
+++ b/Quilt4Net.Toolkit/Features/ApplicationInsights/StackFrameParser.cs
@@ -1,0 +1,152 @@
+using System.Text.Json;
+
+namespace Quilt4Net.Toolkit.Features.ApplicationInsights;
+
+/// <summary>
+/// One frame in the parsed stack of an Application Insights exception. Mirrors the
+/// fields AI stores under <c>AppExceptions.Details[i].parsedStack[j]</c>.
+/// </summary>
+public sealed record StackFrame
+{
+    public int Level { get; init; }
+    public string Assembly { get; init; } = string.Empty;
+    public string Method { get; init; } = string.Empty;
+    public string FileName { get; init; } = string.Empty;
+    public int Line { get; init; }
+
+    /// <summary>True when the frame has no file/line — typically a system or framework frame.</summary>
+    public bool HasFileLocation => !string.IsNullOrEmpty(FileName) && Line > 0;
+}
+
+/// <summary>
+/// Parses the AI exception <c>Details</c> payload (a JSON array of detail objects, each
+/// carrying its own <c>parsedStack</c>) into a flat sequence of <see cref="StackFrame"/>s
+/// suitable for tabular rendering. Robust to either a pre-deserialized
+/// <see cref="JsonElement"/> value or a raw JSON string in the row dictionary.
+/// </summary>
+public static class StackFrameParser
+{
+    /// <summary>
+    /// Parse stack frames from an AI exception row's <c>Raw</c> dictionary.
+    /// Returns empty when <c>Details</c> is missing, empty, or unparseable.
+    /// </summary>
+    public static IReadOnlyList<StackFrame> Parse(IReadOnlyDictionary<string, object> raw)
+    {
+        if (raw is null) return [];
+        if (!raw.TryGetValue("Details", out var detailsObj) || detailsObj is null) return [];
+
+        if (!TryGetJsonElement(detailsObj, out var detailsEl)) return [];
+
+        var frames = new List<StackFrame>();
+
+        if (detailsEl.ValueKind == JsonValueKind.Array)
+        {
+            foreach (var detail in detailsEl.EnumerateArray())
+            {
+                AppendFrames(detail, frames);
+            }
+        }
+        else if (detailsEl.ValueKind == JsonValueKind.Object)
+        {
+            // Some AI rows surface a single detail object rather than an array.
+            AppendFrames(detailsEl, frames);
+        }
+
+        return frames;
+    }
+
+    /// <summary>
+    /// Convert a stack frame into a Resharper-friendly <c>FileName:line N</c> reference.
+    /// When any of <paramref name="sourcePathRoots"/> appears in the path, everything up
+    /// to (and including) that segment is stripped — leaving a leading slash + the path
+    /// inside the project (e.g. <c>\Features\Team\UserService.cs:line 24</c>) which
+    /// Resharper / Rider can resolve from any open solution containing that file.
+    /// </summary>
+    public static string ToResharperPath(StackFrame frame, IReadOnlyList<string> sourcePathRoots = null)
+    {
+        if (frame is null || string.IsNullOrEmpty(frame.FileName)) return string.Empty;
+
+        var path = frame.FileName;
+        if (sourcePathRoots is { Count: > 0 })
+        {
+            foreach (var root in sourcePathRoots)
+            {
+                if (string.IsNullOrEmpty(root)) continue;
+
+                // Match the root as a complete path segment, slash-bounded on either side
+                // (so "Foo" doesn't accidentally match "FooBar"). Try both separators.
+                var stripped = TryStrip(path, "\\" + root + "\\")
+                               ?? TryStrip(path, "/" + root + "/")
+                               ?? TryStrip(path, root + "\\")  // falls back to the start of the path
+                               ?? TryStrip(path, root + "/");
+                if (stripped != null)
+                {
+                    path = "\\" + stripped.Replace('/', '\\');
+                    break;
+                }
+            }
+        }
+
+        return frame.Line > 0 ? $"{path}:line {frame.Line}" : path;
+    }
+
+    private static void AppendFrames(JsonElement detail, List<StackFrame> sink)
+    {
+        if (detail.ValueKind != JsonValueKind.Object) return;
+        if (!detail.TryGetProperty("parsedStack", out var ps) || ps.ValueKind != JsonValueKind.Array) return;
+
+        foreach (var frame in ps.EnumerateArray())
+        {
+            if (frame.ValueKind != JsonValueKind.Object) continue;
+
+            sink.Add(new StackFrame
+            {
+                Level = TryGetInt(frame, "level"),
+                Assembly = TryGetString(frame, "assembly"),
+                Method = TryGetString(frame, "method"),
+                FileName = TryGetString(frame, "fileName"),
+                Line = TryGetInt(frame, "line"),
+            });
+        }
+    }
+
+    private static bool TryGetJsonElement(object value, out JsonElement element)
+    {
+        switch (value)
+        {
+            case JsonElement el:
+                element = el;
+                return true;
+            case string s when !string.IsNullOrWhiteSpace(s):
+                try
+                {
+                    element = JsonDocument.Parse(s).RootElement;
+                    return true;
+                }
+                catch (JsonException)
+                {
+                    element = default;
+                    return false;
+                }
+            default:
+                element = default;
+                return false;
+        }
+    }
+
+    private static int TryGetInt(JsonElement obj, string name)
+        => obj.TryGetProperty(name, out var p) && p.ValueKind == JsonValueKind.Number && p.TryGetInt32(out var i)
+            ? i
+            : 0;
+
+    private static string TryGetString(JsonElement obj, string name)
+        => obj.TryGetProperty(name, out var p) && p.ValueKind == JsonValueKind.String
+            ? p.GetString() ?? string.Empty
+            : string.Empty;
+
+    private static string TryStrip(string path, string marker)
+    {
+        var idx = path.LastIndexOf(marker, StringComparison.OrdinalIgnoreCase);
+        return idx < 0 ? null : path.Substring(idx + marker.Length);
+    }
+}

--- a/Quilt4Net.Toolkit/Features/Logging/TelemetryIdentityEnrichment.cs
+++ b/Quilt4Net.Toolkit/Features/Logging/TelemetryIdentityEnrichment.cs
@@ -1,0 +1,73 @@
+using System.Diagnostics;
+using OpenTelemetry;
+using OpenTelemetry.Logs;
+
+namespace Quilt4Net.Toolkit.Features.Logging;
+
+/// <summary>
+/// The five identity attributes attached to every Quilt4Net-instrumented log record and
+/// activity. Computed once at registration time from <see cref="Quilt4NetLoggingOptions"/>
+/// plus <see cref="System.Environment.MachineName"/>; the processors below copy the values
+/// onto each record/span at export time.
+/// </summary>
+internal sealed record TelemetryIdentity(
+    string Environment,
+    string ApplicationName,
+    string Version,
+    string MachineName,
+    string MonitorName);
+
+/// <summary>
+/// Adds the five <see cref="TelemetryIdentity"/> attributes to every <see cref="LogRecord"/>
+/// (AppTraces, AppExceptions). Resource attributes alone don't reach per-row Properties via
+/// the Azure Monitor exporter, so we copy them onto the record.
+/// </summary>
+internal sealed class TelemetryIdentityLogProcessor : BaseProcessor<LogRecord>
+{
+    private readonly TelemetryIdentity _identity;
+
+    public TelemetryIdentityLogProcessor(TelemetryIdentity identity)
+    {
+        _identity = identity;
+    }
+
+    public override void OnEnd(LogRecord data)
+    {
+        var existing = data.Attributes;
+        var capacity = (existing?.Count ?? 0) + 5;
+        var list = new List<KeyValuePair<string, object>>(capacity);
+        if (existing != null) list.AddRange(existing);
+
+        if (!string.IsNullOrEmpty(_identity.Environment)) list.Add(new("deployment.environment", _identity.Environment));
+        if (!string.IsNullOrEmpty(_identity.ApplicationName)) list.Add(new("service.name", _identity.ApplicationName));
+        if (!string.IsNullOrEmpty(_identity.Version)) list.Add(new("service.version", _identity.Version));
+        if (!string.IsNullOrEmpty(_identity.MachineName)) list.Add(new("host.name", _identity.MachineName));
+        if (!string.IsNullOrEmpty(_identity.MonitorName)) list.Add(new("quilt4net.monitor", _identity.MonitorName));
+
+        data.Attributes = list;
+    }
+}
+
+/// <summary>
+/// Adds the five <see cref="TelemetryIdentity"/> attributes to every <see cref="Activity"/>
+/// (AppRequests + outbound dependencies). <c>SetTag</c> is the OTel-native way to add per-
+/// span attributes; the Azure Monitor exporter forwards them into <c>customDimensions</c>.
+/// </summary>
+internal sealed class TelemetryIdentityActivityProcessor : BaseProcessor<Activity>
+{
+    private readonly TelemetryIdentity _identity;
+
+    public TelemetryIdentityActivityProcessor(TelemetryIdentity identity)
+    {
+        _identity = identity;
+    }
+
+    public override void OnEnd(Activity data)
+    {
+        if (!string.IsNullOrEmpty(_identity.Environment)) data.SetTag("deployment.environment", _identity.Environment);
+        if (!string.IsNullOrEmpty(_identity.ApplicationName)) data.SetTag("service.name", _identity.ApplicationName);
+        if (!string.IsNullOrEmpty(_identity.Version)) data.SetTag("service.version", _identity.Version);
+        if (!string.IsNullOrEmpty(_identity.MachineName)) data.SetTag("host.name", _identity.MachineName);
+        if (!string.IsNullOrEmpty(_identity.MonitorName)) data.SetTag("quilt4net.monitor", _identity.MonitorName);
+    }
+}

--- a/Quilt4Net.Toolkit/LoggingRegistration.cs
+++ b/Quilt4Net.Toolkit/LoggingRegistration.cs
@@ -3,7 +3,9 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
+using OpenTelemetry.Logs;
 using OpenTelemetry.Resources;
+using OpenTelemetry.Trace;
 using Quilt4Net.Toolkit.Features.Logging;
 
 namespace Quilt4Net.Toolkit;
@@ -46,6 +48,13 @@ public static class LoggingRegistration
 
         services.AddHostedService<Quilt4NetStartupHostedService>();
 
+        var identity = new Features.Logging.TelemetryIdentity(
+            Environment: o.Environment,
+            ApplicationName: o.ApplicationName,
+            Version: o.Version,
+            MachineName: System.Environment.MachineName,
+            MonitorName: o.MonitorName);
+
         services.AddOpenTelemetry()
             .ConfigureResource(resource =>
             {
@@ -64,7 +73,13 @@ public static class LoggingRegistration
                         new("deployment.environment", o.Environment),
                     });
                 }
-            });
+            })
+            // Resource attributes alone don't reach per-row Properties via the Azure Monitor
+            // exporter (only the well-known service.* mappings → cloud_RoleName / AppVersion /
+            // cloud_RoleInstance columns). The processors below copy the identity onto each
+            // log record and span as per-record attributes so they land in customDimensions.
+            .WithLogging(b => b.AddProcessor(new Features.Logging.TelemetryIdentityLogProcessor(identity)))
+            .WithTracing(b => b.AddProcessor(new Features.Logging.TelemetryIdentityActivityProcessor(identity)));
 
         return new Quilt4NetLoggingBuilder(services, o);
     }

--- a/Quilt4Net.Toolkit/Quilt4NetLoggingOptions.cs
+++ b/Quilt4Net.Toolkit/Quilt4NetLoggingOptions.cs
@@ -30,4 +30,12 @@ public record Quilt4NetLoggingOptions
     /// Default resolution: IHostEnvironment.EnvironmentName → DOTNET_ENVIRONMENT → ASPNETCORE_ENVIRONMENT → "Production".
     /// </summary>
     public string Environment { get; set; }
+
+    /// <summary>
+    /// Identifier for the instrumentation source emitting the telemetry.
+    /// Surfaces as <c>customDimensions["quilt4net.monitor"]</c> on every trace, exception
+    /// and request, so KQL queries can scope to telemetry produced by Quilt4Net (or by a
+    /// per-deployment override) without parsing message text. Default is <c>"Quilt4Net"</c>.
+    /// </summary>
+    public string MonitorName { get; set; } = "Quilt4Net";
 }

--- a/Quilt4Net.Toolkit/README.md
+++ b/Quilt4Net.Toolkit/README.md
@@ -139,6 +139,8 @@ builder.AddQuilt4NetApplicationInsightsClient();
 | `ClientId` | `null` | For `ClientSecret`: app registration client ID with `Data.Read` permission on Application Insights API. For `ManagedIdentity`: empty for system-assigned MI, or the user-assigned MI's client ID. For `DefaultAzureCredential`: optional hint, used as the preferred user-assigned MI when MI lights up in the chain. |
 | `ClientSecret` | `null` | Client secret for the app registration. Only required when `AuthMode = ClientSecret`. |
 | `AuthMode` | `ClientSecret` | Authentication mode: `ClientSecret` (service principal), `ManagedIdentity` (Azure-hosted apps), or `DefaultAzureCredential` (chained — same config works locally via `az login` and in Azure via MI). |
+| `EnvironmentOrder` | `["Development", "CI", "Staging", "Test", "Production"]` | Preferred environment ordering for the version matrix. Names not listed render after, alphabetically; rows with empty env render last as `(unknown)`. |
+| `ApplicationAlias` | `[]` | Static `raw → logical` alias map for `VersionMatrixDisplay` consumers that don't pass a per-component `AliasFolder` delegate. Each entry groups one or more raw `cloud_RoleName` values under a single logical application name. |
 
 Configuration path: `Quilt4Net:ApplicationInsights`
 
@@ -185,9 +187,9 @@ Typical setup:
 
 > **Trade-off**: `DefaultAzureCredential` masks *which* underlying credential succeeded. If authentication fails, the error chain is less specific than the explicit modes. For diagnosis, switch to `ClientSecret` or `ManagedIdentity` to isolate the issue.
 
-## Universal telemetry tagging
+## Universal telemetry identity
 
-`AddQuilt4NetLogging()` registers an `ITelemetryInitializer` that tags every Application Insights telemetry item (traces, exceptions, requests, dependencies) with application identity. Works for all app types — Web API, Blazor, WPF, console, worker service.
+`AddQuilt4NetLogging()` configures OpenTelemetry resource attributes **and** registers two `BaseProcessor`s — one for `LogRecord`, one for `Activity` — that copy a fixed set of identity attributes onto every per-record Properties bag. Works for all app types; the Azure Monitor exporter forwards the per-record attributes into `customDimensions`, where KQL can read them.
 
 ```csharp
 var builder = WebApplication.CreateBuilder(args);
@@ -195,13 +197,15 @@ var builder = WebApplication.CreateBuilder(args);
 builder.AddQuilt4NetLogging();
 ```
 
-By default the initializer sets:
+Five attributes attached to every `AppTrace`, `AppException`, `AppRequest` (and outbound `AppDependency`):
 
-| Telemetry property | Default value |
-|---|---|
-| `Cloud.RoleName` | `IHostEnvironment.ApplicationName` → entry assembly name (framework assemblies excluded) |
-| `Component.Version` | Application assembly version |
-| `GlobalProperties["Environment"]` | `IHostEnvironment.EnvironmentName` → `DOTNET_ENVIRONMENT` → `ASPNETCORE_ENVIRONMENT` → `"Production"` |
+| Attribute key | Default value | Notes |
+|---|---|---|
+| `service.name` | `IHostEnvironment.ApplicationName` → entry assembly name (framework assemblies excluded) | Also surfaces as the `cloud_RoleName` column. |
+| `service.version` | Entry assembly version | Also surfaces as `application_Version`. |
+| `host.name` | `Environment.MachineName` | Also surfaces as `cloud_RoleInstance`. |
+| `deployment.environment` | `IHostEnvironment.EnvironmentName` → `DOTNET_ENVIRONMENT` → `ASPNETCORE_ENVIRONMENT` → `"Production"` | The Azure Monitor exporter does **not** forward arbitrary OTel resource attributes into per-row `Properties`, so the per-record processor copies it in too. |
+| `quilt4net.monitor` | `"Quilt4Net"` (configurable via `MonitorName`) | Identifies which instrumentation produced the row. Useful when several Quilt4Net-hosted services ship to the same workspace. |
 
 Override via callback or `appsettings.json`:
 
@@ -211,6 +215,7 @@ builder.AddQuilt4NetLogging(o =>
     o.ApplicationName = "florida-server";
     o.Version = "2.0.0";
     o.Environment = "Production";
+    o.MonitorName = "florida";
 });
 ```
 
@@ -220,18 +225,21 @@ builder.AddQuilt4NetLogging(o =>
     "Logging": {
       "ApplicationName": "florida-server",
       "Version": "2.0.0",
-      "Environment": "Production"
+      "Environment": "Production",
+      "MonitorName": "florida"
     }
   }
 }
 ```
 
-`AddQuilt4NetLogging()` returns a `Quilt4NetLoggingBuilder` that extension packages can chain off. For example, `Quilt4Net.Toolkit.Api` adds `.AddHttpRequestLogging()` to enable HTTP request/response middleware:
+`AddQuilt4NetLogging()` returns a `Quilt4NetLoggingBuilder` that extension packages can chain off. `Quilt4Net.Toolkit.Api` adds `.AddHttpRequestLogging()` to enable HTTP request/response middleware including the `X-Correlation-ID` propagation scope:
 
 ```csharp
 builder.AddQuilt4NetLogging()
     .AddHttpRequestLogging();
 ```
+
+When `Quilt4Net.Toolkit.Api`'s `CorrelationIdMiddleware` is active, every `ILogger` call inside a request also picks up `customDimensions["CorrelationId"]` automatically — see the Api package README.
 
 ## Measure extensions
 

--- a/docs/articles/getting-started.md
+++ b/docs/articles/getting-started.md
@@ -70,5 +70,7 @@ public class WhatsLatest
 
 ## Where next
 
-- **[Version matrix](version-matrix.md)** — render the same data as a Blazor table with optional alias folding and conflict detection
-- **[API reference](xref:Quilt4Net.Toolkit)** — every public type and option
+- **[Telemetry identity & correlation](telemetry-identity.md)** — make sure your apps actually emit env / app / version / host / correlation-id properties on every record. `AddQuilt4NetLogging()` registers the OpenTelemetry processors that do this.
+- **[Log views](log-views.md)** — drop in `<LogView />` to get Search / Summary / Detail / Test tabs over the data you just queried, with multi-select filters, per-team browser persistence, the CorrelationId column, and the Stack Trace tab with copy-to-IDE links.
+- **[Version matrix](version-matrix.md)** — render the same data as a Blazor table with optional alias folding and conflict detection.
+- **[API reference](xref:Quilt4Net.Toolkit)** — every public type and option.

--- a/docs/articles/index.md
+++ b/docs/articles/index.md
@@ -3,6 +3,8 @@
 Feature guides for `Quilt4Net.Toolkit`. Skim the [Getting started](getting-started.md) page first if you're new — it gets you from `dotnet add package` to a running query against Application Insights. Otherwise jump to the topic that matches what you're solving:
 
 - **[Getting started](getting-started.md)** — install, register, configure auth, your first query
+- **[Telemetry identity & correlation](telemetry-identity.md)** — `AddQuilt4NetLogging`, the five attributes attached to every record, and the `X-Correlation-ID` propagation pattern that lets one id span client → server → response → client
+- **[Log views](log-views.md)** — `LogView` and the Search / Summary / Detail / Test tabs, the multi-select filter bar with per-team browser persistence, the CorrelationId column, the Stack Trace tab with Resharper-friendly file:line copy, and the application-alias rendering
 - **[Version matrix](version-matrix.md)** — drop-in Blazor component showing application × environment versions, with optional alias folding and per-environment ordering
 
 Each guide is short — the full reference is in the [API](xref:Quilt4Net.Toolkit) tab.

--- a/docs/articles/log-views.md
+++ b/docs/articles/log-views.md
@@ -1,0 +1,107 @@
+# Log views
+
+Drop-in Blazor components that render Application Insights data fetched via `IApplicationInsightsService`. The same components power Quilt4Net Server's `/monitor/log` and `/developer/log` pages.
+
+## Minimum
+
+```razor
+@using Quilt4Net.Toolkit.Blazor.Features.Log
+
+<LogView />
+```
+
+Renders the Search / Summary / Measure / Count tabs against the AI workspace configured by `AddQuilt4NetApplicationInsightsClient`. Detail and Summary drill-downs open in a Radzen dialog.
+
+## Dedicated detail / summary pages
+
+```razor
+@page "/log"
+<LogView Tab="@Tab" DetailPath="/log/detail" SummaryPath="/log/summary" />
+
+@code {
+    [Parameter, SupplyParameterFromQuery] public string Tab { get; set; }
+}
+```
+
+```razor
+@page "/log/detail/{Id}"
+<LogDetailView Id="@Id" Params="@P" SummaryPath="/log/summary" />
+
+@code {
+    [Parameter] public string Id { get; set; }
+    [Parameter, SupplyParameterFromQuery] public string P { get; set; }
+}
+```
+
+`?tab=...` is honoured (and updated) by `LogView` as the user switches tabs — deep linking and browser back/forward work out of the box.
+
+## Application alias rendering
+
+Real-world AI data often spreads one logical app across multiple `cloud_RoleName` values (e.g. `MyApp.Server` + `MyApp.Server.Client` for a Blazor Server + WASM combo). Pass an `ApplicationAliasMap` to render every Application cell as the logical name with the raw value on hover:
+
+```razor
+<LogView ApplicationAliasMap="@_aliasMap" />
+
+@code {
+    private readonly Dictionary<string, string> _aliasMap = new(StringComparer.OrdinalIgnoreCase)
+    {
+        ["MyApp.Server"] = "myapp-web",
+        ["MyApp.Server.Client"] = "myapp-web"
+    };
+}
+```
+
+For static maps shared across the whole app, set `ApplicationInsightsOptions.ApplicationAlias` once at startup and the toolkit picks it up — no per-page wiring needed.
+
+## Filter bar (Source / Level / Application / Environment)
+
+The Search and Summary tabs each render a `<LogFilterBar>` above the grid — four `RadzenSelectBar Multi="true"` rows. Source and Level options come from the enums; Application and Environment options are populated from the loaded data's distinct values (with alias resolution applied to applications). Filtering replaces Radzen's per-column filter inputs.
+
+`FilterStorageScope` enables browser-`localStorage` persistence keyed under `Quilt4Net.Log.Filters.{scope}.{tab}`:
+
+```razor
+<LogView FilterStorageScope="@team.Key" />
+```
+
+The user's filter selection on each tab survives reloads and is isolated per scope value.
+
+## CorrelationId column on Search
+
+The Search tab renders a 140 px **Correlation** column showing the first 8 chars of the GUID with a hover tooltip and a copy button:
+
+```
+1a2b3c4d…  📋
+```
+
+Click the preview → Search re-runs scoped to that correlation id. `LogItem.CorrelationId` is populated automatically when your apps emit it as a structured property; `Quilt4Net.Toolkit.Api`'s `CorrelationIdMiddleware` does this via a logging scope (see [Telemetry identity & correlation](telemetry-identity.md)).
+
+## Stack Trace tab + Resharper-friendly file:line
+
+The Detail view's **Stack Trace** sub-tab parses `AppExceptions.Details[].parsedStack` into a grid:
+
+| # | Assembly | Method | File | Line | Copy |
+|---|---|---|---|---|---|
+| 0 | MyApp.Server | `MyApp.Foo.Bar` | UserService.cs | 24 | 📋 |
+
+The "Show frames without file/line" toggle hides system / framework frames by default. The per-row CopyButton produces a `:line N`-suffixed path. Configure `SourcePathRoots` to shorten paths so an IDE can find the file:
+
+```razor
+<LogView SourcePathRoots="@(new[] { "MyApp.Server" })" />
+```
+
+A frame whose `fileName` is `D:\a\1\s\MyApp.Server\Features\Team\UserService.cs` line 24 → clipboard text `\Features\Team\UserService.cs:line 24`. Paste-ready into Rider's "Find file" prompt.
+
+The Stack Trace tab is exception-only; trace and request rows show a friendly "no parsed stack trace available" alert instead of an empty grid.
+
+## Test tab (developer-only)
+
+```razor
+<LogView ShowTestTab="true" />
+```
+
+Adds a tab that triggers traces and exceptions at every `LogLevel` via `ILogger`, plus an uncaught throw caught by `Tharga.Blazor.CustomErrorBoundary` so the correlation guid surfaces in the recovery banner and in `customDimensions["CorrelationId"]`. Off by default so external apps don't accidentally expose log-injection controls.
+
+## Where next
+
+- **[Telemetry identity & correlation](telemetry-identity.md)** — how the data shown by these components reaches AI in the first place.
+- **API reference** for the new types: `xref:Quilt4Net.Toolkit.Features.ApplicationInsights.LogItem.CorrelationId`, `xref:Quilt4Net.Toolkit.Features.ApplicationInsights.StackFrameParser`.

--- a/docs/articles/telemetry-identity.md
+++ b/docs/articles/telemetry-identity.md
@@ -1,0 +1,92 @@
+# Telemetry identity & correlation
+
+`AddQuilt4NetLogging()` does two things:
+
+1. Configures **OpenTelemetry resource attributes** so the Azure Monitor exporter populates the AI columns `cloud_RoleName`, `application_Version`, and `cloud_RoleInstance`.
+2. Registers **two `BaseProcessor`s** — one for `LogRecord`, one for `Activity` — that copy a five-attribute identity onto every per-record `Properties` bag at export time. The Azure Monitor exporter does *not* forward arbitrary OTel resource attributes to per-row Properties for log records, so without this step `customDimensions["deployment.environment"]` would always be empty.
+
+```csharp
+var builder = WebApplication.CreateBuilder(args);
+
+builder.AddQuilt4NetLogging();
+```
+
+## What lands on every record
+
+Five attributes attached to every `AppTrace`, `AppException`, `AppRequest`, and outbound `AppDependency`:
+
+| Key | Default | Notes |
+|---|---|---|
+| `service.name` | `IHostEnvironment.ApplicationName` | Also surfaces as `cloud_RoleName`. |
+| `service.version` | Entry assembly version | Also surfaces as `application_Version`. |
+| `host.name` | `Environment.MachineName` | Also surfaces as `cloud_RoleInstance`. |
+| `deployment.environment` | `IHostEnvironment.EnvironmentName` → `DOTNET_ENVIRONMENT` → `ASPNETCORE_ENVIRONMENT` → `"Production"` | Per-record copy. Read-side queries use a centralised KQL projection that coalesces this with the legacy `AspNetCoreEnvironment` scope tag. |
+| `quilt4net.monitor` | `"Quilt4Net"` (configurable via [`MonitorName`](xref:Quilt4Net.Toolkit.Quilt4NetLoggingOptions.MonitorName)) | Identifies the instrumentation source — distinguishes telemetry from multiple Quilt4Net-instrumented services shipping to the same workspace. |
+
+## Override
+
+```csharp
+builder.AddQuilt4NetLogging(o =>
+{
+    o.ApplicationName = "florida-server";
+    o.Version = "2.0.0";
+    o.Environment = "Production";
+    o.MonitorName = "florida";
+});
+```
+
+```json
+{
+  "Quilt4Net": {
+    "Logging": {
+      "ApplicationName": "florida-server",
+      "Version": "2.0.0",
+      "Environment": "Production",
+      "MonitorName": "florida"
+    }
+  }
+}
+```
+
+## Correlation across requests + handlers
+
+Pair `AddQuilt4NetLogging()` with `Quilt4Net.Toolkit.Api`:
+
+```csharp
+builder.AddQuilt4NetLogging()
+    .AddHttpRequestLogging();
+
+var app = builder.Build();
+app.UseQuilt4NetLogging();
+```
+
+`CorrelationIdMiddleware`:
+
+1. Reads `X-Correlation-ID` from the request, or generates a new GUID.
+2. Echoes it back as a response header.
+3. Pushes it into a logging scope (`Logger.BeginScope({ ["CorrelationId"] = id })`) for the duration of the request.
+
+Every `ILogger` call made while handling the request inherits the id as a structured property. The Azure Monitor exporter writes it to `customDimensions["CorrelationId"]` on every resulting `AppTrace` / `AppException` / `AppRequest`. KQL pattern:
+
+```kql
+union AppTraces, AppExceptions, AppRequests
+| where Properties contains "<the-correlation-id>"
+| order by TimeGenerated asc
+```
+
+A client that wants to chain calls just sends the same header to every server. Server code that wants to start a new chain can read `HttpContext.Items["CorrelationId"]` and forward it to outbound `HttpClient` calls.
+
+## Demo endpoint
+
+`Quilt4Net.Toolkit.Blazor.Server.Sample` ships a working endpoint:
+
+```bash
+curl -i -H "X-Correlation-ID: my-test-1" https://localhost:7187/api/correlation-demo
+```
+
+→ three `AppTrace` rows in AI, all sharing `customDimensions["CorrelationId"] == "my-test-1"`.
+
+## Where next
+
+- **[Log views](log-views.md)** — render and query the resulting telemetry.
+- **API reference**: `xref:Quilt4Net.Toolkit.Quilt4NetLoggingOptions`, `xref:Quilt4Net.Toolkit.Features.Logging.TelemetryIdentityLogProcessor`.

--- a/docs/articles/toc.yml
+++ b/docs/articles/toc.yml
@@ -2,5 +2,9 @@
   href: index.md
 - name: Getting started
   href: getting-started.md
+- name: Telemetry identity & correlation
+  href: telemetry-identity.md
+- name: Log views
+  href: log-views.md
 - name: Version matrix
   href: version-matrix.md


### PR DESCRIPTION
## Summary

Seven commits that together fix the "Environment column is empty" bug we hit while testing existing log views, and expand the read-side log views with the features that surfaced from there.

### Why
KQL diagnostics against a real workspace showed every Quilt4Net.Server log row had empty `Environment` *and* empty `CorrelationId` in `customDimensions`. Root cause: `AddQuilt4NetLogging` only set OTel resource attributes, and the Azure Monitor exporter does not forward arbitrary resource attributes to per-row Properties for log records. Reading from the wrong KQL key on top of that. Both sides need fixing for the column to populate end-to-end.

### What landed

**Telemetry identity (write side)**
- `AddQuilt4NetLogging` now registers two `BaseProcessor`s — one for `LogRecord`, one for `Activity` — that copy a five-attribute identity onto every record at export time:
  `service.name`, `service.version`, `host.name`, `deployment.environment`, `quilt4net.monitor`.
- New `MonitorName` option on `Quilt4NetLoggingOptions` (default `\"Quilt4Net\"`).
- `Quilt4Net.Toolkit.Api/LoggingOptions.MonitorName` marked `[Obsolete]` redirecting to the core option.
- `RequestBodyLoggingMiddleware` stripped of redundant `ApplicationName` / `Version` / `Monitor` writes (the processors cover all three universally).

**Correlation id**
- `CorrelationIdMiddleware` wraps `_next` in `Logger.BeginScope({ [\"CorrelationId\"] = id })` so every `ILogger` call inside a request inherits the id and lands in `customDimensions[\"CorrelationId\"]` on every resulting AppTrace / AppException / AppRequest. Also forwarded as the response header so chained client → server → response → client traces share one id.
- `LogItem.CorrelationId` projected from the three Search KQL queries.
- New CorrelationId column on `LogSearchView` — 140 px monospace 8-char preview + ellipsis, hover tooltip with the full guid, click to re-run Search scoped to that id, `Tharga.Blazor.CopyButton` for paste-into-other-system flows.
- Demo endpoint `GET /api/correlation-demo` in `Quilt4Net.Toolkit.Blazor.Server.Sample`.

**KQL read-side**
- `EnvironmentProjection` const centralises the `coalesce(_p[\"deployment.environment\"], _p[\"AspNetCoreEnvironment\"])` pattern; swept all 17 read-side queries.
- `VersionProjection` const for the equivalent on Version. `LogDetails.Version` now populated (replaces a long-standing `\"0.0.0.0\" //TODO` placeholder).
- New `Quilt4Net.Server` test tab unhide via `LogView.ShowTestTab` parameter.

**Filter bar**
- New `LogFilters` record + `<LogFilterBar>` component (four `RadzenSelectBar Multi=\"true\"` rows for Source / Level / Application / Environment) replaces Radzen's per-column filter inputs on Search and Summary tabs.
- `<LogView>` takes a `FilterStorageScope` parameter — when set, browser-`localStorage` persists filter state per scope per tab (Quilt4Net.Server passes `team.Key`).

**Application alias rendering**
- New `<ApplicationName>` component renders the logical alias name (with the raw name on hover and a dotted underline when they differ). Wired through `LogView` / `LogDetailView` / `LogSummaryView` via cascading `ApplicationAliasMap`. Fallback to the static map in `ApplicationInsightsOptions.ApplicationAlias` when no parameter passed.

**Details + Stack Trace tabs on `LogDetailContent`**
- Implemented two long-standing TODOs.
- New `Quilt4Net.Toolkit.Features.ApplicationInsights.StackFrameParser` extracts `parsedStack` from the AI exception `Details` payload (handles both pre-deserialised `JsonElement` and raw JSON-string forms; gracefully ignores malformed JSON).
- `StackFrameParser.ToResharperPath(frame, sourcePathRoots)` strips paths so the per-row CopyButton produces \`\Features\Team\UserService.cs:line 24\` — paste-ready into Rider's \"Find file\" prompt.
- New `<LogView SourcePathRoots=\"...\">` parameter cascades to `LogDetailContent`.
- Raw tab gets a `<CopyButton>` for the displayed JSON.

**Test tab**
- Renamed `Trigger` → `Test`, gated on a new `ShowTestTab` parameter (default false). Re-pointed at `Tharga.Blazor.CustomErrorBoundary` so uncaught throws surface a queryable correlation guid.

### Tests
**213 passing** (was 174 at branch start, +39):
- 3 `EnvironmentProjectionTests` — KQL coalesce shape, OTel-key-first ordering.
- 5 `TelemetryIdentityEnrichmentTests` — both processors attach all five attributes, skip empties, preserve pre-existing.
- 5 `LogFiltersTests` — empty-matches-all, per-dimension matching, cross-dimension composition.
- 10 `StackFrameParserTests` — null/empty input, string vs JsonElement payloads, malformed JSON graceful skip, path stripping with both slash directions, no-match fallback, line-zero suffix omission, rightmost-match collision.
- 16 from earlier in the branch covering VersionMatrix view rebuild after the AliasFolder + EnvironmentOrder rework.

### Docs
- Core / Api / Blazor READMEs rewritten / extended for everything above.
- Two new DocFX articles: `docs/articles/telemetry-identity.md`, `docs/articles/log-views.md`. Articles index + toc + getting-started updated.

### Server-side wiring (separate PR)
The Server wiring lives on `feature/log-views-server-wiring` in the Server repo (3 commits, currently against the dev-only Quilt4Net.Toolkit ProjectReferences). Will revert to PackageReference at the new published version once this PR ships and the prerelease nuget is available.

## Test plan
- [x] All 5 toolkit suites green: 213 tests.
- [x] Verified end-to-end against a real workspace via \`az monitor log-analytics query\` — env populated on fresh telemetry after redeploy.
- [x] Full Server pages exercised against the local toolkit branch (\`/monitor/log\`, \`/monitor/log/detail/{id}\`, \`/monitor/log/summary/{fp}\`, \`/developer/log?tab=test\`, \`/api/correlation-demo\` in the sample app).