### PR TITLE
Shrink GetSummaries result set so KQL stops hitting the 64MB ceiling

### DIFF
--- a/Quilt4Net.Toolkit.Tests/SummarizeByFingerprintTests.cs
+++ b/Quilt4Net.Toolkit.Tests/SummarizeByFingerprintTests.cs
@@ -1,0 +1,55 @@
+using FluentAssertions;
+using Quilt4Net.Toolkit.Features.ApplicationInsights;
+using Xunit;
+
+namespace Quilt4Net.Toolkit.Tests;
+
+/// <summary>
+/// The summary list KQL used to bucket by (Fingerprint, Message, Environment, Application, SeverityLevel),
+/// which on busy workspaces produced a row per (fingerprint × message variant) and could blow past
+/// Kusto's 64MB result-set limit. This file pins the new shape so a future edit can't regress to the
+/// over-keyed grouping.
+/// </summary>
+public class SummarizeByFingerprintTests
+{
+    [Fact]
+    public void Buckets_by_fingerprint_only()
+    {
+        ApplicationInsightsService.SummarizeByFingerprint
+            .Should().Contain("by Fingerprint")
+            .And.NotContain("by Fingerprint, Message")
+            .And.NotContain("by Fingerprint, Environment")
+            .And.NotContain("by Fingerprint, Application");
+    }
+
+    [Fact]
+    public void Takes_a_representative_sample_for_descriptive_columns()
+    {
+        ApplicationInsightsService.SummarizeByFingerprint
+            .Should().Contain("Message = take_any(Message)")
+            .And.Contain("Environment = take_any(Environment)")
+            .And.Contain("Application = take_any(Application)");
+    }
+
+    [Fact]
+    public void Aggregates_severity_to_the_max_observed()
+    {
+        ApplicationInsightsService.SummarizeByFingerprint
+            .Should().Contain("SeverityLevel = max(SeverityLevel)");
+    }
+
+    [Fact]
+    public void Counts_occurrences_and_tracks_last_seen()
+    {
+        ApplicationInsightsService.SummarizeByFingerprint
+            .Should().Contain("Count = count()")
+            .And.Contain("LastTimeGenerated = max(TimeGenerated)");
+    }
+
+    [Fact]
+    public void Orders_results_so_the_C_sharp_layer_dedupe_keeps_the_most_recent()
+    {
+        ApplicationInsightsService.SummarizeByFingerprint
+            .Should().Contain("order by LastTimeGenerated desc");
+    }
+}

--- a/Quilt4Net.Toolkit/Features/ApplicationInsights/ApplicationInsightsService.cs
+++ b/Quilt4Net.Toolkit/Features/ApplicationInsights/ApplicationInsightsService.cs
@@ -30,7 +30,35 @@ internal class ApplicationInsightsService : IApplicationInsightsService
     internal const string VersionProjection =
         "coalesce(tostring(_p[\"service.version\"]), tostring(_p[\"Version\"]), tostring(AppVersion))";
 
+    /// <summary>
+    /// Canonical summarize clause for the <c>GetSummaries</c> queries. Buckets by
+    /// <c>Fingerprint</c> only and takes representative samples for the descriptive columns,
+    /// matching the post-fetch C# dedupe (one row per fingerprint, last-seen wins).
+    ///
+    /// Previously the summarize key was <c>(Fingerprint, Message, Environment, Application, SeverityLevel)</c>,
+    /// which split a single fingerprint into N rows whenever the message text varied (always, for
+    /// formatted trace logs) and could exceed Kusto's 64MB result-set limit. Aligning the server-side
+    /// grouping with what the UI actually shows shrinks the result set by orders of magnitude and
+    /// matches what <c>GetSummaries</c>'s C# layer was already enforcing post-fetch.
+    /// </summary>
+    internal const string SummarizeByFingerprint = @"| summarize
+    Count = count(),
+    LastTimeGenerated = max(TimeGenerated),
+    Message = take_any(Message),
+    Environment = take_any(Environment),
+    Application = take_any(Application),
+    SeverityLevel = max(SeverityLevel)
+    by Fingerprint
+| order by LastTimeGenerated desc";
+
     private static readonly LogsQueryOptions _probeOptions = new() { ServerTimeout = TimeSpan.FromSeconds(5) };
+
+    /// <summary>
+    /// Used by <c>GetSummariesInternal</c>. <c>AllowPartialErrors = true</c> means the SDK returns
+    /// truncation warnings via <c>LogsQueryResult.Error</c> instead of throwing — defence-in-depth
+    /// for any future query that grows past the 64MB limit despite the tightened summarize clause.
+    /// </summary>
+    private static readonly LogsQueryOptions _summariesQueryOptions = new() { AllowPartialErrors = true };
     private readonly ConcurrentDictionary<ClientKey, LogsQueryClient> _clientCache = new();
     private readonly ITimeToLiveCache _timeToLiveCache;
     private readonly ApplicationInsightsOptions _options;
@@ -886,11 +914,7 @@ AppExceptions
     Application = coalesce(tostring(_p[""ApplicationName""]), tostring(AppRoleName)),
     SeverityLevel = toint(SeverityLevel)
 {envFilter}
