### PR TITLE
VersionMatrix Startup-fast-path: emit, capture, rank

### DIFF
--- a/Quilt4Net.Toolkit.Tests/Quilt4NetStartupLoggerTests.cs
+++ b/Quilt4Net.Toolkit.Tests/Quilt4NetStartupLoggerTests.cs
@@ -2,6 +2,8 @@ using FluentAssertions;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
+using OpenTelemetry;
+using OpenTelemetry.Logs;
 using Quilt4Net.Toolkit.Features.Logging;
 using Xunit;
 
@@ -31,17 +33,50 @@ public class Quilt4NetStartupLoggerTests
     }
 
     [Fact]
-    public void Log_attaches_Quilt4NetStartup_marker_in_scope()
+    public void Log_emits_Quilt4NetStartup_as_a_structured_property_not_a_scope()
     {
+        // Regression guard for the previous BeginScope-based implementation: OpenTelemetry's
+        // Microsoft.Extensions.Logging bridge does NOT copy scope state into LogRecord.Attributes
+        // unless the consumer sets OpenTelemetryLoggerOptions.IncludeScopes = true. The Azure
+        // Monitor exporter (the toolkit's recommended ingestion path) defaults that to false, so
+        // a scope-based emission of "Quilt4NetStartup=true" never reached App Insights — making
+        // the VersionMatrix "Startup" fast path unreachable for every consumer. Pin the new
+        // contract: the property goes into the message template's structured state, not a scope.
         var capture = new CapturingLogger();
         var options = new Quilt4NetLoggingOptions { ApplicationName = "x" };
 
         Quilt4NetStartupLogger.Log(capture, options);
 
         capture.Entries.Should().ContainSingle();
-        capture.Entries[0].Scopes.Should().ContainSingle()
-            .Which.Should().BeAssignableTo<IDictionary<string, object>>()
-            .Which["Quilt4NetStartup"].Should().Be("true");
+        capture.Entries[0].State.Should().Contain(kv => kv.Key == "Quilt4NetStartup" && kv.Value!.Equals("true"));
+        capture.Entries[0].Scopes.Should().BeEmpty("Quilt4NetStartup must NOT be emitted via BeginScope");
+    }
+
+    [Fact]
+    public void Log_emits_Quilt4NetStartup_into_OTel_LogRecord_Attributes_without_IncludeScopes()
+    {
+        // End-to-end regression guard for the actual reported bug: build a real OTel pipeline
+        // with IncludeScopes left at its `false` default, route ILogger through it, and assert
+        // the captured LogRecord.Attributes contains ("Quilt4NetStartup", "true"). If anyone
+        // ever reverts to scope-based emission, this test fails immediately — proving the
+        // property would have been dropped before reaching the Azure Monitor exporter.
+        LogRecord captured = null!;
+        using var loggerFactory = LoggerFactory.Create(b =>
+        {
+            b.AddOpenTelemetry(o => o.AddProcessor(new CaptureLogRecordProcessor(r => captured = r)));
+        });
+        var logger = loggerFactory.CreateLogger<Quilt4NetStartupLoggerTests>();
+        var options = new Quilt4NetLoggingOptions
+        {
+            ApplicationName = "florida-client",
+            Version = "1.4.7",
+            Environment = "Development"
+        };
+
+        Quilt4NetStartupLogger.Log(logger, options);
+
+        captured.Should().NotBeNull();
+        captured.Attributes.Should().Contain(kv => kv.Key == "Quilt4NetStartup" && kv.Value!.Equals("true"));
     }
 
     [Fact]
@@ -73,7 +108,7 @@ public class Quilt4NetStartupLoggerTests
         Quilt4NetStartupLogger.Log(capture, options);
 
         capture.Entries[0].FormattedMessage
-            .Should().Be("Quilt4Net startup: Eplicta.FortDocs.Server [Thargelion] v1.2.9.0 in CI");
+            .Should().Be("Quilt4Net startup: Eplicta.FortDocs.Server [Thargelion] v1.2.9.0 in CI (true)");
     }
 
     [Fact]
