### PR TITLE
Telemetry hardening: service.instance.id (#86) + registration-order note (#87)

### DIFF
--- a/Quilt4Net.Toolkit.Tests/Quilt4NetStartupLoggerTests.cs
+++ b/Quilt4Net.Toolkit.Tests/Quilt4NetStartupLoggerTests.cs
@@ -56,6 +56,48 @@ public class Quilt4NetStartupLoggerTests
     }
 
     [Fact]
+    public void Log_includes_service_instance_id_in_brackets_when_set()
+    {
+        // Issue #86: when ServiceInstanceId is configured, the startup line surfaces it
+        // between the application name and the version so multi-deployment hosts are
+        // distinguishable at-a-glance, e.g. "Eplicta.FortDocs.Server [Thargelion] v1.2.9 ..."
+        var capture = new CapturingLogger();
+        var options = new Quilt4NetLoggingOptions
+        {
+            ApplicationName = "Eplicta.FortDocs.Server",
+            ServiceInstanceId = "Thargelion",
+            Version = "1.2.9.0",
+            Environment = "CI"
+        };
+
+        Quilt4NetStartupLogger.Log(capture, options);
+
+        capture.Entries[0].FormattedMessage
+            .Should().Be("Quilt4Net startup: Eplicta.FortDocs.Server [Thargelion] v1.2.9.0 in CI");
+    }
+
+    [Fact]
+    public void Log_omits_brackets_when_service_instance_id_is_null_for_back_compat()
+    {
+        // The historical message shape must be preserved when the new option is unset, so
+        // existing log scrapers / dashboards that match the old format don't regress.
+        var capture = new CapturingLogger();
+        var options = new Quilt4NetLoggingOptions
+        {
+            ApplicationName = "Eplicta.FortDocs.Server",
+            ServiceInstanceId = null,
+            Version = "1.2.9.0",
+            Environment = "CI"
+        };
+
+        Quilt4NetStartupLogger.Log(capture, options);
+
+        capture.Entries[0].FormattedMessage
+            .Should().Be("Quilt4Net startup: Eplicta.FortDocs.Server v1.2.9.0 in CI")
+            .And.NotContain("[");
+    }
+
+    [Fact]
     public async Task Hosted_service_emits_log_on_StartAsync()
     {
         var capture = new CapturingLogger<Quilt4NetStartupHostedService>();

--- a/Quilt4Net.Toolkit.Tests/RegistrationOrderTests.cs
+++ b/Quilt4Net.Toolkit.Tests/RegistrationOrderTests.cs
@@ -1,0 +1,186 @@
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Logging;
+using OpenTelemetry;
+using OpenTelemetry.Logs;
+using Quilt4Net.Toolkit;
+using Xunit;
+
+namespace Quilt4Net.Toolkit.Tests;
+
+/// <summary>
+/// Repro for https://github.com/Quilt4/Quilt4Net.Toolkit/issues/87 — when a consumer
+/// calls <c>AddQuilt4NetLogging()</c> BEFORE registering another ILoggerProvider
+/// (e.g. Microsoft.ApplicationInsights.AspNetCore) AND replaces ILoggerFactory with
+/// a custom wrap that iterates <c>sp.GetServices&lt;ILoggerProvider&gt;()</c>, the
+/// AppTraces flow silently breaks — log records never reach the OTel processor that
+/// would forward them to the Azure Monitor exporter. The reverse order works.
+///
+/// These tests pin the symptom and let us validate any fix.
+/// </summary>
+public class RegistrationOrderTests
+{
+    [Fact]
+    public void Quilt4Net_first_then_other_provider_then_factory_wrap_REACHES_otel_processor()
+    {
+        var capturedByOTel = new List<string>();
+        var capturedByOther = new List<string>();
+
+        var services = new ServiceCollection();
+
+        // (1) Quilt4Net first — registers OTel pipeline via AddOpenTelemetry().WithLogging(...).
+        services.AddOpenTelemetry()
+            .WithLogging(b => b.AddProcessor(new CaptureProcessor(r => capturedByOTel.Add(r.Body!))));
+
+        // (2) Some other ILoggerProvider — stand-in for Microsoft.ApplicationInsights.AspNetCore's
+        //     ApplicationInsightsLoggerProvider. We register it the same way AI does:
+        //     services.AddSingleton<ILoggerProvider, ApplicationInsightsLoggerProvider>().
+        services.AddSingleton<ILoggerProvider>(_ => new CapturingLoggerProvider(capturedByOther));
+
+        // (3) Custom ILoggerFactory wrap — exactly the shape the consumer described:
+        //     "iterates sp.GetServices<ILoggerProvider>() and rebuilds a LoggerFactory".
+        services.AddSingleton<ILoggerFactory>(sp =>
+        {
+            var providers = sp.GetServices<ILoggerProvider>().ToArray();
+            return new LoggerFactory(providers);
+        });
+
+        using var sp2 = services.BuildServiceProvider();
+        var loggerFactory = sp2.GetRequiredService<ILoggerFactory>();
+        var logger = loggerFactory.CreateLogger("test");
+        logger.LogInformation("hello-broken-order");
+
+        // Force the OTel SDK to flush any batched log records before assertion.
+        sp2.GetRequiredService<LoggerProvider>().ForceFlush(2_000);
+
+        capturedByOther.Should().Contain("hello-broken-order",
+            "the AI-style ILoggerProvider must always see the record (sanity check)");
+
+        capturedByOTel.Should().Contain("hello-broken-order",
+            "ISSUE #87: the OTel processor should also see the record, regardless of registration order");
+    }
+
+    [Fact]
+    public void Other_provider_first_then_factory_wrap_then_Quilt4Net_REACHES_otel_processor()
+    {
+        var capturedByOTel = new List<string>();
+        var capturedByOther = new List<string>();
+
+        var services = new ServiceCollection();
+
+        // (1) Other provider first.
+        services.AddSingleton<ILoggerProvider>(_ => new CapturingLoggerProvider(capturedByOther));
+
+        // (2) Custom ILoggerFactory wrap — at this point only the other provider exists in DI.
+        services.AddSingleton<ILoggerFactory>(sp =>
+        {
+            var providers = sp.GetServices<ILoggerProvider>().ToArray();
+            return new LoggerFactory(providers);
+        });
+
+        // (3) Quilt4Net last.
+        services.AddOpenTelemetry()
+            .WithLogging(b => b.AddProcessor(new CaptureProcessor(r => capturedByOTel.Add(r.Body!))));
+
+        using var sp2 = services.BuildServiceProvider();
+        var loggerFactory = sp2.GetRequiredService<ILoggerFactory>();
+        var logger = loggerFactory.CreateLogger("test");
+        logger.LogInformation("hello-working-order");
+
+        sp2.GetRequiredService<LoggerProvider>().ForceFlush(2_000);
+
+        capturedByOther.Should().Contain("hello-working-order");
+        capturedByOTel.Should().Contain("hello-working-order");
+    }
+
+    [Fact]
+    public void Quilt4Net_first_then_other_provider_via_AddLogging_then_factory_wrap_REACHES_otel_processor()
+    {
+        // Variant: the "other provider" is registered via `services.AddLogging(b => b.AddProvider(...))`
+        // (which is the canonical pattern — Microsoft.ApplicationInsights.AspNetCore registers its
+        // ApplicationInsightsLoggerProvider through ILoggingBuilder, not directly via TryAddEnumerable).
+        var capturedByOTel = new List<string>();
+        var capturedByOther = new List<string>();
+
+        var services = new ServiceCollection();
+
+        services.AddOpenTelemetry()
+            .WithLogging(b => b.AddProcessor(new CaptureProcessor(r => capturedByOTel.Add(r.Body!))));
+
+        services.AddLogging(b => b.AddProvider(new CapturingLoggerProvider(capturedByOther)));
+
+        services.AddSingleton<ILoggerFactory>(sp =>
+        {
+            var providers = sp.GetServices<ILoggerProvider>().ToArray();
+            return new LoggerFactory(providers);
+        });
+
+        using var sp2 = services.BuildServiceProvider();
+        var loggerFactory = sp2.GetRequiredService<ILoggerFactory>();
+        loggerFactory.CreateLogger("test").LogInformation("hello-via-addlogging");
+        sp2.GetRequiredService<LoggerProvider>().ForceFlush(2_000);
+
+        capturedByOther.Should().Contain("hello-via-addlogging");
+        capturedByOTel.Should().Contain("hello-via-addlogging");
+    }
+
+    [Fact]
+    public void Quilt4Net_first_then_factory_replace_via_Replace_loses_otel_processor_or_not()
+    {
+        // Variant: the consumer replaces ILoggerFactory via `services.Replace(...)` rather than
+        // adding a new singleton on top. This semantically removes the previous registration.
+        // Tests whether OTel's auto-injected ILoggerFactory binding survives a Replace.
+        var capturedByOTel = new List<string>();
+
+        var services = new ServiceCollection();
+
+        services.AddOpenTelemetry()
+            .WithLogging(b => b.AddProcessor(new CaptureProcessor(r => capturedByOTel.Add(r.Body!))));
+
+        // Now Replace the registered ILoggerFactory with a wrap (Replace removes existing,
+        // adds new). Mimics a stronger "I own ILoggerFactory" pattern.
+        services.Replace(ServiceDescriptor.Singleton<ILoggerFactory>(sp =>
+        {
+            var providers = sp.GetServices<ILoggerProvider>().ToArray();
+            return new LoggerFactory(providers);
+        }));
+
+        using var sp2 = services.BuildServiceProvider();
+        var loggerFactory = sp2.GetRequiredService<ILoggerFactory>();
+        loggerFactory.CreateLogger("test").LogInformation("hello-replaced");
+        sp2.GetRequiredService<LoggerProvider>().ForceFlush(2_000);
+
+        capturedByOTel.Should().Contain("hello-replaced");
+    }
+
+    private sealed class CaptureProcessor : BaseProcessor<LogRecord>
+    {
+        private readonly Action<LogRecord> _capture;
+        public CaptureProcessor(Action<LogRecord> capture) => _capture = capture;
+        public override void OnEnd(LogRecord data) => _capture(data);
+    }
+
+    /// <summary>
+    /// Minimal stand-in for <c>Microsoft.ApplicationInsights.AspNetCore</c>'s
+    /// <c>ApplicationInsightsLoggerProvider</c> — captures log message bodies so the
+    /// test can assert which providers actually saw a given record.
+    /// </summary>
+    private sealed class CapturingLoggerProvider : ILoggerProvider
+    {
+        private readonly List<string> _captured;
+        public CapturingLoggerProvider(List<string> captured) => _captured = captured;
+        public ILogger CreateLogger(string categoryName) => new CapturingLogger(_captured);
+        public void Dispose() { }
+
+        private sealed class CapturingLogger : ILogger
+        {
+            private readonly List<string> _captured;
+            public CapturingLogger(List<string> captured) => _captured = captured;
+            public IDisposable BeginScope<TState>(TState state) => null!;
+            public bool IsEnabled(LogLevel logLevel) => true;
+            public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter)
+                => _captured.Add(formatter(state, exception));
+        }
+    }
+}

