### PR TITLE
fix: GetSummary cap + cancellable log queries with loading state

### DIFF
--- a/Quilt4Net.Toolkit.Blazor.Tests/LogEnvironmentSelectorIncidentTests.cs
+++ b/Quilt4Net.Toolkit.Blazor.Tests/LogEnvironmentSelectorIncidentTests.cs
@@ -40,7 +40,7 @@ public class LogEnvironmentSelectorIncidentTests : BunitContext
         public IAsyncEnumerable<MeasureData> GetMeasureAsync(IApplicationInsightsContext context, string environment, TimeSpan timeSpan) => Throw<MeasureData>();
         public IAsyncEnumerable<CountData> GetCountAsync(IApplicationInsightsContext context, string environment, TimeSpan timeSpan) => Throw<CountData>();
         public Task<LogDetails> GetDetail(IApplicationInsightsContext context, string id, LogSource source, string environment, TimeSpan timeSpan) => Task.FromException<LogDetails>(_ex);
-        public Task<SummaryData> GetSummary(IApplicationInsightsContext context, string fingerprint, LogSource source, string environment, TimeSpan timeSpan) => Task.FromException<SummaryData>(_ex);
+        public Task<SummaryData> GetSummary(IApplicationInsightsContext context, string fingerprint, LogSource source, string environment, TimeSpan timeSpan, int maxItems = 100) => Task.FromException<SummaryData>(_ex);
         public IAsyncEnumerable<SummarySubset> GetSummaries(IApplicationInsightsContext context, string environment, TimeSpan timeSpan) => Throw<SummarySubset>();
         public IAsyncEnumerable<VersionMatrixCell> GetVersionMatrixAsync(IApplicationInsightsContext context, TimeSpan? lookback = null) => Throw<VersionMatrixCell>();
         public IAsyncEnumerable<LogItem> SearchByIncidentIdAsync(IApplicationInsightsContext context, string incidentId, TimeSpan timeSpan) => Throw<LogItem>();

--- a/Quilt4Net.Toolkit.Blazor.Tests/LogEnvironmentSelectorIncidentTests.cs
+++ b/Quilt4Net.Toolkit.Blazor.Tests/LogEnvironmentSelectorIncidentTests.cs
@@ -36,12 +36,12 @@ public class LogEnvironmentSelectorIncidentTests : BunitContext
         public Task<bool> CanConnectAsync(IApplicationInsightsContext context) => Task.FromResult(false);
 
         public IAsyncEnumerable<EnvironmentOption> GetEnvironments(IApplicationInsightsContext context) => Throw<EnvironmentOption>();
-        public IAsyncEnumerable<LogItem> SearchAsync(IApplicationInsightsContext context, string environment, string text, TimeSpan timeSpan, SeverityLevel minSeverityLevel = SeverityLevel.Verbose) => Throw<LogItem>();
-        public IAsyncEnumerable<MeasureData> GetMeasureAsync(IApplicationInsightsContext context, string environment, TimeSpan timeSpan) => Throw<MeasureData>();
-        public IAsyncEnumerable<CountData> GetCountAsync(IApplicationInsightsContext context, string environment, TimeSpan timeSpan) => Throw<CountData>();
+        public IAsyncEnumerable<LogItem> SearchAsync(IApplicationInsightsContext context, string environment, string text, TimeSpan timeSpan, SeverityLevel minSeverityLevel = SeverityLevel.Verbose, CancellationToken cancellationToken = default) => Throw<LogItem>();
+        public IAsyncEnumerable<MeasureData> GetMeasureAsync(IApplicationInsightsContext context, string environment, TimeSpan timeSpan, CancellationToken cancellationToken = default) => Throw<MeasureData>();
+        public IAsyncEnumerable<CountData> GetCountAsync(IApplicationInsightsContext context, string environment, TimeSpan timeSpan, CancellationToken cancellationToken = default) => Throw<CountData>();
         public Task<LogDetails> GetDetail(IApplicationInsightsContext context, string id, LogSource source, string environment, TimeSpan timeSpan) => Task.FromException<LogDetails>(_ex);
         public Task<SummaryData> GetSummary(IApplicationInsightsContext context, string fingerprint, LogSource source, string environment, TimeSpan timeSpan, int maxItems = 100) => Task.FromException<SummaryData>(_ex);
-        public IAsyncEnumerable<SummarySubset> GetSummaries(IApplicationInsightsContext context, string environment, TimeSpan timeSpan) => Throw<SummarySubset>();
+        public IAsyncEnumerable<SummarySubset> GetSummaries(IApplicationInsightsContext context, string environment, TimeSpan timeSpan, CancellationToken cancellationToken = default) => Throw<SummarySubset>();
         public IAsyncEnumerable<VersionMatrixCell> GetVersionMatrixAsync(IApplicationInsightsContext context, TimeSpan? lookback = null) => Throw<VersionMatrixCell>();
         public IAsyncEnumerable<LogItem> SearchByIncidentIdAsync(IApplicationInsightsContext context, string incidentId, TimeSpan timeSpan) => Throw<LogItem>();
         public IAsyncEnumerable<LogItem> SearchByCorrelationIdAsync(IApplicationInsightsContext context, string correlationId, TimeSpan timeSpan) => Throw<LogItem>();