@@ -93,7 +128,7 @@ public class Quilt4NetStartupLoggerTests
         Quilt4NetStartupLogger.Log(capture, options);
 
         capture.Entries[0].FormattedMessage
-            .Should().Be("Quilt4Net startup: Eplicta.FortDocs.Server v1.2.9.0 in CI")
+            .Should().Be("Quilt4Net startup: Eplicta.FortDocs.Server v1.2.9.0 in CI (true)")
             .And.NotContain("[");
     }
 
@@ -135,7 +170,7 @@ public class Quilt4NetStartupLoggerTests
             && d.ImplementationType == typeof(Quilt4NetStartupHostedService));
     }
 
-    private sealed record LogEntry(LogLevel Level, string FormattedMessage, List<object> Scopes);
+    private sealed record LogEntry(LogLevel Level, string FormattedMessage, List<object> Scopes, IReadOnlyList<KeyValuePair<string, object>> State);
 
     private sealed class CapturingLogger : ILogger
     {
@@ -152,7 +187,13 @@ public class Quilt4NetStartupLoggerTests
 
         public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter)
         {
-            Entries.Add(new LogEntry(logLevel, formatter(state, exception), new List<object>(_activeScopes)));
+            // ILogger's structured state is conventionally an IReadOnlyList<KeyValuePair<string, object>>
+            // when callers use the message-template overloads (LogInformation("{Foo}", value)). Capturing
+            // it lets the tests assert on per-property structured data without spinning up an OTel
+            // pipeline for every assertion.
+            var stateList = state as IReadOnlyList<KeyValuePair<string, object>>
+                ?? new List<KeyValuePair<string, object>>();
+            Entries.Add(new LogEntry(logLevel, formatter(state, exception), new List<object>(_activeScopes), stateList));
         }
 
         private sealed class Pop : IDisposable
@@ -179,5 +220,12 @@ public class Quilt4NetStartupLoggerTests
         public ILogger CreateLogger(string categoryName) => _logger;
         public void AddProvider(ILoggerProvider provider) { }
         public void Dispose() { }
+    }
+
+    private sealed class CaptureLogRecordProcessor : BaseProcessor<LogRecord>
+    {
+        private readonly Action<LogRecord> _capture;
+        public CaptureLogRecordProcessor(Action<LogRecord> capture) => _capture = capture;
+        public override void OnEnd(LogRecord data) => _capture(data);
     }
 }

--- a/Quilt4Net.Toolkit.Tests/Quilt4NetStartupLoggerTests.cs
+++ b/Quilt4Net.Toolkit.Tests/Quilt4NetStartupLoggerTests.cs
@@ -161,12 +161,26 @@ public class Quilt4NetStartupLoggerTests
     }
 
     [Fact]
-    public void Hosted_service_is_registered_by_AddQuilt4NetLogging()
+    public void Hosted_service_is_registered_by_AddQuilt4NetLogging_via_IServiceCollection_overload()
     {
         var services = new ServiceCollection();
         services.AddQuilt4NetLogging(applicationName: "x");
 
         services.Should().Contain(d => d.ServiceType == typeof(IHostedService)
+            && d.ImplementationType == typeof(Quilt4NetStartupHostedService));
+    }
+
+    [Fact]
+    public void Hosted_service_is_registered_by_AddQuilt4NetLogging_via_IHostApplicationBuilder_overload()
+    {
+        // The IHostApplicationBuilder overload delegates to the IServiceCollection overload —
+        // pinning that hosted-service registration survives the indirection so legacy
+        // IHostBuilder / Tharga.Wpf consumers that route through the IHostApplicationBuilder
+        // overload also get the startup entry without calling LogQuilt4NetStartup manually.
+        var builder = Microsoft.Extensions.Hosting.Host.CreateApplicationBuilder();
+        builder.AddQuilt4NetLogging();
+
+        builder.Services.Should().Contain(d => d.ServiceType == typeof(IHostedService)
             && d.ImplementationType == typeof(Quilt4NetStartupHostedService));
     }
 