--- a/Quilt4Net.Toolkit.Tests/ServiceInstanceIdResolverTests.cs
+++ b/Quilt4Net.Toolkit.Tests/ServiceInstanceIdResolverTests.cs
@@ -1,0 +1,108 @@
+using FluentAssertions;
+using Quilt4Net.Toolkit.Features.Logging;
+using Xunit;
+
+namespace Quilt4Net.Toolkit.Tests;
+
+/// <summary>
+/// Issue #86 — when a consumer deploys the same compiled service under multiple logical
+/// names, telemetry needs <c>service.instance.id</c> to disambiguate them. The resolver
+/// reads from a precedence chain so consumers can pick the source that fits their hosting
+/// environment (option lambda for code-based config, OTel-standard env var for OTel-aware
+/// platforms, Quilt4Net shorthand for hosts that don't want to construct the multi-key
+/// OTel string by hand).
+///
+/// These tests pin the precedence and the back-compat null fallback. The resolver is
+/// pure (env reader injected) so no real env-var manipulation is needed.
+/// </summary>
+public class ServiceInstanceIdResolverTests
+{
+    [Fact]
+    public void Option_value_wins_over_both_env_vars()
+    {
+        var env = Env(("OTEL_RESOURCE_ATTRIBUTES", "service.instance.id=fromOtel"),
+                      ("QUILT4NET_SERVICE_INSTANCE_ID", "fromShorthand"));
+
+        ServiceInstanceIdResolver.Resolve("fromOption", env)
+            .Should().Be("fromOption");
+    }
+
+    [Fact]
+    public void OTEL_RESOURCE_ATTRIBUTES_wins_when_option_is_null()
+    {
+        var env = Env(("OTEL_RESOURCE_ATTRIBUTES", "service.instance.id=fromOtel"),
+                      ("QUILT4NET_SERVICE_INSTANCE_ID", "fromShorthand"));
+
+        ServiceInstanceIdResolver.Resolve(null, env)
+            .Should().Be("fromOtel");
+    }
+
+    [Fact]
+    public void OTEL_RESOURCE_ATTRIBUTES_extracts_only_the_service_instance_id_pair()
+    {
+        // The env var is comma-separated key=value pairs per the OTel spec — make sure
+        // we pluck out the right one and ignore the others.
+        var env = Env(("OTEL_RESOURCE_ATTRIBUTES",
+            "service.namespace=production, service.instance.id=Thargelion, deployment.environment=CI"));
+
+        ServiceInstanceIdResolver.Resolve(null, env)
+            .Should().Be("Thargelion");
+    }
+
+    [Fact]
+    public void OTEL_RESOURCE_ATTRIBUTES_pair_lookup_is_case_insensitive_for_the_key()
+    {
+        var env = Env(("OTEL_RESOURCE_ATTRIBUTES", "Service.Instance.Id=fromOtel"));
+
+        ServiceInstanceIdResolver.Resolve(null, env)
+            .Should().Be("fromOtel");
+    }
+
+    [Fact]
+    public void QUILT4NET_shorthand_env_wins_when_option_and_OTEL_are_absent()
+    {
+        var env = Env(("QUILT4NET_SERVICE_INSTANCE_ID", "fromShorthand"));
+
+        ServiceInstanceIdResolver.Resolve(null, env)
+            .Should().Be("fromShorthand");
+    }
+
+    [Fact]
+    public void Returns_null_when_nothing_is_configured_so_callers_keep_back_compat_fallback()
+    {
+        ServiceInstanceIdResolver.Resolve(null, Env())
+            .Should().BeNull();
+    }
+
+    [Fact]
+    public void Whitespace_only_option_value_is_treated_as_unset()
+    {
+        var env = Env(("QUILT4NET_SERVICE_INSTANCE_ID", "fromShorthand"));
+
+        ServiceInstanceIdResolver.Resolve("   ", env)
+            .Should().Be("fromShorthand");
+    }
+
+    [Fact]
+    public void Empty_OTEL_pair_value_is_skipped_and_falls_through_to_shorthand()
+    {
+        var env = Env(("OTEL_RESOURCE_ATTRIBUTES", "service.instance.id="),
+                      ("QUILT4NET_SERVICE_INSTANCE_ID", "fromShorthand"));
+
+        ServiceInstanceIdResolver.Resolve(null, env)
+            .Should().Be("fromShorthand");
+    }
+
+    [Fact]
+    public void Trims_surrounding_whitespace_from_the_resolved_value()
+    {
+        ServiceInstanceIdResolver.Resolve("  Thargelion  ", Env())
+            .Should().Be("Thargelion");
+    }
+
+    private static Func<string, string> Env(params (string Key, string Value)[] pairs)
+    {
+        var dict = pairs.ToDictionary(p => p.Key, p => p.Value, StringComparer.OrdinalIgnoreCase);
+        return name => dict.TryGetValue(name, out var v) ? v : null;
+    }
+}