--- a/Quilt4Net.Toolkit.Blazor.Tests/LogViewConfigTests.cs
+++ b/Quilt4Net.Toolkit.Blazor.Tests/LogViewConfigTests.cs
@@ -55,12 +55,12 @@ public class LogViewConfigTests : BunitContext
     {
         public Task<bool> CanConnectAsync(IApplicationInsightsContext context) => Task.FromResult(false);
         public IAsyncEnumerable<EnvironmentOption> GetEnvironments(IApplicationInsightsContext context) => Empty<EnvironmentOption>();
-        public IAsyncEnumerable<LogItem> SearchAsync(IApplicationInsightsContext context, string environment, string text, TimeSpan timeSpan, SeverityLevel minSeverityLevel = SeverityLevel.Verbose) => Empty<LogItem>();
-        public IAsyncEnumerable<MeasureData> GetMeasureAsync(IApplicationInsightsContext context, string environment, TimeSpan timeSpan) => Empty<MeasureData>();
-        public IAsyncEnumerable<CountData> GetCountAsync(IApplicationInsightsContext context, string environment, TimeSpan timeSpan) => Empty<CountData>();
+        public IAsyncEnumerable<LogItem> SearchAsync(IApplicationInsightsContext context, string environment, string text, TimeSpan timeSpan, SeverityLevel minSeverityLevel = SeverityLevel.Verbose, CancellationToken cancellationToken = default) => Empty<LogItem>();
+        public IAsyncEnumerable<MeasureData> GetMeasureAsync(IApplicationInsightsContext context, string environment, TimeSpan timeSpan, CancellationToken cancellationToken = default) => Empty<MeasureData>();
+        public IAsyncEnumerable<CountData> GetCountAsync(IApplicationInsightsContext context, string environment, TimeSpan timeSpan, CancellationToken cancellationToken = default) => Empty<CountData>();
         public Task<LogDetails> GetDetail(IApplicationInsightsContext context, string id, LogSource source, string environment, TimeSpan timeSpan) => Task.FromResult<LogDetails>(null);
         public Task<SummaryData> GetSummary(IApplicationInsightsContext context, string fingerprint, LogSource source, string environment, TimeSpan timeSpan, int maxItems = 100) => Task.FromResult<SummaryData>(null);
-        public IAsyncEnumerable<SummarySubset> GetSummaries(IApplicationInsightsContext context, string environment, TimeSpan timeSpan) => Empty<SummarySubset>();
+        public IAsyncEnumerable<SummarySubset> GetSummaries(IApplicationInsightsContext context, string environment, TimeSpan timeSpan, CancellationToken cancellationToken = default) => Empty<SummarySubset>();
         public IAsyncEnumerable<VersionMatrixCell> GetVersionMatrixAsync(IApplicationInsightsContext context, TimeSpan? lookback = null) => Empty<VersionMatrixCell>();
         public IAsyncEnumerable<LogItem> SearchByIncidentIdAsync(IApplicationInsightsContext context, string incidentId, TimeSpan timeSpan) => Empty<LogItem>();
         public IAsyncEnumerable<LogItem> SearchByCorrelationIdAsync(IApplicationInsightsContext context, string correlationId, TimeSpan timeSpan) => Empty<LogItem>();

--- a/Quilt4Net.Toolkit.Blazor.Tests/LogViewConfigTests.cs
+++ b/Quilt4Net.Toolkit.Blazor.Tests/LogViewConfigTests.cs
@@ -59,7 +59,7 @@ public class LogViewConfigTests : BunitContext
         public IAsyncEnumerable<MeasureData> GetMeasureAsync(IApplicationInsightsContext context, string environment, TimeSpan timeSpan) => Empty<MeasureData>();
         public IAsyncEnumerable<CountData> GetCountAsync(IApplicationInsightsContext context, string environment, TimeSpan timeSpan) => Empty<CountData>();
         public Task<LogDetails> GetDetail(IApplicationInsightsContext context, string id, LogSource source, string environment, TimeSpan timeSpan) => Task.FromResult<LogDetails>(null);
-        public Task<SummaryData> GetSummary(IApplicationInsightsContext context, string fingerprint, LogSource source, string environment, TimeSpan timeSpan) => Task.FromResult<SummaryData>(null);
+        public Task<SummaryData> GetSummary(IApplicationInsightsContext context, string fingerprint, LogSource source, string environment, TimeSpan timeSpan, int maxItems = 100) => Task.FromResult<SummaryData>(null);
         public IAsyncEnumerable<SummarySubset> GetSummaries(IApplicationInsightsContext context, string environment, TimeSpan timeSpan) => Empty<SummarySubset>();
         public IAsyncEnumerable<VersionMatrixCell> GetVersionMatrixAsync(IApplicationInsightsContext context, TimeSpan? lookback = null) => Empty<VersionMatrixCell>();
         public IAsyncEnumerable<LogItem> SearchByIncidentIdAsync(IApplicationInsightsContext context, string incidentId, TimeSpan timeSpan) => Empty<LogItem>();

--- a/Quilt4Net.Toolkit.Blazor/Features/Log/LogCountView.razor
+++ b/Quilt4Net.Toolkit.Blazor/Features/Log/LogCountView.razor
@@ -7,7 +7,7 @@
 {
     <RadzenAlert AlertStyle="AlertStyle.Info" Shade="Shade.Lighter" AllowClose="false">@_configError</RadzenAlert>
 }
-else if (Model == null)
+else if (_loading || Model == null)
 {
     <Loading />
 }
@@ -67,11 +67,15 @@ else
     </RadzenTabs>
 }
 
