### PR TITLE
ConnectionService no longer crashes when only half the toolkit is registered

### DIFF
--- a/Quilt4Net.Toolkit.Tests/ConnectionServiceUnconfiguredTests.cs
+++ b/Quilt4Net.Toolkit.Tests/ConnectionServiceUnconfiguredTests.cs
@@ -1,0 +1,86 @@
+using FluentAssertions;
+using Microsoft.Extensions.Options;
+using Quilt4Net.Toolkit.Framework;
+using Xunit;
+
+namespace Quilt4Net.Toolkit.Tests;
+
+/// <summary>
+/// Pre-fix repro: a consumer who called <c>AddQuilt4NetRemoteConfiguration()</c> but not
+/// <c>AddQuilt4NetContent()</c> got <c>IConnectionService</c> registered (it's part of
+/// RemoteConfiguration), but <c>IOptions&lt;ContentOptions&gt;</c> resolved to a default-
+/// constructed instance with <c>Quilt4NetAddress = null</c>. The first health probe doing
+/// <c>CanConnectAsync(Service.Content)</c> hit <c>new Uri(null)</c> outside the try/catch
+/// and crashed with a 23-second elapsed time and "Value cannot be null. (Parameter 'uriString')".
+///
+/// These tests pin the post-fix shape: option type defaults to https://quilt4net.com/, and
+/// any explicit-null sneak path returns a friendly Unhealthy result instead of throwing.
+/// </summary>
+public class ConnectionServiceUnconfiguredTests
+{
+    [Fact]
+    public void ContentOptions_defaults_Quilt4NetAddress_to_public_url()
+    {
+        new ContentOptions().Quilt4NetAddress.Should().Be("https://quilt4net.com/");
+    }
+
+    [Fact]
+    public void RemoteConfigurationOptions_defaults_Quilt4NetAddress_to_public_url()
+    {
+        new RemoteConfigurationOptions().Quilt4NetAddress.Should().Be("https://quilt4net.com/");
+    }
+
+    [Fact]
+    public async Task Service_Content_with_null_address_returns_actionable_error_instead_of_throwing()
+    {
+        var sut = CreateSut(contentAddress: null, configurationAddress: "https://example.com/");
+
+        var result = await sut.CanConnectAsync(Service.Content);
+
+        result.Success.Should().BeFalse();
+        result.Message.Should().Contain("ContentOptions.Quilt4NetAddress")
+                     .And.Contain("AddQuilt4NetContent");
+    }
+
+    [Fact]
+    public async Task Service_Configuration_with_null_address_returns_actionable_error_instead_of_throwing()
+    {
+        var sut = CreateSut(contentAddress: "https://example.com/", configurationAddress: null);
+
+        var result = await sut.CanConnectAsync(Service.Configuration);
+
+        result.Success.Should().BeFalse();
+        result.Message.Should().Contain("RemoteConfigurationOptions.Quilt4NetAddress")
+                     .And.Contain("AddQuilt4NetRemoteConfiguration");
+    }
+
+    [Fact]
+    public async Task Malformed_address_returns_friendly_message_with_the_offending_value()
+    {
+        var sut = CreateSut(contentAddress: "not-a-url", configurationAddress: "https://example.com/");
+
+        var result = await sut.CanConnectAsync(Service.Content);
+
+        result.Success.Should().BeFalse();
+        result.Message.Should().Contain("not-a-url")
+                     .And.Contain("absolute URI");
+    }
+
+    [Fact]
+    public async Task Config_failure_is_cached_so_subsequent_probes_return_immediately()
+    {
+        var sut = CreateSut(contentAddress: null, configurationAddress: "https://example.com/");
+
+        var first = await sut.CanConnectAsync(Service.Content);
+        var second = await sut.CanConnectAsync(Service.Content);
+
+        second.Should().BeSameAs(first);
+    }
+
+    private static ConnectionService CreateSut(string contentAddress, string configurationAddress)
+    {
+        var content = Options.Create(new ContentOptions { Quilt4NetAddress = contentAddress });
+        var configuration = Options.Create(new RemoteConfigurationOptions { Quilt4NetAddress = configurationAddress });
+        return new ConnectionService(content, configuration);
+    }
+}