--- a/Quilt4Net.Toolkit.Tests/TelemetryIdentityEnrichmentTests.cs
+++ b/Quilt4Net.Toolkit.Tests/TelemetryIdentityEnrichmentTests.cs
@@ -15,10 +15,11 @@ public class TelemetryIdentityEnrichmentTests
         ApplicationName: "MyApp",
         Version: "1.2.3",
         MachineName: "host-42",
-        MonitorName: "Quilt4Net");
+        MonitorName: "Quilt4Net",
+        ServiceInstanceId: "Thargelion");
 
     [Fact]
-    public void LogProcessor_attaches_all_five_attributes_to_a_record()
+    public void LogProcessor_attaches_all_six_attributes_to_a_record_when_identity_is_full()
     {
         var record = BuildLogRecord();
 
@@ -29,6 +30,21 @@ public class TelemetryIdentityEnrichmentTests
         record.Attributes.Should().Contain(new KeyValuePair<string, object>("service.version", "1.2.3"));
         record.Attributes.Should().Contain(new KeyValuePair<string, object>("host.name", "host-42"));
         record.Attributes.Should().Contain(new KeyValuePair<string, object>("quilt4net.monitor", "Quilt4Net"));
+        record.Attributes.Should().Contain(new KeyValuePair<string, object>("service.instance.id", "Thargelion"));
+    }
+
+    [Fact]
+    public void LogProcessor_omits_service_instance_id_when_identity_value_is_null_for_back_compat()
+    {
+        // Issue #86: when no ServiceInstanceId is configured, the per-record attribute must
+        // remain absent so existing consumers' AppTraces rows look exactly as they do today.
+        var noInstance = FullIdentity with { ServiceInstanceId = null };
+        var record = BuildLogRecord();
+
+        new TelemetryIdentityLogProcessor(noInstance).OnEnd(record);
+
+        record.Attributes.Should().NotContain(kv => kv.Key == "service.instance.id");
+        record.Attributes.Should().Contain(kv => kv.Key == "service.name" && kv.Value!.Equals("MyApp"));
     }
 
     [Fact]