+@implements IDisposable
+
 @code {
     private CountData[] Model { get; set; }
     private IReadOnlyList<ActionSeries> Series { get; set; } = Array.Empty<ActionSeries>();
     private string _configError;
     private IApplicationInsightsService _ais;
+    private CancellationTokenSource _cts;
+    private bool _loading;
 
     protected override void OnInitialized()
     {
@@ -80,6 +84,12 @@ else
         {
             _configError = LogConfigurationGuard.ServiceNotRegisteredMessage;
         }
+    }
+
+    public void Dispose()
+    {
+        _cts?.Cancel();
+        _cts?.Dispose();
     }
 
     [Parameter]
@@ -100,34 +110,60 @@ else
     {
         if (_configError != null) return;
 
+        _cts?.Cancel();
+        _cts?.Dispose();
+        _cts = new CancellationTokenSource();
+        var token = _cts.Token;
+
+        _loading = true;
         Model = null;
-        Model = await _ais
-            .GetCountAsync(Context, Environment, Range)
-            .ToArrayAsync();
+        StateHasChanged();
 
-        var model = Model.Select(x => new MeasurePoint
+        try
         {
-            Action = x.Action,
-            Environment = x.Environment,
-            TimeGenerated = x.TimeGenerated,
-            Count = x.Count
-        }).ToArray();
+            var loaded = await _ais
+                .GetCountAsync(Context, Environment, Range, token)
+                .ToArrayAsync(token);
 
-        if (model.GroupBy(x => x.Environment).Count() == 1)
-        {
-            Series = model
-                .GroupBy(x => x.Action)
-                .OrderBy(g => g.Key)
-                .Select(g => new ActionSeries(g.Key, g.OrderBy(p => p.TimeGenerated).ToArray()))
-                .ToArray();
+            if (token.IsCancellationRequested) return;
+
+            Model = loaded;
+
+            var model = Model.Select(x => new MeasurePoint
+            {
+                Action = x.Action,
+                Environment = x.Environment,
+                TimeGenerated = x.TimeGenerated,
+                Count = x.Count
+            }).ToArray();
+
+            if (model.GroupBy(x => x.Environment).Count() == 1)
+            {
+                Series = model
+                    .GroupBy(x => x.Action)
+                    .OrderBy(g => g.Key)
+                    .Select(g => new ActionSeries(g.Key, g.OrderBy(p => p.TimeGenerated).ToArray()))
+                    .ToArray();
+            }
+            else
+            {
+                Series = model
+                    .GroupBy(x => (x.Action, x.Environment))
+                    .OrderBy(g => g.Key)
+                    .Select(g => new ActionSeries($"{g.Key.Environment}.{g.Key.Action}", g.OrderBy(p => p.TimeGenerated).ToArray()))
+                    .ToArray();
+            }
         }
-        else
+        catch (OperationCanceledException) when (token.IsCancellationRequested)
         {
-            Series = model
-                .GroupBy(x => (x.Action, x.Environment))
-                .OrderBy(g => g.Key)
-                .Select(g => new ActionSeries($"{g.Key.Environment}.{g.Key.Action}", g.OrderBy(p => p.TimeGenerated).ToArray()))
-                .ToArray();
+        }
+        finally
+        {
+            if (!token.IsCancellationRequested)
+            {
+                _loading = false;
+                StateHasChanged();
+            }
         }
     }
 

--- a/Quilt4Net.Toolkit.Blazor/Features/Log/LogMeasureView.razor
+++ b/Quilt4Net.Toolkit.Blazor/Features/Log/LogMeasureView.razor
@@ -7,7 +7,7 @@
 {
     <RadzenAlert AlertStyle="AlertStyle.Info" Shade="Shade.Lighter" AllowClose="false">@_configError</RadzenAlert>
 }
-else if (Model == null)
+else if (_loading || Model == null)
 {
     <Loading />
 }
@@ -74,11 +74,15 @@ else
     </RadzenTabs>
 }
 
