### PR TITLE
Identify failing AI workspace + offer Edit-configuration link on auth failures

### DIFF
--- a/Quilt4Net.Toolkit.Blazor.Tests/ApplicationInsightsErrorMessageTests.cs
+++ b/Quilt4Net.Toolkit.Blazor.Tests/ApplicationInsightsErrorMessageTests.cs
@@ -1,5 +1,6 @@
 using FluentAssertions;
 using Quilt4Net.Toolkit.Blazor.Features.Log;
+using Quilt4Net.Toolkit.Features.ApplicationInsights;
 using Xunit;
 
 namespace Quilt4Net.Toolkit.Blazor.Tests;
@@ -47,5 +48,48 @@ public class ApplicationInsightsErrorMessageTests
     {
         var msg = ApplicationInsightsErrorMessage.Format("Could not load.", new InvalidOperationException("boom"), string.Empty);
         msg.Should().NotContain("[Incident:");
+    }
+
+    [Fact]
+    public void Format_authentication_failure_with_context_identifies_failing_workspace()
+    {
+        var inner = new InvalidOperationException("AADSTS7000215: Invalid client secret provided.");
+        var outer = new Exception("wrapper", inner);
+        var ctx = new TestContext { WorkspaceId = "03abd6ba-a499-44e8-94bc-96d2500a3161" };
+
+        var msg = ApplicationInsightsErrorMessage.Format("Could not load.", outer, "K7XQ4P", ctx);
+
+        msg.Should().Contain("for workspace 03abd6ba-a499-44e8-94bc-96d2500a3161");
+        msg.Should().EndWith("[Incident: K7XQ4P]");
+    }
+
+    [Fact]
+    public void Format_authentication_failure_without_context_omits_workspace_clause()
+    {
+        var inner = new InvalidOperationException("AADSTS7000215: Invalid client secret provided.");
+        var outer = new Exception("wrapper", inner);
+
+        var msg = ApplicationInsightsErrorMessage.Format("Could not load.", outer, "K7XQ4P", null);
+
+        msg.Should().NotContain("for workspace");
+        msg.Should().StartWith("Could not load. Application Insights authentication failed");
+    }
+
+    [Fact]
+    public void Format_non_auth_failure_with_context_uses_exception_message_unchanged()
+    {
+        var ctx = new TestContext { WorkspaceId = "ws-id" };
+
+        var msg = ApplicationInsightsErrorMessage.Format("Could not load.", new InvalidOperationException("boom"), "K7XQ4P", ctx);
+
+        msg.Should().Be("Could not load. boom [Incident: K7XQ4P]");
+    }
+
+    private sealed class TestContext : IApplicationInsightsContext
+    {
+        public string TenantId { get; init; }
+        public string WorkspaceId { get; init; }
+        public string ClientId { get; init; }
+        public string ClientSecret { get; init; }
     }
 }