--- a/Quilt4Net.Toolkit.Tests/VersionMatrixSourcePriorityTests.cs
+++ b/Quilt4Net.Toolkit.Tests/VersionMatrixSourcePriorityTests.cs
@@ -1,0 +1,73 @@
+using FluentAssertions;
+using Quilt4Net.Toolkit.Features.ApplicationInsights;
+using Xunit;
+
+namespace Quilt4Net.Toolkit.Tests;
+
+/// <summary>
+/// The previous VersionMatrix KQL used <c>union startup, fallback | summarize arg_max(TimeGenerated, …)</c>
+/// — a flat <c>arg_max</c> over the union, which means any regular log row emitted *after* the
+/// Startup hosted service's entry wins the pick. Apps log continuously, so the <c>Source = "Startup"</c>
+/// row was effectively unreachable. These tests pin the new "per-source pick + leftanti merge"
+/// shape so the Startup fast path can't silently regress to that flat <c>arg_max</c> form.
+/// </summary>
+public class VersionMatrixSourcePriorityTests
+{
+    [Fact]
+    public void Picks_latest_Startup_row_per_App_Env_via_arg_max_inside_startup_pick()
+    {
+        // The startup_pick let-binding must summarise startup-only rows with arg_max so we keep
+        // the *latest* Startup version per (App, Env) when there are multiple startup entries
+        // (e.g. multiple deploys in the lookback window).
+        ApplicationInsightsService.VersionMatrixPickStartupPreferred
+            .Should().Contain("let startup_pick = startup")
+            .And.Contain("summarize arg_max(TimeGenerated, Version, Source) by ApplicationName, Environment");
+    }
+
+    [Fact]
+    public void Picks_latest_Log_row_per_App_Env_via_arg_max_inside_log_pick()
+    {
+        // Same shape as startup_pick but for the fallback (Log) source.
+        ApplicationInsightsService.VersionMatrixPickStartupPreferred
+            .Should().Contain("let log_pick = fallback");
+    }
+
+    [Fact]
+    public void Merges_via_leftanti_join_so_Startup_wins_when_both_sources_have_a_row()
+    {
+        // The merge has to keep ALL startup_pick rows and only the log_pick rows that don't have
+        // a matching (App, Env) in startup_pick. `join kind=leftanti` is the operator that does
+        // exactly that; any other join shape would either lose Startup rows or double-count.
+        ApplicationInsightsService.VersionMatrixPickStartupPreferred
+            .Should().Contain("join kind=leftanti startup_pick on ApplicationName, Environment");
+    }
+
+    [Fact]
+    public void Does_not_arg_max_over_a_naive_union_of_both_sources()
+    {
+        // Regression guard for the previous shape — any future edit that reverts to
+        // `union startup, fallback | summarize arg_max(...)` fails this test loudly.
+        ApplicationInsightsService.VersionMatrixPickStartupPreferred
+            .Should().NotContain("union startup, fallback")
+            .And.NotContain("union startup,fallback");
+    }
+
+    [Fact]
+    public void Normalises_empty_Environment_to_unknown_inside_each_per_source_pipeline()
+    {
+        // The empty-environment normalisation has to happen BEFORE the summarize on each side
+        // so rows with empty Environment fold together under the (unknown) bucket per source.
+        // Doing it after the merge would group correctly but would need the rewrite to keep the
+        // semantics — pin the per-pipeline shape so it doesn't drift.
+        var picksByEnvironment = ApplicationInsightsService.VersionMatrixPickStartupPreferred
+            .Split("\n");
+        picksByEnvironment.Should().Contain(line => line.Contains("extend Environment = iff(isempty(Environment), \"(unknown)\", Environment)"));
+    }
+
+    [Fact]
+    public void Orders_result_by_App_then_Environment_for_stable_UI_rendering()
+    {
+        ApplicationInsightsService.VersionMatrixPickStartupPreferred
+            .Should().Contain("order by ApplicationName asc, Environment asc");
+    }
+}