+@implements IDisposable
+
 @code {
     private MeasureData[] Model { get; set; }
     private IReadOnlyList<ActionSeries> Series { get; set; } = Array.Empty<ActionSeries>();
     private string _configError;
     private IApplicationInsightsService _ais;
+    private CancellationTokenSource _cts;
+    private bool _loading;
 
     protected override void OnInitialized()
     {
@@ -87,6 +91,12 @@ else
         {
             _configError = LogConfigurationGuard.ServiceNotRegisteredMessage;
         }
+    }
+
+    public void Dispose()
+    {
+        _cts?.Cancel();
+        _cts?.Dispose();
     }
 
     [Parameter]
@@ -107,35 +117,61 @@ else
     {
         if (_configError != null) return;
 
+        _cts?.Cancel();
+        _cts?.Dispose();
+        _cts = new CancellationTokenSource();
+        var token = _cts.Token;
+
+        _loading = true;
         Model = null;
-        Model = await _ais
-            .GetMeasureAsync(Context, Environment, Range)
-            .Where(x => x.Elapsed < TimeSpan.FromHours(10)) //TODO: I made a misstake with a log entry, remove this when Neurolito log is clean. That would be about 2026-02-01.
-            .ToArrayAsync();
+        StateHasChanged();
 
-        var model = Model.Select(x => new MeasurePoint
+        try
         {
-            Action = x.Action,
-            Environment = x.Environment,
-            TimeGenerated = x.TimeGenerated,
-            ElapsedMs = x.Elapsed.TotalMilliseconds
-        }).ToArray();
+            var loaded = await _ais
+                .GetMeasureAsync(Context, Environment, Range, token)
+                .Where(x => x.Elapsed < TimeSpan.FromHours(10)) //TODO: I made a misstake with a log entry, remove this when Neurolito log is clean. That would be about 2026-02-01.
+                .ToArrayAsync(token);
 
-        if (model.GroupBy(x => x.Environment).Count() == 1)
-        {
-            Series = model
-                .GroupBy(x => x.Action)
-                .OrderBy(g => g.Key)
-                .Select(g => new ActionSeries(g.Key, g.OrderBy(p => p.TimeGenerated).ToArray()))
-                .ToArray();
+            if (token.IsCancellationRequested) return;
+
+            Model = loaded;
+
+            var model = Model.Select(x => new MeasurePoint
+            {
+                Action = x.Action,
+                Environment = x.Environment,
+                TimeGenerated = x.TimeGenerated,
+                ElapsedMs = x.Elapsed.TotalMilliseconds
+            }).ToArray();
+
+            if (model.GroupBy(x => x.Environment).Count() == 1)
+            {
+                Series = model
+                    .GroupBy(x => x.Action)
+                    .OrderBy(g => g.Key)
+                    .Select(g => new ActionSeries(g.Key, g.OrderBy(p => p.TimeGenerated).ToArray()))
+                    .ToArray();
+            }
+            else
+            {
+                Series = model
+                    .GroupBy(x => (x.Action, x.Environment))
+                    .OrderBy(g => g.Key)
+                    .Select(g => new ActionSeries($"{g.Key.Environment}.{g.Key.Action}", g.OrderBy(p => p.TimeGenerated).ToArray()))
+                    .ToArray();
+            }
         }
-        else
+        catch (OperationCanceledException) when (token.IsCancellationRequested)
         {
-            Series = model
-                .GroupBy(x => (x.Action, x.Environment))
-                .OrderBy(g => g.Key)
-                .Select(g => new ActionSeries($"{g.Key.Environment}.{g.Key.Action}", g.OrderBy(p => p.TimeGenerated).ToArray()))
-                .ToArray();
+        }
+        finally
+        {
+            if (!token.IsCancellationRequested)
+            {
+                _loading = false;
+                StateHasChanged();
+            }
         }
     }
 

--- a/Quilt4Net.Toolkit.Blazor/Features/Log/LogSearchView.razor
+++ b/Quilt4Net.Toolkit.Blazor/Features/Log/LogSearchView.razor
@@ -64,11 +64,14 @@ else if (Model != null)
     </RadzenDataGrid>
 }
 
+@implements IDisposable
+
 @code {
     private bool _loading;
     private string _searchText;
     private string _configError;
     private IApplicationInsightsService _ais;
+    private CancellationTokenSource _cts;
     private LogItem[] Model { get; set; }
     private LogItem[] _filtered = [];
     private string[] _distinctApps = [];
@@ -82,6 +85,12 @@ else if (Model != null)
         {
             _configError = LogConfigurationGuard.ServiceNotRegisteredMessage;
         }
+    }
+
+    public void Dispose()
+    {
+        _cts?.Cancel();
+        _cts?.Dispose();
     }
 
     [CascadingParameter]
@@ -110,17 +119,37 @@ else if (Model != null)
 
     private async Task Search()
     {
+        // Cancel any in-flight search whose result we no longer want.
+        _cts?.Cancel();
+        _cts?.Dispose();
+        _cts = new CancellationTokenSource();
+        var token = _cts.Token;
+
         _loading = true;
         StateHasChanged();
 
-        var searchText = _searchText ?? string.Empty;
-        Model = await _ais.SearchAsync(Context, Environment, searchText, Range).ToArrayAsync();
+        try
+        {
+            var searchText = _searchText ?? string.Empty;
+            var loaded = await _ais.SearchAsync(Context, Environment, searchText, Range, SeverityLevel.Verbose, token).ToArrayAsync(token);
 
-        RecomputeDistincts();
-        ApplyFilters();
+            if (token.IsCancellationRequested) return;
 
-        _loading = false;
-        StateHasChanged();
+            Model = loaded;
+            RecomputeDistincts();
+            ApplyFilters();
+        }
+        catch (OperationCanceledException) when (token.IsCancellationRequested)
+        {
+        }
+        finally
+        {
+            if (!token.IsCancellationRequested)
+            {
+                _loading = false;
+                StateHasChanged();
+            }
+        }
     }
 
     private Task OnFiltersChanged(LogFilters next)