--- a/Quilt4Net.Toolkit/ContentOptions.cs
+++ b/Quilt4Net.Toolkit/ContentOptions.cs
@@ -13,9 +13,12 @@ public record ContentOptions
 
     /// <summary>
     /// Address to the Quilt4Net server.
-    /// Default is https://quilt4net.com/.
+    /// Default is https://quilt4net.com/. Defaulted on the type so an unbound
+    /// <c>IOptions&lt;ContentOptions&gt;</c> still carries a usable URL when only
+    /// part of the toolkit is registered (e.g. <c>AddQuilt4NetRemoteConfiguration</c>
+    /// without <c>AddQuilt4NetContent</c>).
     /// </summary>
-    public string Quilt4NetAddress { get; set; }
+    public string Quilt4NetAddress { get; set; } = "https://quilt4net.com/";
 
     /// <summary>
     /// Api key to be used for calls to the server.

--- a/Quilt4Net.Toolkit/Framework/ConnectionService.cs
+++ b/Quilt4Net.Toolkit/Framework/ConnectionService.cs
@@ -22,14 +22,24 @@ internal class ConnectionService : IConnectionService
         if (_cache.TryGetValue(service, out var cached))
             return cached;
 
-        var config = GetConfiguration(service);
+        if (!TryGetConfiguration(service, out var config, out var configError))
+        {
+            // Cache the unconfigured result so subsequent probes return immediately
+            // instead of paying the upstream HealthService timeout per call.
+            var unconfigured = new ConnectionResult { Success = false, Message = configError };
+            _cache[service] = unconfigured;
+            return unconfigured;
+        }
 
         try
         {
             using var client = new HttpClient();
 
             client.BaseAddress = config.BaseAddress;
-            client.DefaultRequestHeaders.Add("X-API-KEY", config.ApiKey);
+            if (!string.IsNullOrEmpty(config.ApiKey))
+            {
+                client.DefaultRequestHeaders.Add("X-API-KEY", config.ApiKey);
+            }
 
             var response = await client.GetAsync("Api/System/WhoAmI");
 
@@ -63,13 +73,37 @@ internal class ConnectionService : IConnectionService
         }
     }
 
-    private (Uri BaseAddress, string ApiKey) GetConfiguration(Service service)
+    /// <summary>
+    /// Resolves the per-service base address + api key. Returns false (not throws) when
+    /// the configured address is missing or unparseable, so the caller can surface an
+    /// <c>Unhealthy</c> result with an actionable message instead of letting
+    /// <c>new Uri(null)</c> escape past <see cref="CanConnectAsync"/>'s try/catch.
+    /// </summary>
+    private bool TryGetConfiguration(Service service, out (Uri BaseAddress, string ApiKey) config, out string error)
     {
-        return service switch
+        var (address, apiKey, optionsName, registrationName) = service switch
         {
-            Service.Content => (new Uri(_contentOptions.Quilt4NetAddress), _contentOptions.ApiKey),
-            Service.Configuration => (new Uri(_configurationOptions.Quilt4NetAddress), _configurationOptions.ApiKey),
+            Service.Content => (_contentOptions?.Quilt4NetAddress, _contentOptions?.ApiKey, nameof(ContentOptions), "AddQuilt4NetContent"),
+            Service.Configuration => (_configurationOptions?.Quilt4NetAddress, _configurationOptions?.ApiKey, nameof(RemoteConfigurationOptions), "AddQuilt4NetRemoteConfiguration"),
             _ => throw new ArgumentOutOfRangeException(nameof(service), service, null)
         };
+
+        if (string.IsNullOrWhiteSpace(address))
+        {
+            config = default;
+            error = $"{optionsName}.Quilt4NetAddress is not configured. Call {registrationName}() during startup or set Quilt4Net:{optionsName.Replace("Options", string.Empty)}:Quilt4NetAddress (or Quilt4Net:Quilt4NetAddress) in configuration.";
+            return false;
+        }
+
+        if (!Uri.TryCreate(address, UriKind.Absolute, out var uri))
+        {
+            config = default;
+            error = $"{optionsName}.Quilt4NetAddress '{address}' is not a valid absolute URI.";
+            return false;
+        }
+
+        config = (uri, apiKey);
+        error = null;
+        return true;
     }
 }