--- a/Quilt4Net.Toolkit/Features/ApplicationInsights/ApplicationInsightsService.cs
+++ b/Quilt4Net.Toolkit/Features/ApplicationInsights/ApplicationInsightsService.cs
@@ -59,6 +59,30 @@ internal class ApplicationInsightsService : IApplicationInsightsService
     /// for any future query that grows past the 64MB limit despite the tightened summarize clause.
     /// </summary>
     private static readonly LogsQueryOptions _summariesQueryOptions = new() { AllowPartialErrors = true };
+
+    /// <summary>
+    /// Pick-the-winner stage for <c>GetVersionMatrixAsync</c>'s KQL. Expects two <c>let</c>-bound
+    /// inputs upstream: <c>startup</c> (rows where <c>Quilt4NetStartup=true</c>) and <c>fallback</c>
+    /// (rows from any of AppTraces/AppExceptions/AppRequests).
+    ///
+    /// Previously the implementation was <c>union startup, fallback | summarize arg_max(TimeGenerated, Version, Source) by ApplicationName, Environment</c>,
+    /// which sorts every row by timestamp regardless of source. Any regular log entry emitted *after*
+    /// <c>Quilt4NetStartupHostedService.StartAsync</c> wins the <c>arg_max</c> — and apps log
+    /// continuously, so the <c>Source = "Startup"</c> row was effectively unreachable. The doc/XML
+    /// promised a "Startup fast path" but the implementation gave no preference.
+    ///
+    /// New shape: pick the latest row per source first, then <c>leftanti</c>-join Log against Startup
+    /// to keep Log rows only where no Startup row exists for that (App, Env). The result is that any
+    /// Startup row beats any Log row for the same (App, Env) pair, regardless of timestamps.
+    /// </summary>
+    internal const string VersionMatrixPickStartupPreferred = @"let startup_pick = startup
+| extend Environment = iff(isempty(Environment), ""(unknown)"", Environment)
+| summarize arg_max(TimeGenerated, Version, Source) by ApplicationName, Environment;
+let log_pick = fallback
+| extend Environment = iff(isempty(Environment), ""(unknown)"", Environment)
+| summarize arg_max(TimeGenerated, Version, Source) by ApplicationName, Environment;
+union startup_pick, (log_pick | join kind=leftanti startup_pick on ApplicationName, Environment)
+| order by ApplicationName asc, Environment asc";
     private readonly ConcurrentDictionary<ClientKey, LogsQueryClient> _clientCache = new();
     private readonly ITimeToLiveCache _timeToLiveCache;
     private readonly ApplicationInsightsOptions _options;
@@ -1041,10 +1065,7 @@ let fallback = union AppTraces, AppExceptions, AppRequests
     Version = coalesce(tostring(_p[""application_Version""]), tostring(_p[""service.version""]), tostring(AppVersion))
 | where isnotempty(ApplicationName) and isnotempty(Version)
 | project TimeGenerated, ApplicationName, Environment, Version, Source = ""Log"";
-union startup, fallback
-| extend Environment = iff(isempty(Environment), ""(unknown)"", Environment)
-| summarize arg_max(TimeGenerated, Version, Source) by ApplicationName, Environment
-| order by ApplicationName asc, Environment asc";
+{VersionMatrixPickStartupPreferred}";
 
         var range = lookback.HasValue
             ? new LogsQueryTimeRange(DateTimeOffset.UtcNow - lookback.Value, DateTimeOffset.UtcNow)