@@ -57,7 +73,7 @@ public class TelemetryIdentityEnrichmentTests
     }
 
     [Fact]
-    public void ActivityProcessor_attaches_all_five_tags_to_an_activity()
+    public void ActivityProcessor_attaches_all_six_tags_to_an_activity_when_identity_is_full()
     {
         using var source = new ActivitySource(nameof(TelemetryIdentityEnrichmentTests));
         using var listener = new ActivityListener
@@ -75,6 +91,26 @@ public class TelemetryIdentityEnrichmentTests
         activity.GetTagItem("service.version").Should().Be("1.2.3");
         activity.GetTagItem("host.name").Should().Be("host-42");
         activity.GetTagItem("quilt4net.monitor").Should().Be("Quilt4Net");
+        activity.GetTagItem("service.instance.id").Should().Be("Thargelion");
+    }
+
+    [Fact]
+    public void ActivityProcessor_omits_service_instance_id_tag_when_identity_value_is_null()
+    {
+        using var source = new ActivitySource(nameof(TelemetryIdentityEnrichmentTests));
+        using var listener = new ActivityListener
+        {
+            ShouldListenTo = _ => true,
+            Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllData
+        };
+        ActivitySource.AddActivityListener(listener);
+        using var activity = source.StartActivity("test")!;
+
+        var noInstance = FullIdentity with { ServiceInstanceId = null };
+        new TelemetryIdentityActivityProcessor(noInstance).OnEnd(activity);
+
+        activity.GetTagItem("service.instance.id").Should().BeNull();
+        activity.GetTagItem("service.name").Should().Be("MyApp");
     }
 
     [Fact]