-| summarize
-    Count = count(),
-    LastTimeGenerated = max(TimeGenerated)
-    by Fingerprint, Message, Environment, Application, SeverityLevel
-| order by LastTimeGenerated desc";
+{SummarizeByFingerprint}";
 
         var appTracesQuery = $@"
 AppTraces
@@ -905,11 +929,7 @@ AppTraces
     Application = coalesce(tostring(_p[""ApplicationName""]), tostring(AppRoleName)),
     SeverityLevel = toint(SeverityLevel)
 {envFilter}
-| summarize
-    Count = count(),
-    LastTimeGenerated = max(TimeGenerated)
-    by Fingerprint, Message, Environment, Application, SeverityLevel
-| order by LastTimeGenerated desc";
+{SummarizeByFingerprint}";
 
         var appRequestsQuery = $@"
 AppRequests
@@ -922,18 +942,22 @@ AppRequests
     Application = coalesce(tostring(_p[""ApplicationName""]), tostring(AppRoleName)),
     SeverityLevel = iif(tobool(coalesce(Success, true)), 1, 3)
 {envFilter}
-| summarize
-    Count = count(),
-    LastTimeGenerated = max(TimeGenerated)
-    by Fingerprint, Message, Environment, Application, SeverityLevel
-| order by LastTimeGenerated desc";
+{SummarizeByFingerprint}";
 
         async IAsyncEnumerable<SummarySubset> Run(string query, LogSource source)
         {
             var response = await client.QueryWorkspaceAsync(
                 workspaceId,
                 query,
-                new LogsQueryTimeRange(timeSpan));
+                new LogsQueryTimeRange(timeSpan),
+                _summariesQueryOptions);
+
+            if (response.Value.Error != null)
+            {
+                _logger.LogWarning(
+                    "GetSummaries returned a partial result for {Source}. Error={Error} WorkspaceId={WorkspaceId} TimeSpan={TimeSpan}",
+                    source, response.Value.Error.Message, MaskId(workspaceId), timeSpan);
+            }
 
             var table = response.Value.Table;
 


### PR DESCRIPTION
## Summary

Step #3 of the prod-exception cleanup. `Quilt4Net.Server` v4.2.16.0 has been throwing `Azure.RequestFailedException` (`E_QUERY_RESULT_SET_TOO_LARGE` / partial-error, 5 occurrences) from the toolkit's `GetSummariesInternal`. Confirmed via AI: the failure is on the summaries list (`Fingerprint, Message, Environment, Application, SeverityLevel, Count, LastTimeGenerated` columns), not `GetDetail`/`SearchAsync` as the original feature plan suspected.

### Root cause

The three queries in `GetSummariesInternal` summarize by `(Fingerprint, Message, Environment, Application, SeverityLevel)`. When the same `ProblemId` hash maps to many message-text variants — which is *always* the case for formatted trace logs — the server emits one row per variant. Long messages (think 10KB JSON dumps) × thousands of variants per fingerprint blows past Kusto's 64MB result-set limit.

The C# layer in `GetSummaries` has long had `list.GroupBy(x => x.Fingerprint).Select(x => x.First())` which collapses everything down to one row per fingerprint anyway. So the extra rows the server was generating were thrown away on receipt — the over-keying was waste that also failed.

### Fix

- **Align the server-side summarize with the actual UI semantic** — bucket by `Fingerprint` only, use `take_any()` for `Message`/`Environment`/`Application` and `max()` for `SeverityLevel`. Result-set shrinks by orders of magnitude on busy workspaces; the C# dedupe becomes a no-op safety net.
- **Defence-in-depth** — share a `_summariesQueryOptions` with `AllowPartialErrors = true`, so any future query that still grows past the limit returns partial data with a `LogsQueryResult.Error` instead of throwing. Emit a structured `Warning` log when `Error != null` so truncation shows up in our own AI logs and we can spot it before users report a 500.
- **Pin the new shape** — extracted into `internal const string SummarizeByFingerprint`, with `SummarizeByFingerprintTests` (5 tests) asserting it groups by Fingerprint only, samples descriptive columns via `take_any()`, takes `max(SeverityLevel)`, and orders by last-seen-desc (so the C# dedupe keeps the most recent).

### Test plan

- [x] `dotnet build -c Release` (Toolkit-only): 0 errors, 254 warnings (under the 261 ratchet ceiling)
- [x] `dotnet test -c Release` — 221 passed, 0 failed (5 new in `SummarizeByFingerprintTests`)
- [ ] Once deployed: KQL `AppExceptions | where AppRoleName == 'Quilt4Net.Server' and AppVersion == '<new>' and OuterType == 'Azure.RequestFailedException'` should drop to zero. Worst-case detail page no longer 500s.

### Branch context

Steps 2 and 4 from the feature plan are Server-only and don't need a toolkit cycle, so this PR closes the toolkit work for the prod-exception fix feature. Once merged + published as the next `Quilt4Net.Toolkit.*` nuget alongside #83, Server can bump to it in one go.