--- a/Quilt4Net.Toolkit.Blazor/Features/Log/LogSummaryListView.razor
+++ b/Quilt4Net.Toolkit.Blazor/Features/Log/LogSummaryListView.razor
@@ -7,7 +7,7 @@
 {
     <RadzenAlert AlertStyle="AlertStyle.Info" Shade="Shade.Lighter" AllowClose="false">@_configError</RadzenAlert>
 }
-else if (Model == null)
+else if (_loading || Model == null)
 {
     <Loading />
 }
@@ -44,6 +44,8 @@ else
     </RadzenDataGrid>
 }
 
+@implements IDisposable
+
 @code {
     private SummarySubset[] Model { get; set; }
     private SummarySubset[] _filtered = [];
@@ -52,6 +54,8 @@ else
     private LogFilters _filters = LogFilters.Empty;
     private string _configError;
     private IApplicationInsightsService _ais;
+    private CancellationTokenSource _cts;
+    private bool _loading;
 
     protected override void OnInitialized()
     {
@@ -60,6 +64,12 @@ else
         {
             _configError = LogConfigurationGuard.ServiceNotRegisteredMessage;
         }
+    }
+
+    public void Dispose()
+    {
+        _cts?.Cancel();
+        _cts?.Dispose();
     }
 
     [CascadingParameter]
@@ -90,13 +100,40 @@ else
     {
         if (_configError != null) return;
 
-        Model = null;
-        Model = await _ais
-            .GetSummaries(Context, Environment, Range)
-            .ToArrayAsync();
+        // Cancel any in-flight load whose parameters were superseded by this call.
+        _cts?.Cancel();
+        _cts?.Dispose();
+        _cts = new CancellationTokenSource();
+        var token = _cts.Token;
 
-        RecomputeDistincts();
-        ApplyFilters();
+        _loading = true;
+        Model = null;
+        StateHasChanged();
+
+        try
+        {
+            var loaded = await _ais
+                .GetSummaries(Context, Environment, Range, token)
+                .ToArrayAsync(token);
+
+            if (token.IsCancellationRequested) return;
+
+            Model = loaded;
+            RecomputeDistincts();
+            ApplyFilters();
+        }
+        catch (OperationCanceledException) when (token.IsCancellationRequested)
+        {
+            // Superseded by a newer parameter change; drop this result silently.
+        }
+        finally
+        {
+            if (!token.IsCancellationRequested)
+            {
+                _loading = false;
+                StateHasChanged();
+            }
+        }
     }
 
     private Task OnFiltersChanged(LogFilters next)

--- a/Quilt4Net.Toolkit.Tests/GetSummaryMaxItemsTests.cs
+++ b/Quilt4Net.Toolkit.Tests/GetSummaryMaxItemsTests.cs
@@ -1,0 +1,100 @@
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+using Quilt4Net.Toolkit.Features.ApplicationInsights;
+using Tharga.Cache;
+using Xunit;
+
+namespace Quilt4Net.Toolkit.Tests;
+
+/// <summary>
+/// Pins the upper-bound contract on <see cref="ApplicationInsightsService.GetSummary"/>.
+/// Without a row limit, a fingerprint with 100k+ matching rows over the lookback window
+/// returns the whole set, which made detail/summary navigation hang in production.
+/// </summary>
+public class GetSummaryMaxItemsTests
+{
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    [InlineData(-100)]
+    public async Task GetSummary_throws_for_non_positive_maxItems(int maxItems)
+    {
+        var sut = CreateSut(out _);
+
+        var act = () => sut.GetSummary(MakeContext(), "fp", LogSource.Exception, "Production", TimeSpan.FromDays(1), maxItems);
+
+        await act.Should().ThrowAsync<ArgumentOutOfRangeException>()
+            .Where(e => e.ParamName == "maxItems");
+    }
+
+    [Fact]
+    public async Task GetSummary_includes_maxItems_in_cache_key_so_different_limits_do_not_collide()
+    {
+        var sut = CreateSut(out var capturedKeys);
+
+        // Both calls will trip the mocked cache (which returns null) but we don't care —
+        // we're verifying the keys the service computes before the factory runs.
+        try { await sut.GetSummary(MakeContext(), "fp", LogSource.Exception, "Production", TimeSpan.FromDays(1), 100); } catch { }
+        try { await sut.GetSummary(MakeContext(), "fp", LogSource.Exception, "Production", TimeSpan.FromDays(1), 500); } catch { }
+
+        capturedKeys.Should().HaveCount(2);
+        capturedKeys[0].Should().NotBe(capturedKeys[1]);
+        capturedKeys[0].Should().EndWith("|100");
+        capturedKeys[1].Should().EndWith("|500");
+    }
+
+    [Fact]
+    public async Task GetSummary_default_maxItems_is_100()
+    {
+        var sut = CreateSut(out var capturedKeys);
+
+        try { await sut.GetSummary(MakeContext(), "fp", LogSource.Exception, "Production", TimeSpan.FromDays(1)); } catch { }
+
+        capturedKeys.Should().ContainSingle().Which.Should().EndWith("|100");
+    }
+
+    private static ApplicationInsightsService CreateSut(out List<string> capturedKeys)
+    {
+        var keys = new List<string>();
+        capturedKeys = keys;
+
+        var cache = new Mock<ITimeToLiveCache>();
+        cache
+            .Setup(c => c.GetAsync(It.IsAny<Key>(), It.IsAny<Func<Task<SummaryData>>>()))
+            .Callback<Key, Func<Task<SummaryData>>>((key, _) => keys.Add(key.ToString()))
+            .Returns(Task.FromResult<SummaryData>(null!));
+
+        var options = Options.Create(new ApplicationInsightsOptions
+        {
+            TenantId = "tenant",
+            WorkspaceId = "workspace",
+            ClientId = "client",
+            ClientSecret = "secret"
+        });
+
+        return new ApplicationInsightsService(
+            cache.Object,
+            options,
+            NullLogger<ApplicationInsightsService>.Instance);
+    }
+
+    private static IApplicationInsightsContext MakeContext() => new TestContext
+    {
+        TenantId = "tenant",
+        WorkspaceId = "workspace",
+        ClientId = "client",
+        ClientSecret = "secret",
+        AuthMode = ApplicationInsightsAuthMode.ClientSecret
+    };
+
+    private sealed record TestContext : IApplicationInsightsContext
+    {
+        public string TenantId { get; init; }
+        public string WorkspaceId { get; init; }
+        public string ClientId { get; init; }
+        public string ClientSecret { get; init; }
+        public ApplicationInsightsAuthMode AuthMode { get; init; }
+    }
+}

--- a/Quilt4Net.Toolkit/Features/ApplicationInsights/ApplicationInsightsService.cs
+++ b/Quilt4Net.Toolkit/Features/ApplicationInsights/ApplicationInsightsService.cs
@@ -790,13 +790,15 @@ AppRequests
         };
     }
 