--- a/Quilt4Net.Toolkit/Features/Logging/Quilt4NetStartupLogger.cs
+++ b/Quilt4Net.Toolkit/Features/Logging/Quilt4NetStartupLogger.cs
@@ -8,11 +8,26 @@ internal static class Quilt4NetStartupLogger
     {
         using (logger.BeginScope(new Dictionary<string, object> { ["Quilt4NetStartup"] = "true" }))
         {
-            logger.LogInformation(
-                "Quilt4Net startup: {ApplicationName} v{Version} in {Environment}",
-                options.ApplicationName ?? "(unknown)",
-                options.Version ?? "(unknown)",
-                options.Environment ?? "(unknown)");
+            // ServiceInstanceId is appended in square brackets between the application name and
+            // version when set, so multi-deployment hosts can be told apart at-a-glance in the
+            // startup line. Format collapses cleanly to the historical shape when unset.
+            if (!string.IsNullOrEmpty(options.ServiceInstanceId))
+            {
+                logger.LogInformation(
+                    "Quilt4Net startup: {ApplicationName} [{ServiceInstanceId}] v{Version} in {Environment}",
+                    options.ApplicationName ?? "(unknown)",
+                    options.ServiceInstanceId,
+                    options.Version ?? "(unknown)",
+                    options.Environment ?? "(unknown)");
+            }
+            else
+            {
+                logger.LogInformation(
+                    "Quilt4Net startup: {ApplicationName} v{Version} in {Environment}",
+                    options.ApplicationName ?? "(unknown)",
+                    options.Version ?? "(unknown)",
+                    options.Environment ?? "(unknown)");
+            }
         }
     }
 }

--- a/Quilt4Net.Toolkit/Features/Logging/ServiceInstanceIdResolver.cs
+++ b/Quilt4Net.Toolkit/Features/Logging/ServiceInstanceIdResolver.cs
@@ -1,0 +1,65 @@
+namespace Quilt4Net.Toolkit.Features.Logging;
+
+/// <summary>
+/// Resolves the <c>service.instance.id</c> OpenTelemetry resource attribute from a
+/// precedence chain so multi-deployment binaries (same csproj, multiple branded /
+/// tenanted hosts) can be told apart in telemetry without inventing per-deployment
+/// resource keys.
+///
+/// Order of precedence:
+/// <list type="number">
+/// <item>The explicit <c>ServiceInstanceId</c> option value passed to <c>AddQuilt4NetLogging</c>.</item>
+/// <item>The OTel-standard <c>OTEL_RESOURCE_ATTRIBUTES</c> env var, parsed for <c>service.instance.id=...</c>.</item>
+/// <item>The Quilt4Net shorthand <c>QUILT4NET_SERVICE_INSTANCE_ID</c> env var.</item>
+/// <item>Null — caller falls back to existing behaviour (e.g. MachineName for the OTel
+///       resource, no per-record attribute).</item>
+/// </list>
+/// </summary>
+internal static class ServiceInstanceIdResolver
+{
+    internal const string OtelResourceAttributesEnvVar = "OTEL_RESOURCE_ATTRIBUTES";
+    internal const string Quilt4NetEnvVar = "QUILT4NET_SERVICE_INSTANCE_ID";
+    internal const string OtelKey = "service.instance.id";
+
+    public static string Resolve(string optionValue, Func<string, string> envReader = null)
+    {
+        envReader ??= System.Environment.GetEnvironmentVariable;
+
+        if (!string.IsNullOrWhiteSpace(optionValue)) return optionValue.Trim();
+
+        var fromOtel = ParseFromOtelResourceAttributes(envReader(OtelResourceAttributesEnvVar));
+        if (!string.IsNullOrWhiteSpace(fromOtel)) return fromOtel;
+
+        var fromShorthand = envReader(Quilt4NetEnvVar);
+        if (!string.IsNullOrWhiteSpace(fromShorthand)) return fromShorthand.Trim();
+
+        return null;
+    }
+
+    /// <summary>
+    /// OTEL_RESOURCE_ATTRIBUTES is comma-separated key=value pairs per the OTel spec
+    /// (https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/#general-sdk-configuration).
+    /// We only need the <c>service.instance.id</c> entry. URL-decoding is not applied —
+    /// values containing reserved characters should use the option lambda or the
+    /// QUILT4NET shorthand env var instead.
+    /// </summary>
+    private static string ParseFromOtelResourceAttributes(string raw)
+    {
+        if (string.IsNullOrWhiteSpace(raw)) return null;
+
+        foreach (var rawPair in raw.Split(','))
+        {
+            var pair = rawPair.Trim();
+            var eq = pair.IndexOf('=');
+            if (eq <= 0 || eq == pair.Length - 1) continue;
+
+            var key = pair.Substring(0, eq).Trim();
+            if (!key.Equals(OtelKey, StringComparison.OrdinalIgnoreCase)) continue;
+
+            var value = pair.Substring(eq + 1).Trim();
+            return string.IsNullOrEmpty(value) ? null : value;
+        }
+
+        return null;
+    }
+}

--- a/Quilt4Net.Toolkit/Features/Logging/TelemetryIdentityEnrichment.cs
+++ b/Quilt4Net.Toolkit/Features/Logging/TelemetryIdentityEnrichment.cs
@@ -5,17 +5,20 @@ using OpenTelemetry.Logs;
 namespace Quilt4Net.Toolkit.Features.Logging;
 
 /// <summary>
-/// The five identity attributes attached to every Quilt4Net-instrumented log record and
+/// The identity attributes attached to every Quilt4Net-instrumented log record and
 /// activity. Computed once at registration time from <see cref="Quilt4NetLoggingOptions"/>
 /// plus <see cref="System.Environment.MachineName"/>; the processors below copy the values