--- a/Quilt4Net.Toolkit/Features/Logging/Quilt4NetStartupLogger.cs
+++ b/Quilt4Net.Toolkit/Features/Logging/Quilt4NetStartupLogger.cs
@@ -4,30 +4,40 @@ namespace Quilt4Net.Toolkit.Features.Logging;
 
 internal static class Quilt4NetStartupLogger
 {
+    /// <summary>
+    /// Property name used to identify the Quilt4Net startup log entry. Emitted as a
+    /// **structured argument** on the message template (not via <c>BeginScope</c>) so it
+    /// lands in <see cref="OpenTelemetry.Logs.LogRecord.Attributes"/> regardless of the
+    /// consumer's <c>OpenTelemetryLoggerOptions.IncludeScopes</c> setting. The Azure
+    /// Monitor OpenTelemetry exporter defaults that to <c>false</c>, so a previous
+    /// <c>BeginScope</c>-based implementation never reached App Insights and the
+    /// VersionMatrix "Startup" fast path was unreachable in practice.
+    /// </summary>
+    public const string StartupPropertyName = "Quilt4NetStartup";
+
     public static void Log(ILogger logger, Quilt4NetLoggingOptions options)
     {
-        using (logger.BeginScope(new Dictionary<string, object> { ["Quilt4NetStartup"] = "true" }))
+        // ServiceInstanceId is appended in square brackets between the application name and
+        // version when set, so multi-deployment hosts can be told apart at-a-glance in the
+        // startup line. Format collapses cleanly to the historical shape when unset.
+        if (!string.IsNullOrEmpty(options.ServiceInstanceId))
         {
-            // ServiceInstanceId is appended in square brackets between the application name and
-            // version when set, so multi-deployment hosts can be told apart at-a-glance in the
-            // startup line. Format collapses cleanly to the historical shape when unset.
-            if (!string.IsNullOrEmpty(options.ServiceInstanceId))
-            {
-                logger.LogInformation(
-                    "Quilt4Net startup: {ApplicationName} [{ServiceInstanceId}] v{Version} in {Environment}",
-                    options.ApplicationName ?? "(unknown)",
-                    options.ServiceInstanceId,
-                    options.Version ?? "(unknown)",
-                    options.Environment ?? "(unknown)");
-            }
-            else
-            {
-                logger.LogInformation(
-                    "Quilt4Net startup: {ApplicationName} v{Version} in {Environment}",
-                    options.ApplicationName ?? "(unknown)",
-                    options.Version ?? "(unknown)",
-                    options.Environment ?? "(unknown)");
-            }
+            logger.LogInformation(
+                "Quilt4Net startup: {ApplicationName} [{ServiceInstanceId}] v{Version} in {Environment} ({" + StartupPropertyName + "})",
+                options.ApplicationName ?? "(unknown)",
+                options.ServiceInstanceId,
+                options.Version ?? "(unknown)",
+                options.Environment ?? "(unknown)",
+                "true");
+        }
+        else
+        {
+            logger.LogInformation(
+                "Quilt4Net startup: {ApplicationName} v{Version} in {Environment} ({" + StartupPropertyName + "})",
+                options.ApplicationName ?? "(unknown)",
+                options.Version ?? "(unknown)",
+                options.Environment ?? "(unknown)",
+                "true");
         }
     }
 }

--- a/Quilt4Net.Toolkit/LoggingRegistration.cs
+++ b/Quilt4Net.Toolkit/LoggingRegistration.cs
@@ -24,6 +24,10 @@ public static class LoggingRegistration
     /// <summary>
     /// Register universal telemetry identity (service.name, service.version, deployment.environment, service.instance.id)
     /// on the OpenTelemetry Resource. Applies to traces, logs and metrics.
+    /// Also registers <see cref="Quilt4NetStartupHostedService"/> so apps with an <see cref="IHost"/>
+    /// (including those built via <see cref="IHostApplicationBuilder"/>, the older <c>IHostBuilder</c>
+    /// pattern, or <c>Tharga.Wpf</c>'s generic-host setup) emit the startup entry automatically.
+    /// Truly no-host contexts should call <see cref="LogQuilt4NetStartup"/> manually.
     /// </summary>
     public static Quilt4NetLoggingBuilder AddQuilt4NetLogging(this IServiceCollection services, IConfiguration configuration = null, Action<Quilt4NetLoggingOptions> options = null, string environmentName = null, string applicationName = null)
     {
@@ -97,9 +101,18 @@ public static class LoggingRegistration
     }
 
     /// <summary>