-    public async Task<SummaryData> GetSummary(IApplicationInsightsContext context, string fingerprint, LogSource source, string environment, TimeSpan timeSpan)
+    public async Task<SummaryData> GetSummary(IApplicationInsightsContext context, string fingerprint, LogSource source, string environment, TimeSpan timeSpan, int maxItems = 100)
     {
-        var cacheKey = $"summary|{context.ToKey()}|{fingerprint}|{source}|{environment}|{timeSpan}";
-        return await _timeToLiveCache.GetAsync(cacheKey, () => GetSummaryInternalAsync(context, fingerprint, source, environment, timeSpan));
+        if (maxItems <= 0) throw new ArgumentOutOfRangeException(nameof(maxItems), "maxItems must be positive.");
+
+        var cacheKey = $"summary|{context.ToKey()}|{fingerprint}|{source}|{environment}|{timeSpan}|{maxItems}";
+        return await _timeToLiveCache.GetAsync(cacheKey, () => GetSummaryInternalAsync(context, fingerprint, source, environment, timeSpan, maxItems));
     }
 
-    private async Task<SummaryData> GetSummaryInternalAsync(IApplicationInsightsContext context, string fingerprint, LogSource source, string environment, TimeSpan timeSpan)
+    private async Task<SummaryData> GetSummaryInternalAsync(IApplicationInsightsContext context, string fingerprint, LogSource source, string environment, TimeSpan timeSpan, int maxItems)
     {
         var client = GetClient(context);
         var workspaceId = context?.WorkspaceId ?? _options.WorkspaceId;
@@ -814,7 +816,8 @@ AppExceptions
     Id = _ItemId
 | where Fingerprint == ""{fingerprint}""
 | project Id, TimeGenerated, Message, Environment, Application, SeverityLevel
-| order by TimeGenerated desc",
+| order by TimeGenerated desc
+| take {maxItems}",
 
             LogSource.Trace => $@"
 AppTraces
@@ -831,7 +834,8 @@ AppTraces
     Fingerprint = base64_encode_tostring(tostring(hash(FingerprintSource)))
 | where Fingerprint == ""{fingerprint}""
 | project Id, TimeGenerated, Message, Environment, Application, SeverityLevel
-| order by TimeGenerated desc",
+| order by TimeGenerated desc
+| take {maxItems}",
 
             LogSource.Request => $@"
 AppRequests
@@ -845,7 +849,8 @@ AppRequests
     Id = _ItemId
 | where Fingerprint == ""{fingerprint}""
 | project Id, TimeGenerated, Message, Environment, Application, SeverityLevel
-| order by TimeGenerated desc",
+| order by TimeGenerated desc
+| take {maxItems}",
 
             _ => throw new ArgumentOutOfRangeException(nameof(source))
         };

--- a/Quilt4Net.Toolkit/Features/ApplicationInsights/ApplicationInsightsService.cs
+++ b/Quilt4Net.Toolkit/Features/ApplicationInsights/ApplicationInsightsService.cs
@@ -204,9 +204,12 @@ union
         }
     }
 