-/// onto each record/span at export time.
+/// onto each record/span at export time. <see cref="ServiceInstanceId"/> is optional —
+/// when null no <c>service.instance.id</c> attribute is emitted per-record (today's behaviour);
+/// when set the same value is also stamped on the OTel resource by the registration helper.
 /// </summary>
 internal sealed record TelemetryIdentity(
     string Environment,
     string ApplicationName,
     string Version,
     string MachineName,
-    string MonitorName);
+    string MonitorName,
+    string ServiceInstanceId = null);
 
 /// <summary>
 /// Adds the five <see cref="TelemetryIdentity"/> attributes to every <see cref="LogRecord"/>
@@ -34,7 +37,7 @@ internal sealed class TelemetryIdentityLogProcessor : BaseProcessor<LogRecord>
     public override void OnEnd(LogRecord data)
     {
         var existing = data.Attributes;
-        var capacity = (existing?.Count ?? 0) + 5;
+        var capacity = (existing?.Count ?? 0) + 6;
         var list = new List<KeyValuePair<string, object>>(capacity);
         if (existing != null) list.AddRange(existing);
 
@@ -43,6 +46,7 @@ internal sealed class TelemetryIdentityLogProcessor : BaseProcessor<LogRecord>
         if (!string.IsNullOrEmpty(_identity.Version)) list.Add(new("service.version", _identity.Version));
         if (!string.IsNullOrEmpty(_identity.MachineName)) list.Add(new("host.name", _identity.MachineName));
         if (!string.IsNullOrEmpty(_identity.MonitorName)) list.Add(new("quilt4net.monitor", _identity.MonitorName));
+        if (!string.IsNullOrEmpty(_identity.ServiceInstanceId)) list.Add(new("service.instance.id", _identity.ServiceInstanceId));
 
         data.Attributes = list;
     }
@@ -69,5 +73,6 @@ internal sealed class TelemetryIdentityActivityProcessor : BaseProcessor<Activit
         if (!string.IsNullOrEmpty(_identity.Version)) data.SetTag("service.version", _identity.Version);
         if (!string.IsNullOrEmpty(_identity.MachineName)) data.SetTag("host.name", _identity.MachineName);
         if (!string.IsNullOrEmpty(_identity.MonitorName)) data.SetTag("quilt4net.monitor", _identity.MonitorName);
+        if (!string.IsNullOrEmpty(_identity.ServiceInstanceId)) data.SetTag("service.instance.id", _identity.ServiceInstanceId);
     }
 }

--- a/Quilt4Net.Toolkit/LoggingRegistration.cs
+++ b/Quilt4Net.Toolkit/LoggingRegistration.cs
@@ -44,6 +44,12 @@ public static class LoggingRegistration
 
         options?.Invoke(o);
 
+        // Resolve service.instance.id AFTER the option lambda so the user's explicit value
+        // wins, then fall back to the OTel-standard env var, then the Quilt4Net shorthand.
+        // Storing the resolved value back onto the options so the startup-line emitter
+        // reads the same value the resource gets.
+        o.ServiceInstanceId = Features.Logging.ServiceInstanceIdResolver.Resolve(o.ServiceInstanceId);
+
         services.AddSingleton(o);
 
         services.AddHostedService<Quilt4NetStartupHostedService>();
@@ -53,17 +59,23 @@ public static class LoggingRegistration
             ApplicationName: o.ApplicationName,
             Version: o.Version,
             MachineName: System.Environment.MachineName,
-            MonitorName: o.MonitorName);
+            MonitorName: o.MonitorName,
+            ServiceInstanceId: o.ServiceInstanceId);
 
         services.AddOpenTelemetry()
             .ConfigureResource(resource =>
             {
                 if (!string.IsNullOrEmpty(o.ApplicationName))
                 {
+                    // serviceInstanceId: when the user / env supplied a value, surface it on the
+                    // resource (so cloud_RoleInstance carries the variant); otherwise keep the
+                    // historical MachineName fallback so existing consumers see no change.
                     resource.AddService(
                         serviceName: o.ApplicationName,
                         serviceVersion: string.IsNullOrEmpty(o.Version) ? null : o.Version,
-                        serviceInstanceId: System.Environment.MachineName);
+                        serviceInstanceId: string.IsNullOrEmpty(o.ServiceInstanceId)
+                            ? System.Environment.MachineName
+                            : o.ServiceInstanceId);
                 }
 
                 if (!string.IsNullOrEmpty(o.Environment))

--- a/Quilt4Net.Toolkit/Quilt4NetLoggingOptions.cs
+++ b/Quilt4Net.Toolkit/Quilt4NetLoggingOptions.cs
@@ -38,4 +38,21 @@ public record Quilt4NetLoggingOptions
     /// per-deployment override) without parsing message text. Default is <c>"Quilt4Net"</c>.
     /// </summary>
     public string MonitorName { get; set; } = "Quilt4Net";
+
+    /// <summary>
+    /// Logical instance identifier used to disambiguate multiple deployments of the same
+    /// compiled service (same <c>service.name</c>) — for example a multi-tenanted or
+    /// multi-branded deployment of one binary. Maps to OpenTelemetry resource attribute
+    /// <c>service.instance.id</c> (surfaces as <c>cloud_RoleInstance</c> and
+    /// <c>customDimensions["service.instance.id"]</c> in Application Insights).
+    ///
+    /// Resolution order if this property is null:
+    /// <list type="number">
+    /// <item><c>OTEL_RESOURCE_ATTRIBUTES</c> env var (parsed for <c>service.instance.id=...</c>).</item>
+    /// <item><c>QUILT4NET_SERVICE_INSTANCE_ID</c> env var.</item>
+    /// <item>Falls back to <c>MachineName</c> on the OTel resource (today's behaviour) and
+    ///       <i>absent</i> from per-record customDimensions — no breaking change for existing consumers.</item>
+    /// </list>
+    /// </summary>
+    public string ServiceInstanceId { get; set; }
 }

