### PR TITLE
chore: bump Microsoft.ApplicationInsights*, Tharga.Cache, Tharga.Blazor for 0.7.10

### DIFF
--- a/Quilt4Net.Toolkit.Blazor/Features/Log/LogSearchView.razor
+++ b/Quilt4Net.Toolkit.Blazor/Features/Log/LogSearchView.razor
@@ -48,7 +48,7 @@ else if (Model != null)
                             <span title="@($"{context.CorrelationId} (click to filter)")"
                                   style="cursor: pointer; text-decoration: underline; font-family: var(--rz-font-family-monospace, monospace);"
                                   @onclick="@(() => SearchByCorrelationIdAsync(context.CorrelationId))">@preview</span>
-                            <CopyButton Content="@context.CorrelationId" />
+                            <CopyButton Content="@context.CorrelationId" Size="ButtonSize.ExtraSmall"/>
                         </RadzenStack>
                     }
                 </Template>

--- a/Quilt4Net.Toolkit.Blazor/Quilt4Net.Toolkit.Blazor.csproj
+++ b/Quilt4Net.Toolkit.Blazor/Quilt4Net.Toolkit.Blazor.csproj
@@ -27,7 +27,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Authentication.WebAssembly.Msal" Version="10.0.7" />
     <PackageReference Include="Microsoft.Identity.Client" Version="4.84.0" />
-    <PackageReference Include="Tharga.Blazor" Version="2.1.4" />
+    <PackageReference Include="Tharga.Blazor" Version="2.1.5" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Quilt4Net.Toolkit\Quilt4Net.Toolkit.csproj" />

--- a/Quilt4Net.Toolkit.Health/Quilt4Net.Toolkit.Health.csproj
+++ b/Quilt4Net.Toolkit.Health/Quilt4Net.Toolkit.Health.csproj
@@ -40,7 +40,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-	  <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="3.1.0" />
+	  <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="3.1.1" />
 	  <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.203">
 		  <PrivateAssets>all</PrivateAssets>
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Quilt4Net.Toolkit/Quilt4Net.Toolkit.csproj
+++ b/Quilt4Net.Toolkit/Quilt4Net.Toolkit.csproj
@@ -38,7 +38,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Azure.Identity" Version="1.21.0" />
-    <PackageReference Include="Microsoft.ApplicationInsights" Version="3.1.0" />
+    <PackageReference Include="Microsoft.ApplicationInsights" Version="3.1.1" />
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.15.3" />
     <PackageReference Include="Azure.Monitor.Query.Logs" Version="1.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.7" />
@@ -51,6 +51,6 @@
     </PackageReference>
     <PackageReference Include="System.Management" Version="10.0.7" />
     <PackageReference Include="System.Linq.Async" Version="7.0.1" />
-    <PackageReference Include="Tharga.Cache" Version="0.4.3" />
+    <PackageReference Include="Tharga.Cache" Version="0.4.4" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## What

Patch / minor bumps so 0.7.10 ships the addressed transitive security advisory and the latest internal packages alongside the [#85](https://github.com/Quilt4/Quilt4Net.Toolkit/pull/85) ConnectionService null-Uri fix.

| Package | Bump | Project | Why |
|---|---|---|---|
| `Microsoft.ApplicationInsights` | 3.1.0 → 3.1.1 | `Quilt4Net.Toolkit` | Security: addresses [GHSA-g94r-2vxg-569j](https://github.com/advisories/GHSA-g94r-2vxg-569j) in `OpenTelemetry.Api` 1.15.1 by pulling OTel deps to 1.15.2/1.15.3 + `Azure.Monitor.OpenTelemetry.Exporter` 1.8.0 |
| `Microsoft.ApplicationInsights.AspNetCore` | 3.1.0 → 3.1.1 | `Quilt4Net.Toolkit.Health` | Same OTel security fix family |
| `Tharga.Cache` | 0.4.3 → 0.4.4 | `Quilt4Net.Toolkit` | Internal patch |
| `Tharga.Blazor` | 2.1.4 → 2.1.5 | `Quilt4Net.Toolkit.Blazor` | Internal patch |

Plus a small UI polish: `LogSearchView.razor` `CopyButton` gets `Size="ButtonSize.ExtraSmall"` so it doesn't dominate the correlation-id cell.

## Why now

- 0.7.10 is already gated waiting for release-environment approval. Bundling these here means one nuget release covers: the ConnectionService null-Uri fix (#85) + the OTel security patch + the internal patches. Avoids a 0.7.11 right after.
- Cross-major bump `Microsoft.AspNetCore.Components.Authorization 9.0.15 → 10.0.7` deliberately not included — net9.0 TFM should track 9.x.

## Test plan

- [x] `dotnet build -c Release` — 0 errors, 254 warnings (under the 261 ratchet ceiling)
- [x] `dotnet test -c Release --no-build` — **227 passed** (Api 1, Mcp 15, Health 48, core 105, Blazor 58)
- [x] **Server-side compatibility check**: diff has no Toolkit public API surface change (only csproj transitive bumps + a `Size` attribute). Server's direct refs to `Tharga.Cache.Blazor 0.4.3` / `Tharga.Blazor 2.1.4` will be transitively pulled forward to the higher versions when Server bumps to 0.7.10 (NuGet's max-version-wins). Safe.

## After merge

1. Approve the gated release run → 0.7.10 publishes
2. Bump `Quilt4Net.Server`'s `Quilt4Net.Toolkit.{Api,Blazor,Health}` from 0.7.9 → 0.7.10 (separate chore commit on whatever branch is in flight)
3. Other consumers (Eplicta.FortDocs etc.) pick up the ConnectionService null-Uri fix automatically