--- a/Quilt4Net.Toolkit.Blazor/Features/Log/ApplicationInsightsErrorMessage.cs
+++ b/Quilt4Net.Toolkit.Blazor/Features/Log/ApplicationInsightsErrorMessage.cs
@@ -1,14 +1,24 @@
+using Quilt4Net.Toolkit.Features.ApplicationInsights;
+
 namespace Quilt4Net.Toolkit.Blazor.Features.Log;
 
 internal static class ApplicationInsightsErrorMessage
 {
     public static string Format(string prefix, Exception ex)
-        => Format(prefix, ex, null);
+        => Format(prefix, ex, null, null);
 
     public static string Format(string prefix, Exception ex, string incidentId)
+        => Format(prefix, ex, incidentId, null);
+
+    /// <summary>
+    /// Auth-failure messages now include the failing workspace's id when the calling
+    /// component knows it — so the user can identify which AI configuration to fix
+    /// instead of bisecting through the configuration list themselves.
+    /// </summary>
+    public static string Format(string prefix, Exception ex, string incidentId, IApplicationInsightsContext context)
     {
         var body = IsAuthenticationFailure(ex)
-            ? "Application Insights authentication failed — the configured TenantId, WorkspaceId, ClientId or ClientSecret may be incorrect, the secret may have expired, or the service principal may not have access to the workspace. Verify the Application Insights settings."
+            ? FormatAuthFailure(context)
             : ex.Message;
 
         return string.IsNullOrEmpty(incidentId)
@@ -16,7 +26,19 @@ internal static class ApplicationInsightsErrorMessage
             : $"{prefix} {body} [Incident: {incidentId}]";
     }
 
-    private static bool IsAuthenticationFailure(Exception ex)
+    private static string FormatAuthFailure(IApplicationInsightsContext context)
+    {
+        var workspace = context?.WorkspaceId;
+        var which = string.IsNullOrEmpty(workspace) ? string.Empty : $" for workspace {workspace}";
+        return $"Application Insights authentication failed{which} — the configured TenantId, ClientId or ClientSecret may be incorrect, the secret may have expired, or the service principal may not have access to the workspace.";
+    }
+
+    /// <summary>
+    /// Razor catch sites use this to decide whether to render a "fix the configuration" link
+    /// next to the error alert — the configuration page is only useful when this specific
+    /// failure mode is the cause.
+    /// </summary>
+    internal static bool IsAuthenticationFailure(Exception ex)
     {
         for (var current = ex; current != null; current = current.InnerException)
         {

--- a/Quilt4Net.Toolkit.Blazor/Features/Log/LogEnvironmentSelector.razor
+++ b/Quilt4Net.Toolkit.Blazor/Features/Log/LogEnvironmentSelector.razor
@@ -11,7 +11,13 @@
 }
 else if (_loadError != null)
 {
-    <RadzenAlert AlertStyle="AlertStyle.Warning" Shade="Shade.Lighter" AllowClose="false">@_loadError</RadzenAlert>
+    <RadzenAlert AlertStyle="AlertStyle.Warning" Shade="Shade.Lighter" AllowClose="false">
+        @_loadError
+        @if (_loadErrorIsAuthFailure && !string.IsNullOrEmpty(NavOptions?.ConfigurationPath))
+        {
+            <text> </text><RadzenLink Path="@NavOptions.ConfigurationPath" Text="Edit configuration" />
+        }
+    </RadzenAlert>
 }
 else if (_environments == null)
 {
@@ -35,6 +41,7 @@ else
     private IApplicationInsightsContext _loadedContext;
     private EnvironmentOption _firedContext;
     private string _loadError;
+    private bool _loadErrorIsAuthFailure;
     private string _configError;
     private IApplicationInsightsService _ais;
 
@@ -43,6 +50,9 @@ else
 
     [Parameter]
     public IApplicationInsightsContext Context { get; set; }
+
+    [CascadingParameter]
+    public LogNavigationOptions NavOptions { get; set; }
 
     protected override void OnInitialized()
     {
@@ -61,6 +71,7 @@ else
         {
             _loadedContext = Context;
             _loadError = null;
+            _loadErrorIsAuthFailure = false;
 
             try
             {
@@ -78,7 +89,8 @@ else
             catch (Exception ex)
             {
                 _loadError = LogIncidentLogger.LogAndFormat(Logger, ex, nameof(LogEnvironmentSelector),
-                    "Could not load Application Insights environments.");
+                    "Could not load Application Insights environments.", _loadedContext);
+                _loadErrorIsAuthFailure = ApplicationInsightsErrorMessage.IsAuthenticationFailure(ex);
                 _environments = Array.Empty<EnvironmentOption>();
             }
         }

--- a/Quilt4Net.Toolkit.Blazor/Features/Log/LogIncidentLogger.cs
+++ b/Quilt4Net.Toolkit.Blazor/Features/Log/LogIncidentLogger.cs
@@ -1,4 +1,5 @@
 using Microsoft.Extensions.Logging;
+using Quilt4Net.Toolkit.Features.ApplicationInsights;
 using Quilt4Net.Toolkit.Features.Diagnostics;
 
 namespace Quilt4Net.Toolkit.Blazor.Features.Log;
@@ -6,20 +7,23 @@ namespace Quilt4Net.Toolkit.Blazor.Features.Log;
 internal static class LogIncidentLogger
 {
     /// <summary>
-    /// Mints an incident id, logs the exception with structured properties,
-    /// and returns a user-facing message that includes the same id so the
-    /// reporter and the log entry can be cross-referenced.
+    /// Mints an incident id, logs the exception with structured properties (including the
+    /// failing workspace when known), and returns a user-facing message that includes the
+    /// same id so the reporter and the log entry can be cross-referenced. The optional
+    /// <paramref name="context"/> lets the message identify which AI configuration is
+    /// broken when the failure is an authentication failure.
     /// </summary>
     public static string LogAndFormat(
         ILogger logger,
         Exception ex,
         string componentName,
-        string userPrefix)
+        string userPrefix,
+        IApplicationInsightsContext context = null)
     {
         var incidentId = IncidentId.New();
         logger.LogError(ex,
-            "AI call failed. Incident={IncidentId} Component={Component}",
-            incidentId, componentName);
-        return ApplicationInsightsErrorMessage.Format(userPrefix, ex, incidentId);
+            "AI call failed. Incident={IncidentId} Component={Component} Workspace={Workspace}",
+            incidentId, componentName, context?.WorkspaceId);
+        return ApplicationInsightsErrorMessage.Format(userPrefix, ex, incidentId, context);
     }
 }

--- a/Quilt4Net.Toolkit.Blazor/Features/Log/LogNavigationOptions.cs
+++ b/Quilt4Net.Toolkit.Blazor/Features/Log/LogNavigationOptions.cs
@@ -21,4 +21,12 @@ public record LogNavigationOptions
     /// When null, clicking a summary link opens a dialog.
     /// </summary>
     public string SummaryPath { get; init; }
+
+    /// <summary>
+    /// Optional path for the host's Application Insights configuration page, e.g. "/monitor/configuration".
+    /// When set, log views render an "Edit configuration" link next to authentication-failure
+    /// alerts so operators can jump straight to the broken AI configuration instead of
+    /// hunting through the configuration list.
+    /// </summary>
+    public string ConfigurationPath { get; init; }
 }

--- a/Quilt4Net.Toolkit.Blazor/Features/Log/LogView.razor
+++ b/Quilt4Net.Toolkit.Blazor/Features/Log/LogView.razor
@@ -58,7 +58,11 @@
         </ChildContent>
         <ErrorContent Context="ex">
             <RadzenAlert AlertStyle="AlertStyle.Warning" Shade="Shade.Lighter" AllowClose="false">
-                @ApplicationInsightsErrorMessage.Format("Could not query Application Insights.", ex, _errorBoundary?.IncidentId)
+                @ApplicationInsightsErrorMessage.Format("Could not query Application Insights.", ex, _errorBoundary?.IncidentId, Context)
+                @if (!string.IsNullOrEmpty(ConfigurationPath) && ApplicationInsightsErrorMessage.IsAuthenticationFailure(ex))
+                {
+                    <text> </text><RadzenLink Path="@ConfigurationPath" Text="Edit configuration" />
+                }
             </RadzenAlert>
         </ErrorContent>
     </LoggingErrorBoundary>
@@ -106,6 +110,15 @@
     /// </summary>
     [Parameter]
     public string SummaryPath { get; set; }
+
+    /// <summary>
+    /// Optional path for the host's Application Insights configuration page, e.g. "/monitor/configuration".
+    /// When set, log views render an "Edit configuration" link next to authentication-failure
+    /// alerts so operators can jump straight to the broken AI configuration instead of
+    /// hunting through the configuration list.
+    /// </summary>
+    [Parameter]
+    public string ConfigurationPath { get; set; }
 
     /// <summary>
     /// The initially selected tab name (e.g. "summary"). Case-insensitive.
@@ -199,7 +212,8 @@
         _navOptions = new LogNavigationOptions
         {
             DetailPath = DetailPath,
-            SummaryPath = SummaryPath
+            SummaryPath = SummaryPath,
+            ConfigurationPath = ConfigurationPath
         };
 
         _effectiveAliasMap = ApplicationAliasMap ?? ResolveStaticMap();

--- a/Quilt4Net.Toolkit.Blazor/Features/VersionMatrix/VersionMatrixDisplay.razor
+++ b/Quilt4Net.Toolkit.Blazor/Features/VersionMatrix/VersionMatrixDisplay.razor
@@ -1,4 +1,5 @@
 @using Quilt4Net.Toolkit
+@using Quilt4Net.Toolkit.Blazor.Features.Log
 @using Quilt4Net.Toolkit.Features.ApplicationInsights
 @using Microsoft.Extensions.Logging
 @using Microsoft.Extensions.Options
@@ -21,7 +22,13 @@
     }
     else if (_error != null)
     {
-        <RadzenAlert AlertStyle="AlertStyle.Danger" Title="Failed to load version matrix" AllowClose="false" Text="@_error" />
+        <RadzenAlert AlertStyle="AlertStyle.Danger" Title="Failed to load version matrix" AllowClose="false">
+            @_error
+            @if (_errorIsAuthFailure && !string.IsNullOrEmpty(ConfigurationPath))
+            {
+                <text> </text><RadzenLink Path="@ConfigurationPath" Text="Edit configuration" />
+            }
+        </RadzenAlert>
     }
     else if (_view == null || _view.Applications.Count == 0)
     {
@@ -121,10 +128,19 @@
     [Parameter]
     public IReadOnlyList<string> EnvironmentOrder { get; set; }
 
+    /// <summary>
+    /// Optional path for the host's Application Insights configuration page, e.g. "/monitor/configuration".
+    /// When set, an "Edit configuration" link is rendered next to authentication-failure alerts so
+    /// operators can jump straight to the broken AI configuration instead of hunting through the list.
+    /// </summary>
+    [Parameter]
+    public string ConfigurationPath { get; set; }
+
     private VersionMatrixView _view;
     private IReadOnlyList<string> _orderedEnvironments = [];
     private bool _loading;
     private string _error;
+    private bool _errorIsAuthFailure;
 
     protected override async Task OnInitializedAsync()
     {
@@ -140,6 +156,7 @@
     {
         _loading = true;
         _error = null;
+        _errorIsAuthFailure = false;
         StateHasChanged();
 
         try
@@ -168,8 +185,9 @@
         }
         catch (Exception ex)
         {
-            Logger.LogError(ex, "Failed to load version matrix.");
-            _error = ex.Message;
+            _error = LogIncidentLogger.LogAndFormat(Logger, ex, nameof(VersionMatrixDisplay),
+                "Failed to load version matrix.", Context);
+            _errorIsAuthFailure = ApplicationInsightsErrorMessage.IsAuthenticationFailure(ex);
         }
         finally
         {


### PR DESCRIPTION
## Summary

When a workspace's `ClientSecret` is rotated or expires, our existing alert reads `Could not load Application Insights environments. ... [Incident: XXXXX]` and buries the cause behind ~50 identical exceptions per session — operators have to bisect the configuration list to find which AI workspace is broken.

This PR makes the failure self-identifying and one-click fixable from the consuming app.

- **`ApplicationInsightsErrorMessage.Format`** — new 4-arg overload taking `IApplicationInsightsContext`. Auth-failure body now reads `Application Insights authentication failed for workspace {WorkspaceId} — the configured TenantId, ClientId or ClientSecret may be incorrect, the secret may have expired, or the service principal may not have access to the workspace.` Three earlier overloads are preserved (back-compat).
- **`LogIncidentLogger.LogAndFormat`** — optional `IApplicationInsightsContext context = null`. Structured log line now includes `Workspace={WorkspaceId}` alongside the incident id.
- **`LogNavigationOptions.ConfigurationPath`** — new optional path. When set, log views render an `Edit configuration` `RadzenLink` next to authentication-failure alerts.
- **Wired into three catch sites:**
  - `LogView` — propagates `ConfigurationPath` via the existing cascading `_navOptions` and renders the link inside the `LoggingErrorBoundary` `ErrorContent`.
  - `LogEnvironmentSelector` — picks up `LogNavigationOptions` via `[CascadingParameter]`, tracks `_loadErrorIsAuthFailure`, renders the link in its warning alert.
  - `VersionMatrixDisplay` — own `[Parameter] string ConfigurationPath`. Side benefit: previously dumped `ex.Message` to a Danger alert with no incident logging; now uses `LogIncidentLogger` like the other catch sites, so failures here also get a correlation id and the same friendly auth-failure body.

## Test plan

- [x] `dotnet build -c Release` — 0 errors, 254 warnings (under the 261 ratchet ceiling = ceil(248 × 1.05))
- [x] `dotnet test Quilt4Net.Toolkit.Blazor.Tests` — 58 passed (3 new in `ApplicationInsightsErrorMessageTests` covering: workspace clause when context supplied, no clause when context null, non-auth exceptions unaffected by context)
- [ ] Smoke: in the consuming app, force an auth failure (revoke/rotate the AI workspace secret) and confirm the alert reads `... for workspace <id> ...` with a working `Edit configuration` link

## Follow-up (separate PRs / cycles)

- Bump `Quilt4Net.Toolkit.*` to next nuget version
- In Quilt4Net.Server, pass `ConfigurationPath="/monitor/configuration"` from `MonitorLog` and `MonitorVersion` so the link routes to the team's existing AI config admin page