--- a/Quilt4Net.Toolkit/README.md
+++ b/Quilt4Net.Toolkit/README.md
@@ -197,15 +197,16 @@ var builder = WebApplication.CreateBuilder(args);
 builder.AddQuilt4NetLogging();
 ```
 
-Five attributes attached to every `AppTrace`, `AppException`, `AppRequest` (and outbound `AppDependency`):
+Up to six attributes attached to every `AppTrace`, `AppException`, `AppRequest` (and outbound `AppDependency`):
 
 | Attribute key | Default value | Notes |
 |---|---|---|
 | `service.name` | `IHostEnvironment.ApplicationName` → entry assembly name (framework assemblies excluded) | Also surfaces as the `cloud_RoleName` column. |
 | `service.version` | Entry assembly version | Also surfaces as `application_Version`. |
-| `host.name` | `Environment.MachineName` | Also surfaces as `cloud_RoleInstance`. |
+| `host.name` | `Environment.MachineName` | Also surfaces as `cloud_RoleInstance` *unless* `ServiceInstanceId` is set (see below) — in which case the variant id wins for `cloud_RoleInstance` and `host.name` keeps the machine name in `customDimensions`. |
 | `deployment.environment` | `IHostEnvironment.EnvironmentName` → `DOTNET_ENVIRONMENT` → `ASPNETCORE_ENVIRONMENT` → `"Production"` | The Azure Monitor exporter does **not** forward arbitrary OTel resource attributes into per-row `Properties`, so the per-record processor copies it in too. |
 | `quilt4net.monitor` | `"Quilt4Net"` (configurable via `MonitorName`) | Identifies which instrumentation produced the row. Useful when several Quilt4Net-hosted services ship to the same workspace. |
+| `service.instance.id` | *unset by default* — see "Distinguishing multiple deployments of the same binary" below. | Only emitted per-record when explicitly configured. Existing consumers see no new attribute. |
 
 Override via callback or `appsettings.json`:
 
@@ -240,6 +241,55 @@ builder.AddQuilt4NetLogging()
 ```
 
 When `Quilt4Net.Toolkit.Api`'s `CorrelationIdMiddleware` is active, every `ILogger` call inside a request also picks up `customDimensions["CorrelationId"]` automatically — see the Api package README.