--- a/Quilt4Net.Toolkit/RemoteConfigurationOptions.cs
+++ b/Quilt4Net.Toolkit/RemoteConfigurationOptions.cs
@@ -3,7 +3,13 @@
 public record RemoteConfigurationOptions
 {
     public TimeSpan? Ttl { get; set; }
-    public string Quilt4NetAddress { get; set; }
+
+    /// <summary>
+    /// Address to the Quilt4Net server.
+    /// Default is https://quilt4net.com/. Defaulted on the type so an unbound
+    /// <c>IOptions&lt;RemoteConfigurationOptions&gt;</c> still carries a usable URL.
+    /// </summary>
+    public string Quilt4NetAddress { get; set; } = "https://quilt4net.com/";
     public string ApiKey { get; set; }
 
     /// <summary>


### PR DESCRIPTION
## Repro

A consumer that calls `AddQuilt4NetRemoteConfiguration()` but **not** `AddQuilt4NetContent()` (the [`blazor-platform`](https://github.com/Tharga/Starter/blob/master/templates/blazor-platform/Tharga.Blazor1/Program.cs) template generates exactly this) gets `IConnectionService` registered — it's part of RemoteConfiguration's DI — but `IOptions<ContentOptions>` resolves to a default-constructed instance with `Quilt4NetAddress = null`. The first health probe doing `CanConnectAsync(Service.Content)` then hits `new Uri(null)` *before* the `try`/`catch` in `CanConnectAsync` and surfaces as:

```
Quilt4Net.Content   Unhealthy   00:00:23.298…
exception.message:    Value cannot be null. (Parameter 'uriString')
exception.stacktrace: at System.Uri..ctor(String uriString)
                      at Quilt4Net.Toolkit.Framework.ConnectionService.GetConfiguration(Service service)
                      at Quilt4Net.Toolkit.Framework.ConnectionService.CanConnectAsync(Service service)
                      at <consumer>.GetComponents() …
                      at Quilt4Net.Toolkit.Features.Health.HealthService.RunTaskAsync(…)
```

The 23-second elapsed time is the upstream HealthService timeout swallowing the unhandled throw.

## Fix — two layers

**1. Self-defaulting options.** `ContentOptions.Quilt4NetAddress` and `RemoteConfigurationOptions.Quilt4NetAddress` now default to `https://quilt4net.com/` on the type itself. An unbound `IOptions<T>` already carries a usable URL, eliminating the bug class for the common "didn't call the matching `Add…`" case.

**2. Defensive ConnectionService.** `GetConfiguration` is replaced with `TryGetConfiguration` that returns `false` (with an actionable message) instead of throwing on null/empty or unparseable URIs:

> `ContentOptions.Quilt4NetAddress is not configured. Call AddQuilt4NetContent() during startup or set Quilt4Net:Content:Quilt4NetAddress (or Quilt4Net:Quilt4NetAddress) in configuration.`

The unconfigured result is now cached so subsequent probes return immediately instead of retrying through the upstream HealthService timeout. The `Uri` construction itself moved inside the existing `try`/`catch` as defence-in-depth for any future failure mode.

Side cleanup: skip the `X-API-KEY` header when the api key is empty (was throwing `ArgumentException` from `HttpRequestHeaders.Add` in the unconfigured case).

## Test plan

- [x] `dotnet build -c Release` — 0 errors, 254 warnings (under the 261 ratchet ceiling)
- [x] `dotnet test Quilt4Net.Toolkit.Tests` — 105 passed (+6 in `ConnectionServiceUnconfiguredTests` covering: type defaults, per-Service null/empty handling with actionable messages, malformed-URI message contents, config-failure caching)

## Companion

Filed [Tharga/Starter#2](https://github.com/Tharga/Starter/issues/2) to add the missing `builder.AddQuilt4NetContent();` to the `blazor-platform` template's `IncludeQuilt4Net` block so future generated projects don't hit this. Both fixes are useful: the toolkit fix prevents the crash class entirely, but the template should still call `AddQuilt4NetContent()` so consumers can override `Quilt4NetAddress` / `ApiKey` via configuration the way they expect.