-    public async IAsyncEnumerable<LogItem> SearchAsync(IApplicationInsightsContext context, string environment, string text, TimeSpan timeSpan, SeverityLevel minSeverityLevel = SeverityLevel.Verbose)
+    public async IAsyncEnumerable<LogItem> SearchAsync(IApplicationInsightsContext context, string environment, string text, TimeSpan timeSpan, SeverityLevel minSeverityLevel = SeverityLevel.Verbose, [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
         var cacheKey = $"search|{context.ToKey()}|{environment}|{text}|{timeSpan}|{minSeverityLevel}";
+        // CancellationToken.None inside the cache factory: a cancel from one caller must not poison
+        // the cached load for other concurrent callers (the network call continues; the cancelling
+        // caller short-circuits below at the yield-loop check).
         var items = await _timeToLiveCache.GetAsync(cacheKey, async () =>
         {
             var list = await SearchInternalAsync(context, environment, text, timeSpan, minSeverityLevel).ToArrayAsync();
@@ -214,6 +217,7 @@ union
         });
         foreach (var item in items)
         {
+            cancellationToken.ThrowIfCancellationRequested();
             yield return item;
         }
     }
@@ -458,7 +462,7 @@ AppRequests
         }
     }
 
-    public async IAsyncEnumerable<MeasureData> GetMeasureAsync(IApplicationInsightsContext context, string environment, TimeSpan timeSpan)
+    public async IAsyncEnumerable<MeasureData> GetMeasureAsync(IApplicationInsightsContext context, string environment, TimeSpan timeSpan, [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
         var cacheKey = $"measure|{context.ToKey()}|{environment}|{timeSpan}";
         var items = await _timeToLiveCache.GetAsync(cacheKey, async () =>
@@ -468,6 +472,7 @@ AppRequests
         });
         foreach (var item in items)
         {
+            cancellationToken.ThrowIfCancellationRequested();
             yield return item;
         }
     }
@@ -563,7 +568,7 @@ AppTraces
         }
     }
 
-    public async IAsyncEnumerable<CountData> GetCountAsync(IApplicationInsightsContext context, string environment, TimeSpan timeSpan)
+    public async IAsyncEnumerable<CountData> GetCountAsync(IApplicationInsightsContext context, string environment, TimeSpan timeSpan, [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
         var cacheKey = $"count|{context.ToKey()}|{environment}|{timeSpan}";
         var items = await _timeToLiveCache.GetAsync(cacheKey, async () =>
@@ -573,6 +578,7 @@ AppTraces
         });
         foreach (var item in items)
         {
+            cancellationToken.ThrowIfCancellationRequested();
             yield return item;
         }
     }
@@ -897,7 +903,7 @@ AppRequests
         };
     }
 
-    public async IAsyncEnumerable<SummarySubset> GetSummaries(IApplicationInsightsContext context, string environment, TimeSpan timeSpan)
+    public async IAsyncEnumerable<SummarySubset> GetSummaries(IApplicationInsightsContext context, string environment, TimeSpan timeSpan, [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
         var cacheKey = $"summaries|{context.ToKey()}|{environment}|{timeSpan}";
         var items = await _timeToLiveCache.GetAsync(cacheKey, async () =>
@@ -907,6 +913,7 @@ AppRequests
         });
         foreach (var item in items)
         {
+            cancellationToken.ThrowIfCancellationRequested();
             yield return item;
         }
     }

--- a/Quilt4Net.Toolkit/Features/ApplicationInsights/IApplicationInsightsService.cs
+++ b/Quilt4Net.Toolkit/Features/ApplicationInsights/IApplicationInsightsService.cs
@@ -8,7 +8,13 @@ public interface IApplicationInsightsService
     IAsyncEnumerable<MeasureData> GetMeasureAsync(IApplicationInsightsContext context, string environment, TimeSpan timeSpan);
     IAsyncEnumerable<CountData> GetCountAsync(IApplicationInsightsContext context, string environment, TimeSpan timeSpan);
     Task<LogDetails> GetDetail(IApplicationInsightsContext context, string id, LogSource source, string environment, TimeSpan timeSpan);
-    Task<SummaryData> GetSummary(IApplicationInsightsContext context, string fingerprint, LogSource source, string environment, TimeSpan timeSpan);
+    /// <summary>
+    /// Get the latest items for a single fingerprint. Capped at <paramref name="maxItems"/>
+    /// (default 100) — a fingerprint can match 100k+ rows over the lookback window, and
+    /// returning all of them is what made detail/summary navigation hang. Items are ordered
+    /// newest-first; only the top <paramref name="maxItems"/> are returned.
+    /// </summary>
+    Task<SummaryData> GetSummary(IApplicationInsightsContext context, string fingerprint, LogSource source, string environment, TimeSpan timeSpan, int maxItems = 100);
     IAsyncEnumerable<SummarySubset> GetSummaries(IApplicationInsightsContext context, string environment, TimeSpan timeSpan);
 
     /// <summary>