+
+### Distinguishing multiple deployments of the same binary
+
+If the same compiled service is deployed under multiple logical names (multi-tenant / multi-brand / blue-green / shadow) and `service.name` is the same across them, telemetry alone can't tell the deployments apart — `host.name` only disambiguates the *machine*, not the *variant*. Set `ServiceInstanceId` so each row carries the deployment-variant identity:
+
+```csharp
+builder.AddQuilt4NetLogging(o =>
+{
+    o.ServiceInstanceId = builder.Configuration["DeploymentVariant"]; // e.g. "Thargelion"
+});
+```
+
+When set, the value lands on the OTel resource (`cloud_RoleInstance` in Application Insights) **and** on `customDimensions["service.instance.id"]` for every record, so KQL can split rows by variant without portal lookups:
+
+```kql
+AppTraces
+| where AppRoleName == 'Eplicta.FortDocs.Server'
+| extend variant = tostring(todynamic(Properties)['service.instance.id'])
+| summarize count() by variant, host = tostring(todynamic(Properties)['host.name'])
+```
+
+The toolkit's startup line also surfaces the variant when set:
+
+```
+Quilt4Net startup: Eplicta.FortDocs.Server [Thargelion] v1.2.9.0 in CI
+```
+
+Resolution precedence if `ServiceInstanceId` isn't passed in code:
+
+1. `OTEL_RESOURCE_ATTRIBUTES` env var, parsed for the `service.instance.id=...` pair (the OTel-standard env var, [SDK env var spec](https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/#general-sdk-configuration)).
+2. `QUILT4NET_SERVICE_INSTANCE_ID` env var (Quilt4Net shorthand for hosts that don't want to construct the multi-key OTel string by hand).
+3. *Unset* — falls back to today's behaviour (`cloud_RoleInstance` is `MachineName`; no per-record attribute).
+
+### Registration order with other ILoggerProvider registrations
+
+If you also use a non-OTel logger provider — e.g. `Microsoft.ApplicationInsights.AspNetCore`'s `AddApplicationInsightsTelemetry` — **and** wrap `ILoggerFactory` (e.g. for enrichment), call `AddQuilt4NetLogging()` **before** the other AI/OTel `ILoggerProvider` registration **and** before the factory wrap. Some shapes of "wrap that captures `sp.GetServices<ILoggerProvider>()` and rebuilds a `LoggerFactory`" interact with the OTel pipeline in a way that silently drops `AppTraces` when the order is reversed (`AppRequests` continue to flow because they're written via `TelemetryClient.TrackRequest` directly). Tracked in [issue #87](https://github.com/Quilt4/Quilt4Net.Toolkit/issues/87).
+
+The recommended shape:
+
+```csharp
+// 1. Quilt4Net first.
+builder.AddQuilt4NetLogging()
+    .AddHttpRequestLogging();
+
+// 2. Then the AI / other OTel provider.
+builder.Services.AddApplicationInsightsTelemetry(o => { o.ConnectionString = "..."; });
+
+// 3. Then any custom ILoggerFactory wrapping.
+```
 
 ## Measure extensions
 


### PR DESCRIPTION
Closes #86, closes #87.

Two open issues that both touch `LoggingRegistration` / the OTel pipeline, bundled into one branch + PR + nuget release (target: 0.7.11) so consumers get one bump for both.

## #86 — `service.instance.id` for multi-deployment binaries

**Problem.** When the same compiled service is deployed under multiple logical names (multi-tenant / multi-brand / blue-green), `service.name` is identical and `host.name` only disambiguates the *machine*. There's no way to split rows by deployment-variant in KQL without portal lookups.

**Fix.** Add the OTel-standard `service.instance.id` resource attribute, sourced from a precedence chain:

1. `Quilt4NetLoggingOptions.ServiceInstanceId` in code
2. `OTEL_RESOURCE_ATTRIBUTES` env var, parsed for `service.instance.id=...` (the [OTel-standard env var](https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/#general-sdk-configuration))
3. `QUILT4NET_SERVICE_INSTANCE_ID` env var (Quilt4Net shorthand)
4. *Unset* → falls back to today's behaviour (`cloud_RoleInstance` is `MachineName`, no per-record attribute) — purely additive for unconfigured consumers

When set, the value lands on the OTel resource (`cloud_RoleInstance` in AI) **and** on `customDimensions["service.instance.id"]` per-record, so KQL can split rows trivially:

```kql
AppTraces
| where AppRoleName == 'Eplicta.FortDocs.Server'
| extend variant = tostring(todynamic(Properties)['service.instance.id'])
| summarize count() by variant, host = tostring(todynamic(Properties)['host.name'])
```

`Quilt4NetStartupHostedService`'s startup line surfaces the variant when set:

```
Quilt4Net startup: Eplicta.FortDocs.Server [Thargelion] v1.2.9.0 in CI
```

Resolver is split into `Features/Logging/ServiceInstanceIdResolver.cs` with an injectable env reader — 9 tests pin precedence, OTel-pair parsing, case-insensitive key match, whitespace handling, and null fallthrough.

## #87 — registration-order silent break, docs-only fix

**Problem.** Reporter hit a silent `AppTraces`-missing failure when `AddQuilt4NetLogging()` was called *before* `AddApplicationInsightsTelemetry()` plus a custom `ILoggerFactory` wrap. Reversing the order works.

**Investigation.** Wrote `RegistrationOrderTests.cs` with 4 variants of the consumer's "custom wrap" (direct `AddSingleton<ILoggerProvider>`, `AddLogging(b => b.AddProvider(...))`, `Replace<ILoggerFactory>(...)`, with both registration orders). **All 4 pass in both orders** — naive interpretations of the consumer's setup don't reproduce the symptom. The real failure likely depends on something specific to `Microsoft.ApplicationInsights.AspNetCore.AddApplicationInsightsTelemetry` (LoggerFilterOptions / IConfigureOptions / TelemetryConfiguration build) plus the consumer's exact wrap shape — none of which are visible from this side.

**Fix.** Document the gotcha with a clear "Registration order with other ILoggerProvider registrations" callout in `Quilt4Net.Toolkit/README.md` recommending `AddQuilt4NetLogging()` be called first. The 4 `RegistrationOrderTests` stay as regression coverage so the naive case is pinned as order-independent. If a concrete repro surfaces later we can revisit a code-side fix.

## Test plan

- [x] `dotnet build -c Release` — 0 errors, 254 warnings (under the 261 ratchet ceiling)
- [x] `dotnet test -c Release --no-build` — **244 passed** (Api 1, Mcp 15, Health 48, core 122, Blazor 58); +17 new across `ServiceInstanceIdResolverTests` (9), `RegistrationOrderTests` (4), `TelemetryIdentityEnrichmentTests` (2 new), `Quilt4NetStartupLoggerTests` (2 new)
- [x] Back-compat: existing `TelemetryIdentityEnrichmentTests` confirm the per-record processor omits `service.instance.id` when null; `Quilt4NetStartupLoggerTests` confirm the historical message format is preserved when `ServiceInstanceId` is unset.

## After merge

1. Approve the gated release run → 0.7.11 publishes
2. Bump consumers (Quilt4Net.Server etc.) when convenient — separate chore PR

## Commits

- `feat: service.instance.id for telemetry from multi-deployment binaries (#86)`
- `docs: registration-order note for AddQuilt4NetLogging + ApplicationInsights (#87)`