-    /// Manually emit the Quilt4Net startup log entry. Use this in non-hosted
-    /// applications (WPF, console without IHost) where IHostedService does not run.
-    /// Hosted applications (IHostApplicationBuilder) get the startup entry automatically.
+    /// Manually emit the Quilt4Net startup log entry. Use this **only** when the calling code
+    /// has no <see cref="IHost"/> and therefore no <see cref="IHostedService"/> runs — e.g. a
+    /// pure script, a static-<c>Main</c> console without `Microsoft.Extensions.Hosting`, or a
+    /// plain `Application.Run` WPF app that doesn't build a host.
+    ///
+    /// Apps that DO build an <see cref="IHost"/> — including those wired via
+    /// <see cref="IHostApplicationBuilder"/>, the older <c>IHostBuilder</c> pattern, or
+    /// <c>Tharga.Wpf</c>'s generic-host setup — get the startup entry automatically via
+    /// <see cref="Quilt4NetStartupHostedService"/> regardless of which <c>AddQuilt4NetLogging</c>
+    /// overload was used to register it (the <see cref="IServiceCollection"/> overload registers
+    /// the hosted service the same as the <see cref="IHostApplicationBuilder"/> overload).
+    /// Calling this method in those contexts produces a duplicate startup entry.
     /// </summary>
     public static void LogQuilt4NetStartup(this IServiceProvider serviceProvider)
     {


### PR DESCRIPTION
Closes the three interlocking gaps that left the VersionMatrix `Source = Startup` fast path **dead in practice** for every consumer. Each gap is small on its own; all three are needed because without any one of them the fast path stays broken. Empirically verified against `florida-client` running 0.7.11 — even with the structured-property fix applied, a regular log row six seconds later still beat the startup entry in the `arg_max`.

## Three commits, dependency order

### `fc9c6b5` — emit `Quilt4NetStartup` as a structured argument so OTel picks it up without `IncludeScopes`

Previous: `logger.BeginScope(new Dictionary { ["Quilt4NetStartup"] = "true" })` around `LogInformation(...)`. OpenTelemetry's `Microsoft.Extensions.Logging` bridge does **not** copy scope state into `LogRecord.Attributes` unless `OpenTelemetryLoggerOptions.IncludeScopes = true`. Azure.Monitor.OpenTelemetry (the toolkit's recommended ingestion path) defaults that to `false`, so the tag never reached App Insights.

Now: `Quilt4NetStartup` moves into the message template's named-placeholder list, which `Log<TState>` passes through verbatim to providers — OTel's bridge captures structured state regardless of `IncludeScopes`.

Two regression guards in `Quilt4NetStartupLoggerTests`:
- `Log_emits_Quilt4NetStartup_as_a_structured_property_not_a_scope` — fast unit test asserting the captured `state` (the `IReadOnlyList<KeyValuePair<string, object>>`) contains `("Quilt4NetStartup", "true")` and `Scopes` is empty.
- `Log_emits_Quilt4NetStartup_into_OTel_LogRecord_Attributes_without_IncludeScopes` — end-to-end against a real `LoggerFactory.Create(b => b.AddOpenTelemetry(...))` with `IncludeScopes` left at its `false` default. If anyone ever reverts to scope-based emission, this fails immediately.

### `76daad9` — VersionMatrix KQL prefers `Source=Startup` so a later Log row can't shadow it

Previous KQL: `union startup, fallback | summarize arg_max(TimeGenerated, Version, Source) by ApplicationName, Environment`. A flat `arg_max` over the union sorts every row by timestamp regardless of source — any regular log entry emitted after `Quilt4NetStartupHostedService.StartAsync` wins. Apps log continuously, so `Source = "Startup"` was unreachable.