--- a/Quilt4Net.Toolkit/Features/ApplicationInsights/IApplicationInsightsService.cs
+++ b/Quilt4Net.Toolkit/Features/ApplicationInsights/IApplicationInsightsService.cs
@@ -4,9 +4,9 @@ public interface IApplicationInsightsService
 {
     Task<bool> CanConnectAsync(IApplicationInsightsContext context);
     IAsyncEnumerable<EnvironmentOption> GetEnvironments(IApplicationInsightsContext context);
-    IAsyncEnumerable<LogItem> SearchAsync(IApplicationInsightsContext context, string environment, string text, TimeSpan timeSpan, SeverityLevel minSeverityLevel = SeverityLevel.Verbose);
-    IAsyncEnumerable<MeasureData> GetMeasureAsync(IApplicationInsightsContext context, string environment, TimeSpan timeSpan);
-    IAsyncEnumerable<CountData> GetCountAsync(IApplicationInsightsContext context, string environment, TimeSpan timeSpan);
+    IAsyncEnumerable<LogItem> SearchAsync(IApplicationInsightsContext context, string environment, string text, TimeSpan timeSpan, SeverityLevel minSeverityLevel = SeverityLevel.Verbose, CancellationToken cancellationToken = default);
+    IAsyncEnumerable<MeasureData> GetMeasureAsync(IApplicationInsightsContext context, string environment, TimeSpan timeSpan, CancellationToken cancellationToken = default);
+    IAsyncEnumerable<CountData> GetCountAsync(IApplicationInsightsContext context, string environment, TimeSpan timeSpan, CancellationToken cancellationToken = default);
     Task<LogDetails> GetDetail(IApplicationInsightsContext context, string id, LogSource source, string environment, TimeSpan timeSpan);
     /// <summary>
     /// Get the latest items for a single fingerprint. Capped at <paramref name="maxItems"/>
@@ -15,7 +15,7 @@ public interface IApplicationInsightsService
     /// newest-first; only the top <paramref name="maxItems"/> are returned.
     /// </summary>
     Task<SummaryData> GetSummary(IApplicationInsightsContext context, string fingerprint, LogSource source, string environment, TimeSpan timeSpan, int maxItems = 100);
-    IAsyncEnumerable<SummarySubset> GetSummaries(IApplicationInsightsContext context, string environment, TimeSpan timeSpan);
+    IAsyncEnumerable<SummarySubset> GetSummaries(IApplicationInsightsContext context, string environment, TimeSpan timeSpan, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Get the latest version of each (application, environment) combination


### PR DESCRIPTION
## Summary

Two related fixes to the Application Insights log UI, both addressing slowness/UX issues observed in production.

### 1. `fix: cap GetSummary at maxItems (default 100)`

A fingerprint with 100k+ matching rows over the lookback window returned all rows from `GetSummary`, making detail/summary navigation hang. The KQL ordered by `TimeGenerated desc` but had no `take` clause, so the whole set came back.

- Add `int maxItems = 100` parameter (source-compatible — existing callers get the cap automatically).
- Add `| take {maxItems}` after the order-by in all three source-specific queries (`AppExceptions` / `AppTraces` / `AppRequests`).
- Include `maxItems` in the cache key so different limits do not collide.
- Reject non-positive values with `ArgumentOutOfRangeException`.

5 new unit tests cover validation, cache-key shape, and the default. Existing `LogSummaryContent.razor` and `ApplicationInsightsToolProvider` (MCP) automatically get the cap.

### 2. `feat: cancellable log queries with loading state during reloads`

Switching filters (Range, Environment, top-level tab) in LogView used to fire a new server query that raced with any in-flight one — and showed no loading indicator beyond the initial `Model=null` gap, so a slow query followed by a fast one could overwrite the fast result silently.

- `IApplicationInsightsService.SearchAsync` / `GetMeasureAsync` / `GetCountAsync` / `GetSummaries` now accept an optional `CancellationToken` (default = `default`, source-compatible). Each public iterator carries `[EnumeratorCancellation]` so consumer-side `.WithCancellation(...)` / `.ToArrayAsync(token)` flows in.
- Inside the cache factory we pass `CancellationToken.None` so a cancel from one caller cannot poison the shared cached load for other concurrent callers; the cancelling caller exits early at the yield-loop check.
- `LogSearchView`, `LogSummaryListView`, `LogCountView`, `LogMeasureView` now hold a `CancellationTokenSource`, cancel/recreate it on each parameter change (or Search-button click for `LogSearchView`), set `_loading = true` during the await, and swallow `OperationCanceledException` for the superseded request. The `Loading` component shows during reloads, not just initial loads. All four implement `IDisposable` to cancel the in-flight CTS on teardown.
- Blazor test stubs for `IApplicationInsightsService` updated to match the new method signatures.

## Test plan

- [ ] Unit tests pass (`Quilt4Net.Toolkit.Tests`, +5 new; 257 total across all projects)
- [ ] Build clean across `net8.0`, `net9.0`, `net10.0`
- [ ] Manual: detail navigation from a fingerprint with 100k+ entries completes promptly (capped at 100)
- [ ] Manual: switching tabs / range / environment mid-query shows the `Loading` indicator immediately and the stale result is dropped silently