New KQL: pick the latest row per source first, then `leftanti`-join Log against Startup so Log rows survive only when no Startup row exists for that `(App, Env)`. Any Startup row beats any Log row regardless of timestamps.

```kql
let startup_pick = startup
| extend Environment = iff(isempty(Environment), "(unknown)", Environment)
| summarize arg_max(TimeGenerated, Version, Source) by ApplicationName, Environment;
let log_pick = fallback
| extend Environment = iff(isempty(Environment), "(unknown)", Environment)
| summarize arg_max(TimeGenerated, Version, Source) by ApplicationName, Environment;
union startup_pick, (log_pick | join kind=leftanti startup_pick on ApplicationName, Environment)
| order by ApplicationName asc, Environment asc
```

Extracted as `internal const string VersionMatrixPickStartupPreferred` (mirrors the `SummarizeByFingerprint` precedent from PR #84) so the new shape is testable. New `VersionMatrixSourcePriorityTests` (6 tests) pin the per-source `arg_max`, the `leftanti` merge operator, the empty-Environment normalisation, the sort order, **and** explicitly negative-assert the previous `union startup, fallback` form so it can't silently return.

**Behavioural note for the PR landing**: for apps that have both Startup and Log rows in AI, the matrix `Source` flips from `Log` → `Startup` and the displayed `Version` may change if the latest deployed binary differs from what was most recently logged. That's the desired fix — first matrix refresh after a 0.7.12 deploy may show different values for apps in this shape.

### `08e4e85` — clarify hosted-service registration covers both `AddQuilt4NetLogging` overloads

The third backlog item (#16) turned out to be docs-only: the `IServiceCollection` overload already calls `services.AddHostedService<Quilt4NetStartupHostedService>()`, and the `IHostApplicationBuilder` overload delegates to it — so any app that builds an `IHost` (including legacy `IHostBuilder` and `Tharga.Wpf` generic-host setups) gets the startup entry automatically. The XML doc historically said "non-hosted applications (WPF, console without IHost)" should call `LogQuilt4NetStartup` manually, which is correct for the narrow pure-`Application.Run` case but misleading for `Tharga.Wpf` consumers that DO build an `IHost` — they'd produce a duplicate entry.

Tightens the wording on both relevant XML doc sites + adds `Hosted_service_is_registered_by_AddQuilt4NetLogging_via_IHostApplicationBuilder_overload` so a future refactor of the delegating call can't silently regress that route.

## Test plan

- [x] `dotnet build -c Release` — 0 errors, **254 warnings** (under the 261 ratchet ceiling, unchanged from 0.7.11 baseline)
- [x] `dotnet test -c Release --no-build` — **252 passed** (+8 from this feature: 2 in `Quilt4NetStartupLoggerTests` for the structured-property regression guards, 6 in the new `VersionMatrixSourcePriorityTests`, plus a rename of one existing test for symmetry)
- [ ] After publish + Server bump to 0.7.12: VersionMatrix on `/monitor/version` should populate the `Source = Startup` rows for apps deployed long enough to log at least one startup entry; rendered `Version` for those rows should match the actual deployed binary, not the most-recently-logged one.

## Source backlog

Closes three interlocking items from `$DOC_ROOT/Tharga/Quilt4Net.md`:
- Line 16 (Important / Easy / Toolkit / Code): hosted-service registration coverage — already done in code, docs clarified here.
- Line 17 (Critical / Easy / Toolkit / Code): `Quilt4NetStartup` as structured property, not scope.
- Line 18 (Critical / Easy / Toolkit / Code): VersionMatrix KQL prefers Startup over Log.

Target release: `Quilt4Net.Toolkit 0.7.12`.

## After merge

1. Approve the gated release run → 0.7.12 publishes
2. Bump `Quilt4Net.Server`'s `Quilt4Net.Toolkit.{Api,Blazor,Health}` from 0.7.11 → 0.7.12 — separate small chore PR
3. Visit `/monitor/version` after Server is deployed long enough to log a startup entry against the new toolkit; confirm rows render with `Source = Startup` instead of `Log`