### PR TITLE
feat: remote AI configuration for Toolkit consumers

### DIFF
--- a/Quilt4Net.Toolkit.Api.Sample/Quilt4Net.Toolkit.Api.Sample.csproj
+++ b/Quilt4Net.Toolkit.Api.Sample/Quilt4Net.Toolkit.Api.Sample.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <NoWarn>1701;1702;CS1591;CS0809</NoWarn>
+    <NoWarn>1701;1702;CS1591;CS0809;CS0618;ASP0019</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Quilt4Net.Toolkit.Api.Tests/Quilt4Net.Toolkit.Api.Tests.csproj
+++ b/Quilt4Net.Toolkit.Api.Tests/Quilt4Net.Toolkit.Api.Tests.csproj
@@ -7,21 +7,21 @@
 
 	<ItemGroup>
 		<PackageReference Include="AutoFixture" Version="4.18.1" />
-		<PackageReference Include="FluentAssertions" Version="8.9.0" />
+		<PackageReference Include="FluentAssertions" Version="8.10.0" />
 		<PackageReference Include="JetBrains.Annotations" Version="2025.2.4" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
 		<PackageReference Include="Moq" Version="4.20.72" />
-		<PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.7" />
+		<PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.8" />
 		<PackageReference Include="OneOf" Version="3.0.271" />
 		<PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="coverlet.msbuild" Version="10.0.0">
+		<PackageReference Include="coverlet.msbuild" Version="10.0.1">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="coverlet.collector" Version="10.0.0">
+		<PackageReference Include="coverlet.collector" Version="10.0.1">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>

--- a/Quilt4Net.Toolkit.Api/Quilt4Net.Toolkit.Api.csproj
+++ b/Quilt4Net.Toolkit.Api/Quilt4Net.Toolkit.Api.csproj
@@ -40,7 +40,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-	  <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.203">
+	  <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.300">
 		  <PrivateAssets>all</PrivateAssets>
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 	  </PackageReference>

--- a/Quilt4Net.Toolkit.Blazor.Server.Sample/Quilt4Net.Toolkit.Blazor.Server.Sample.csproj
+++ b/Quilt4Net.Toolkit.Blazor.Server.Sample/Quilt4Net.Toolkit.Blazor.Server.Sample.csproj
@@ -5,6 +5,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <BlazorDisableThrowNavigationException>true</BlazorDisableThrowNavigationException>
     <UserSecretsId>e37e5897-4012-49b7-99bb-6a5c66b3124e</UserSecretsId>
+    <NoWarn>1701;1702;CS1591;CS0809;CS0618;CS8669</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Quilt4Net.Toolkit.Blazor.Tests/ApplicationInsightsConfigurationSelectorTests.cs
+++ b/Quilt4Net.Toolkit.Blazor.Tests/ApplicationInsightsConfigurationSelectorTests.cs
@@ -3,6 +3,8 @@ using Quilt4Net.Toolkit.Blazor.Features.ApplicationInsights;
 using Quilt4Net.Toolkit.Features.ApplicationInsights;
 using Xunit;
 
+#pragma warning disable xUnit1051
+
 namespace Quilt4Net.Toolkit.Blazor.Tests;
 
 public class ApplicationInsightsConfigurationSelectorTests

--- a/Quilt4Net.Toolkit.Blazor.Tests/ApplicationInsightsConfigurationSelectorTests.cs
+++ b/Quilt4Net.Toolkit.Blazor.Tests/ApplicationInsightsConfigurationSelectorTests.cs
@@ -1,0 +1,101 @@
+using FluentAssertions;
+using Quilt4Net.Toolkit.Blazor.Features.ApplicationInsights;
+using Quilt4Net.Toolkit.Features.ApplicationInsights;
+using Xunit;
+
+namespace Quilt4Net.Toolkit.Blazor.Tests;
+
+public class ApplicationInsightsConfigurationSelectorTests
+{
+    [Fact]
+    public async Task LoadAsync_Empty_List_Marks_Loaded_With_Null_Selected()
+    {
+        var provider = new FakeProvider([]);
+        var selector = new ApplicationInsightsConfigurationSelector(provider);
+
+        await selector.LoadAsync();
+
+        selector.IsLoaded.Should().BeTrue();
+        selector.Available.Should().BeEmpty();
+        selector.Selected.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task LoadAsync_Defaults_To_First_When_Multiple()
+    {
+        var provider = new FakeProvider([
+            new() { Id = "a", Name = "Prod" },
+            new() { Id = "b", Name = "Test" }
+        ]);
+        var selector = new ApplicationInsightsConfigurationSelector(provider);
+
+        await selector.LoadAsync();
+
+        selector.Selected!.Id.Should().Be("a");
+    }
+
+    [Fact]
+    public async Task SelectAsync_Switches_Selected_And_Raises_OnChanged()
+    {
+        var provider = new FakeProvider([
+            new() { Id = "a", Name = "Prod" },
+            new() { Id = "b", Name = "Test" }
+        ]);
+        var selector = new ApplicationInsightsConfigurationSelector(provider);
+        await selector.LoadAsync();
+
+        var notifications = 0;
+        selector.OnChanged += () => notifications++;
+
+        await selector.SelectAsync("b");
+
+        selector.Selected!.Id.Should().Be("b");
+        notifications.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task SelectAsync_Unknown_Id_Is_NoOp()
+    {
+        var provider = new FakeProvider([new() { Id = "a", Name = "Prod" }]);
+        var selector = new ApplicationInsightsConfigurationSelector(provider);
+        await selector.LoadAsync();
+
+        var notifications = 0;
+        selector.OnChanged += () => notifications++;
+
+        await selector.SelectAsync("does-not-exist");
+
+        selector.Selected!.Id.Should().Be("a");
+        notifications.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task LoadAsync_Is_Idempotent()
+    {
+        var provider = new FakeProvider([new() { Id = "a", Name = "Prod" }]);
+        var selector = new ApplicationInsightsConfigurationSelector(provider);
+
+        await selector.LoadAsync();
+        var firstHits = provider.HitCount;
+        await selector.LoadAsync();
+
+        provider.HitCount.Should().Be(firstHits, "load-once per circuit; reloads must not refetch");
+    }
+
+    private sealed class FakeProvider : IApplicationInsightsConfigurationProvider
+    {
+        private readonly ApplicationInsightsConfigurationResponse[] _items;
+        public int HitCount { get; private set; }
+
+        public FakeProvider(ApplicationInsightsConfigurationResponse[] items)
+        {
+            _items = items;
+        }
+
+        public Task<ApplicationInsightsConfigurationResponse[]> GetAllAsync(CancellationToken cancellationToken = default)
+        {
+            HitCount++;
+            return Task.FromResult(_items);
+        }
+    }
+}

--- a/Quilt4Net.Toolkit.Blazor.Tests/Quilt4Net.Toolkit.Blazor.Tests.csproj
+++ b/Quilt4Net.Toolkit.Blazor.Tests/Quilt4Net.Toolkit.Blazor.Tests.csproj
@@ -8,8 +8,8 @@
 
   <ItemGroup>
     <PackageReference Include="bunit" Version="2.7.2" />
-    <PackageReference Include="FluentAssertions" Version="8.9.0" />
-    <PackageReference Include="coverlet.collector" Version="10.0.0">
+    <PackageReference Include="FluentAssertions" Version="8.10.0" />
+    <PackageReference Include="coverlet.collector" Version="10.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/Quilt4Net.Toolkit.Blazor.Wasm.Sample/Quilt4Net.Toolkit.Blazor.Wasm.Sample.csproj
+++ b/Quilt4Net.Toolkit.Blazor.Wasm.Sample/Quilt4Net.Toolkit.Blazor.Wasm.Sample.csproj
@@ -8,8 +8,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.7" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="10.0.7" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.8" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="10.0.8" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Quilt4Net.Toolkit.Blazor/Features/ApplicationInsights/ApplicationInsightsConfigurationDropdown.razor
+++ b/Quilt4Net.Toolkit.Blazor/Features/ApplicationInsights/ApplicationInsightsConfigurationDropdown.razor
@@ -1,0 +1,41 @@
+@using Quilt4Net.Toolkit.Features.ApplicationInsights
+@inject IApplicationInsightsConfigurationSelector Selector
+@implements IDisposable
+
+@if (Selector.Available.Count > 1)
+{
+    <RadzenStack Orientation="Orientation.Vertical" Gap="0">
+        <RadzenText TextStyle="TextStyle.Caption" Text="Configuration" />
+        <RadzenDropDown Data="@Selector.Available"
+                        TValue="string"
+                        Value="@Selector.Selected?.Id"
+                        TextProperty="Name"
+                        ValueProperty="Id"
+                        Change="@OnChangeAsync" />
+    </RadzenStack>
+}
+
+@code {
+    protected override void OnInitialized()
+    {
+        Selector.OnChanged += HandleChanged;
+    }
+
+    private void HandleChanged()
+    {
+        InvokeAsync(StateHasChanged);
+    }
+
+    private async Task OnChangeAsync(object value)
+    {
+        if (value is string id)
+        {
+            await Selector.SelectAsync(id);
+        }
+    }
+
+    public void Dispose()
+    {
+        Selector.OnChanged -= HandleChanged;
+    }
+}

--- a/Quilt4Net.Toolkit.Blazor/Features/ApplicationInsights/ApplicationInsightsConfigurationSelector.cs
+++ b/Quilt4Net.Toolkit.Blazor/Features/ApplicationInsights/ApplicationInsightsConfigurationSelector.cs
@@ -1,0 +1,79 @@
+using Blazored.LocalStorage;
+using Quilt4Net.Toolkit.Features.ApplicationInsights;
+
+namespace Quilt4Net.Toolkit.Blazor.Features.ApplicationInsights;
+
+internal class ApplicationInsightsConfigurationSelector : IApplicationInsightsConfigurationSelector
+{
+    private const string StorageKeyPrefix = "Quilt4Net.Monitor.SelectedConfig.";
+
+    private readonly IApplicationInsightsConfigurationProvider _provider;
+    private readonly ILocalStorageService _localStorage;
+    private readonly SemaphoreSlim _loadGate = new(1, 1);
+
+    private string _storageKey;
+
+    public ApplicationInsightsConfigurationResponse Selected { get; private set; }
+    public IReadOnlyList<ApplicationInsightsConfigurationResponse> Available { get; private set; } = [];
+    public bool IsLoaded { get; private set; }
+
+    public event Action OnChanged;
+
+    public ApplicationInsightsConfigurationSelector(
+        IApplicationInsightsConfigurationProvider provider,
+        ILocalStorageService localStorage = null)
+    {
+        _provider = provider;
+        _localStorage = localStorage;
+    }
+
+    public async Task LoadAsync(string storageScope = null, CancellationToken cancellationToken = default)
+    {
+        await _loadGate.WaitAsync(cancellationToken);
+        try
+        {
+            if (IsLoaded) return;
+
+            _storageKey = !string.IsNullOrEmpty(storageScope) ? StorageKeyPrefix + storageScope : null;
+            Available = await _provider.GetAllAsync(cancellationToken);
+            IsLoaded = true;
+
+            if (Available.Count == 0)
+            {
+                Selected = null;
+                OnChanged?.Invoke();
+                return;
+            }
+
+            string preferredId = null;
+            if (_storageKey != null && _localStorage != null)
+            {
+                try { preferredId = await _localStorage.GetItemAsStringAsync(_storageKey, cancellationToken); }
+                catch { /* private mode / quota — fall through to default */ }
+            }
+
+            Selected = (preferredId != null ? Available.FirstOrDefault(x => x.Id == preferredId) : null) ?? Available[0];
+            OnChanged?.Invoke();
+        }
+        finally
+        {
+            _loadGate.Release();
+        }
+    }
+
+    public async Task SelectAsync(string id)
+    {
+        var next = Available.FirstOrDefault(x => x.Id == id);
+        if (next == null || next.Id == Selected?.Id) return;
+
+        Selected = next;
+
+        if (_storageKey != null && _localStorage != null)
+        {
+            try { await _localStorage.SetItemAsStringAsync(_storageKey, id); }
+            catch { /* localStorage write failures shouldn't break the UI */ }
+        }
+
+        OnChanged?.Invoke();
+    }
+}

--- a/Quilt4Net.Toolkit.Blazor/Features/ApplicationInsights/BlazorApplicationInsightsRegistration.cs
+++ b/Quilt4Net.Toolkit.Blazor/Features/ApplicationInsights/BlazorApplicationInsightsRegistration.cs
@@ -1,0 +1,35 @@
+using Blazored.LocalStorage;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Quilt4Net.Toolkit;
+
+namespace Quilt4Net.Toolkit.Blazor.Features.ApplicationInsights;
+
+public static class BlazorApplicationInsightsRegistration
+{
+    /// <summary>
+    /// Register the Blazor-side wiring for remote Application Insights configuration:
+    /// the toolkit-level remote provider plus the circuit-scoped selector that powers
+    /// the in-component dropdown when the team has more than one configuration. Use this
+    /// instead of <see cref="ApplicationInsightsRegistration.AddQuilt4NetApplicationInsightsClientRemote(IHostApplicationBuilder, Action{RemoteConfigurationOptions})"/>
+    /// in Blazor host applications.
+    /// </summary>
+    public static IServiceCollection AddQuilt4NetBlazorApplicationInsightsClientRemote(
+        this IHostApplicationBuilder builder,
+        Action<RemoteConfigurationOptions> options = null)
+    {
+        return builder.Services.AddQuilt4NetBlazorApplicationInsightsClientRemote(builder.Configuration, options);
+    }
+
+    public static IServiceCollection AddQuilt4NetBlazorApplicationInsightsClientRemote(
+        this IServiceCollection services,
+        IConfiguration configuration,
+        Action<RemoteConfigurationOptions> options = null)
+    {
+        services.AddQuilt4NetApplicationInsightsClientRemote(configuration, options);
+        services.AddBlazoredLocalStorage();
+        services.AddScoped<IApplicationInsightsConfigurationSelector, ApplicationInsightsConfigurationSelector>();
+        return services;
+    }
+}

--- a/Quilt4Net.Toolkit.Blazor/Features/ApplicationInsights/IApplicationInsightsConfigurationSelector.cs
+++ b/Quilt4Net.Toolkit.Blazor/Features/ApplicationInsights/IApplicationInsightsConfigurationSelector.cs
@@ -1,0 +1,21 @@
+using Quilt4Net.Toolkit.Features.ApplicationInsights;
+
+namespace Quilt4Net.Toolkit.Blazor.Features.ApplicationInsights;
+
+/// <summary>
+/// Holds the currently selected Application Insights configuration for a Blazor circuit.
+/// LogView and VersionMatrixDisplay both consume this in remote mode so they pick the
+/// same configuration when rendered side-by-side on one page. Selection optionally
+/// persists in localStorage when a storage scope is supplied.
+/// </summary>
+public interface IApplicationInsightsConfigurationSelector
+{
+    ApplicationInsightsConfigurationResponse Selected { get; }
+    IReadOnlyList<ApplicationInsightsConfigurationResponse> Available { get; }
+    bool IsLoaded { get; }
+
+    Task LoadAsync(string storageScope = null, CancellationToken cancellationToken = default);
+    Task SelectAsync(string id);
+
+    event Action OnChanged;
+}

--- a/Quilt4Net.Toolkit.Blazor/Features/Log/LogView.razor
+++ b/Quilt4Net.Toolkit.Blazor/Features/Log/LogView.razor
@@ -2,10 +2,12 @@
 @using Microsoft.Extensions.DependencyInjection
 @using Microsoft.Extensions.Options
 @using Quilt4Net.Toolkit
+@using Quilt4Net.Toolkit.Blazor.Features.ApplicationInsights
 @using Quilt4Net.Toolkit.Features.ApplicationInsights
 @using Tharga.Blazor.Features.BreadCrumbs
 @inject NavigationManager NavigationManager
 @inject IServiceProvider ServiceProvider
+@implements IDisposable
 
 @if (_configError != null)
 {
@@ -19,7 +21,13 @@
 <CascadingValue Name="ApplicationAliasMap" Value="@_effectiveAliasMap">
 <CascadingValue Name="FilterStorageScope" Value="@FilterStorageScope">
 <CascadingValue Name="SourcePathRoots" Value="@SourcePathRoots">
-    <RadzenRow Style="margin-bottom: 6px;" Visible="@(ShowRangeSelector || ShowEnvironmentSelector)">
+    <RadzenRow Style="margin-bottom: 6px;" Visible="@(_selector != null || ShowRangeSelector || ShowEnvironmentSelector)">
+        @if (_selector != null && _selector.Available.Count > 1)
+        {
+            <RadzenColumn>
+                <ApplicationInsightsConfigurationDropdown />
+            </RadzenColumn>
+        }
         <RadzenColumn Visible="@ShowRangeSelector">
             <RadzenStack Orientation="Orientation.Vertical" Gap="0">
                 <RadzenText TextStyle="TextStyle.Caption" Text="Range"/>
@@ -29,7 +37,7 @@
         <RadzenColumn Visible="@ShowEnvironmentSelector">
             <RadzenStack Orientation="Orientation.Vertical" Gap="0">
                 <RadzenText TextStyle="TextStyle.Caption" Text="Environment" />
-                <LogEnvironmentSelector OnSelected="OnEnvironmentSelected" Context="@Context" />
+                <LogEnvironmentSelector OnSelected="OnEnvironmentSelected" Context="@EffectiveContext" />
             </RadzenStack>
         </RadzenColumn>
     </RadzenRow>
@@ -39,19 +47,19 @@
             <RadzenTabs SelectedIndex="@_tabIndex" Change="@OnTabChange">
                 <Tabs>
                     <RadzenTabsItem Text="Search">
-                        <LogSearchView Range="@RangeToUse" Environment="@EnvironmentToUse" Context="Context" />
+                        <LogSearchView Range="@RangeToUse" Environment="@EnvironmentToUse" Context="EffectiveContext" />
                     </RadzenTabsItem>
                     <RadzenTabsItem Text="Summary">
-                        <LogSummaryListView Range="@RangeToUse" Environment="@EnvironmentToUse" Context="Context" />
+                        <LogSummaryListView Range="@RangeToUse" Environment="@EnvironmentToUse" Context="EffectiveContext" />
                     </RadzenTabsItem>
                     <RadzenTabsItem Text="Measure">
-                        <LogMeasureView Range="@RangeToUse" Environment="@EnvironmentToUse" Context="Context" />
+                        <LogMeasureView Range="@RangeToUse" Environment="@EnvironmentToUse" Context="EffectiveContext" />
                     </RadzenTabsItem>
                     <RadzenTabsItem Text="Count">
-                        <LogCountView Range="@RangeToUse" Environment="@EnvironmentToUse" Context="Context" />
+                        <LogCountView Range="@RangeToUse" Environment="@EnvironmentToUse" Context="EffectiveContext" />
                     </RadzenTabsItem>
                     <RadzenTabsItem Text="Test" Visible="@ShowTestTab">
-                        <LogTriggerView Context="Context" />
+                        <LogTriggerView Context="EffectiveContext" />
                     </RadzenTabsItem>
                 </Tabs>
             </RadzenTabs>
@@ -81,6 +89,10 @@
     private int _tabIndex;
     private string _configError;
     private LoggingErrorBoundary _errorBoundary;
+    private IApplicationInsightsConfigurationSelector _selector;
+
+    private IApplicationInsightsContext EffectiveContext
+        => Context ?? _selector?.Selected;
 
     [Parameter]
     public bool ShowRangeSelector { get; set; } = true;
@@ -181,7 +193,7 @@
         ? _environment
         : Environment;
 
-    protected override void OnInitialized()
+    protected override async Task OnInitializedAsync()
     {
         if (LogConfigurationGuard.TryResolve(ServiceProvider) == null)
         {
@@ -191,20 +203,44 @@
 
         if (Context == null)
         {
-            var options = ServiceProvider.GetService<IOptions<ApplicationInsightsOptions>>()?.Value;
-            if (options == null
-                || string.IsNullOrEmpty(options.TenantId)
-                || string.IsNullOrEmpty(options.WorkspaceId)
-                || string.IsNullOrEmpty(options.ClientId)
-                || string.IsNullOrEmpty(options.ClientSecret))
+            _selector = ServiceProvider.GetService<IApplicationInsightsConfigurationSelector>();
+            if (_selector != null)
             {
-                _configError = "Application Insights is not configured. Set TenantId, WorkspaceId, ClientId, and ClientSecret in appsettings.json under Quilt4Net:ApplicationInsights.";
-                return;
+                _selector.OnChanged += HandleSelectorChanged;
+                await _selector.LoadAsync(FilterStorageScope);
+                if (_selector.Available.Count == 0)
+                {
+                    _configError = "No Application Insights configurations are available for this team on the Quilt4Net server. Add one under the team's monitoring settings, or grant the API key the 'monitor:read' scope.";
+                    return;
+                }
+            }
+            else
+            {
+                var options = ServiceProvider.GetService<IOptions<ApplicationInsightsOptions>>()?.Value;
+                if (options == null
+                    || string.IsNullOrEmpty(options.TenantId)
+                    || string.IsNullOrEmpty(options.WorkspaceId)
+                    || string.IsNullOrEmpty(options.ClientId)
+                    || string.IsNullOrEmpty(options.ClientSecret))
+                {
+                    _configError = "Application Insights is not configured. Set TenantId, WorkspaceId, ClientId, and ClientSecret in appsettings.json under Quilt4Net:ApplicationInsights, or register the remote provider with AddQuilt4NetBlazorApplicationInsightsClientRemote.";
+                    return;
+                }
             }
         }
 
         var breadCrumbService = ServiceProvider.GetService<BreadCrumbService>();
         breadCrumbService?.RegisterVirtualSegmentQueryParam("tab");
+    }
+
+    private void HandleSelectorChanged()
+    {
+        InvokeAsync(StateHasChanged);
+    }
+
+    public void Dispose()
+    {
+        if (_selector != null) _selector.OnChanged -= HandleSelectorChanged;
     }
 
     protected override void OnParametersSet()

--- a/Quilt4Net.Toolkit.Blazor/Features/VersionMatrix/VersionMatrixDisplay.razor
+++ b/Quilt4Net.Toolkit.Blazor/Features/VersionMatrix/VersionMatrixDisplay.razor
@@ -1,13 +1,21 @@
+@using Microsoft.Extensions.DependencyInjection
 @using Quilt4Net.Toolkit
+@using Quilt4Net.Toolkit.Blazor.Features.ApplicationInsights
 @using Quilt4Net.Toolkit.Blazor.Features.Log
 @using Quilt4Net.Toolkit.Features.ApplicationInsights
 @using Microsoft.Extensions.Logging
 @using Microsoft.Extensions.Options
 @inject IVersionMatrixService VersionMatrixService
 @inject IOptions<ApplicationInsightsOptions> Options
+@inject IServiceProvider ServiceProvider
 @inject ILogger<VersionMatrixDisplay> Logger
+@implements IDisposable
 
 <RadzenStack Orientation="Orientation.Vertical" Gap="1rem">
+    @if (_selector != null && _selector.Available.Count > 1)
+    {
+        <ApplicationInsightsConfigurationDropdown />
+    }
     <RadzenStack Orientation="Orientation.Horizontal" AlignItems="AlignItems.Center" Gap="1rem">
         <RadzenButton Icon="refresh" Text="Refresh" Click="OnRefreshAsync" Disabled="@_loading" ButtonStyle="ButtonStyle.Secondary" />
         @if (_view != null)
@@ -105,8 +113,13 @@
 </style>
 
 @code {
-    [Parameter, EditorRequired]
-    public IApplicationInsightsContext Context { get; set; } = default!;
+    /// <summary>
+    /// Application Insights configuration to query against. Optional when the consumer registered
+    /// <see cref="BlazorApplicationInsightsRegistration.AddQuilt4NetBlazorApplicationInsightsClientRemote"/> —
+    /// the selector then resolves the configuration (and renders a dropdown when there is more than one).
+    /// </summary>
+    [Parameter]
+    public IApplicationInsightsContext Context { get; set; }
 
     [Parameter]
     public TimeSpan? Lookback { get; set; }
@@ -141,10 +154,33 @@
     private bool _loading;
     private string _error;
     private bool _errorIsAuthFailure;
+    private IApplicationInsightsConfigurationSelector _selector;
+
+    private IApplicationInsightsContext EffectiveContext => Context ?? _selector?.Selected;
 
     protected override async Task OnInitializedAsync()
     {
+        if (Context == null)
+        {
+            _selector = ServiceProvider.GetService<IApplicationInsightsConfigurationSelector>();
+            if (_selector != null)
+            {
+                _selector.OnChanged += HandleSelectorChanged;
+                await _selector.LoadAsync();
+            }
+        }
+
         await LoadAsync(forceRefresh: false);
+    }
+
+    private async void HandleSelectorChanged()
+    {
+        await LoadAsync(forceRefresh: false);
+    }
+
+    public void Dispose()
+    {
+        if (_selector != null) _selector.OnChanged -= HandleSelectorChanged;
     }
 
     private async Task OnRefreshAsync()
@@ -162,8 +198,8 @@
         try
         {
             var raw = forceRefresh
-                ? await VersionMatrixService.RefreshAsync(Context, Lookback)
-                : await VersionMatrixService.GetAsync(Context, Lookback);
+                ? await VersionMatrixService.RefreshAsync(EffectiveContext, Lookback)
+                : await VersionMatrixService.GetAsync(EffectiveContext, Lookback);
 
             VersionMatrixView folded;
             if (AliasFolder != null)
@@ -186,7 +222,7 @@
         catch (Exception ex)
         {
             _error = LogIncidentLogger.LogAndFormat(Logger, ex, nameof(VersionMatrixDisplay),
-                "Failed to load version matrix.", Context);
+                "Failed to load version matrix.", EffectiveContext);
             _errorIsAuthFailure = ApplicationInsightsErrorMessage.IsAuthenticationFailure(ex);
         }
         finally

--- a/Quilt4Net.Toolkit.Blazor/Quilt4Net.Toolkit.Blazor.csproj
+++ b/Quilt4Net.Toolkit.Blazor/Quilt4Net.Toolkit.Blazor.csproj
@@ -25,9 +25,9 @@
     <None Remove="wwwroot\**" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Authentication.WebAssembly.Msal" Version="10.0.7" />
+    <PackageReference Include="Microsoft.Authentication.WebAssembly.Msal" Version="10.0.8" />
     <PackageReference Include="Microsoft.Identity.Client" Version="4.84.0" />
-    <PackageReference Include="Tharga.Blazor" Version="2.1.5" />
+    <PackageReference Include="Tharga.Blazor" Version="2.1.6" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Quilt4Net.Toolkit\Quilt4Net.Toolkit.csproj" />
@@ -36,6 +36,6 @@
     <PackageReference Include="Microsoft.AspNetCore.Components.Authorization" Version="9.0.15" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
-    <PackageReference Include="Microsoft.AspNetCore.Components.Authorization" Version="10.0.7" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.Authorization" Version="10.0.8" />
   </ItemGroup>
 </Project>

--- a/Quilt4Net.Toolkit.Blazor/README.md
+++ b/Quilt4Net.Toolkit.Blazor/README.md
@@ -202,7 +202,18 @@ The component displays a data grid with editors for boolean, integer, and string
 
 ## Log viewer
 
-View and search Application Insights logs with the `LogView` component. Requires [Quilt4Net.Toolkit](https://github.com/Quilt4/Quilt4Net.Toolkit/tree/master/Quilt4Net.Toolkit) Application Insights client to be configured.
+View and search Application Insights logs with the `LogView` component. Requires the Application Insights client to be configured in one of two modes (mutually exclusive):
+
+**Local mode** — credentials live in the consumer's `appsettings.json` under `Quilt4Net:ApplicationInsights`:
+```csharp
+builder.AddQuilt4NetApplicationInsightsClient();
+```
+
+**Remote mode** — credentials are pulled from Quilt4Net.Server using an API key that carries the `monitor:read` scope:
+```csharp
+builder.AddQuilt4NetBlazorApplicationInsightsClientRemote();
+```
+The host then stops needing any `Quilt4Net:ApplicationInsights` block; only `Quilt4Net:ApiKey` (or `Quilt4Net:RemoteConfiguration:ApiKey`) is required. When the team has more than one configured workspace on the server, `LogView` and `VersionMatrixDisplay` render a built-in configuration dropdown — selection persists in `localStorage` under `Quilt4Net.Monitor.SelectedConfig.{FilterStorageScope}`.
 
 ```razor
 <LogView />

--- a/Quilt4Net.Toolkit.Console.Sample/Quilt4Net.Toolkit.Console.Sample.csproj
+++ b/Quilt4Net.Toolkit.Console.Sample/Quilt4Net.Toolkit.Console.Sample.csproj
@@ -12,7 +12,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.7" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.8" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Quilt4Net.Toolkit.Health.Tests/Quilt4Net.Toolkit.Health.Tests.csproj
+++ b/Quilt4Net.Toolkit.Health.Tests/Quilt4Net.Toolkit.Health.Tests.csproj
@@ -7,21 +7,21 @@
 
 	<ItemGroup>
 		<PackageReference Include="AutoBogus" Version="2.13.1" />
-		<PackageReference Include="FluentAssertions" Version="8.9.0" />
+		<PackageReference Include="FluentAssertions" Version="8.10.0" />
 		<PackageReference Include="JetBrains.Annotations" Version="2025.2.4" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
-		<PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.7" />
+		<PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.8" />
 		<PackageReference Include="Moq" Version="4.20.72" />
 		<PackageReference Include="OneOf" Version="3.0.271" />
 		<PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="coverlet.msbuild" Version="10.0.0">
+		<PackageReference Include="coverlet.msbuild" Version="10.0.1">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="coverlet.collector" Version="10.0.0">
+		<PackageReference Include="coverlet.collector" Version="10.0.1">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>

--- a/Quilt4Net.Toolkit.Health/Quilt4Net.Toolkit.Health.csproj
+++ b/Quilt4Net.Toolkit.Health/Quilt4Net.Toolkit.Health.csproj
@@ -41,7 +41,7 @@
 
 	<ItemGroup>
 	  <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="3.1.1" />
-	  <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.203">
+	  <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.300">
 		  <PrivateAssets>all</PrivateAssets>
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 	  </PackageReference>

--- a/Quilt4Net.Toolkit.Mcp.Tests/Quilt4Net.Toolkit.Mcp.Tests.csproj
+++ b/Quilt4Net.Toolkit.Mcp.Tests/Quilt4Net.Toolkit.Mcp.Tests.csproj
@@ -6,14 +6,14 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="FluentAssertions" Version="8.9.0" />
+		<PackageReference Include="FluentAssertions" Version="8.10.0" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
 		<PackageReference Include="Moq" Version="4.20.72" />
 		<PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="coverlet.collector" Version="10.0.0">
+		<PackageReference Include="coverlet.collector" Version="10.0.1">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>

--- a/Quilt4Net.Toolkit.Mcp/Quilt4Net.Toolkit.Mcp.csproj
+++ b/Quilt4Net.Toolkit.Mcp/Quilt4Net.Toolkit.Mcp.csproj
@@ -32,8 +32,8 @@
     <InternalsVisibleTo Include="DynamicProxyGenAssembly2" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Tharga.Mcp" Version="0.1.3" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.203">
+    <PackageReference Include="Tharga.Mcp" Version="0.1.4" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.300">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/Quilt4Net.Toolkit.Tests/Quilt4Net.Toolkit.Tests.csproj
+++ b/Quilt4Net.Toolkit.Tests/Quilt4Net.Toolkit.Tests.csproj
@@ -7,20 +7,20 @@
 
 	<ItemGroup>
 		<PackageReference Include="AutoFixture" Version="4.18.1" />
-		<PackageReference Include="FluentAssertions" Version="8.9.0" />
+		<PackageReference Include="FluentAssertions" Version="8.10.0" />
 		<PackageReference Include="JetBrains.Annotations" Version="2025.2.4" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
 		<PackageReference Include="Moq" Version="4.20.72" />
-		<PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.7" />
+		<PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.8" />
 		<PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="coverlet.msbuild" Version="10.0.0">
+		<PackageReference Include="coverlet.msbuild" Version="10.0.1">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="coverlet.collector" Version="10.0.0">
+		<PackageReference Include="coverlet.collector" Version="10.0.1">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>

--- a/Quilt4Net.Toolkit.Tests/RemoteApplicationInsightsConfigurationProviderTests.cs
+++ b/Quilt4Net.Toolkit.Tests/RemoteApplicationInsightsConfigurationProviderTests.cs
@@ -1,0 +1,209 @@
+using System.Net;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Quilt4Net.Toolkit.Features.ApplicationInsights;
+using Xunit;
+
+namespace Quilt4Net.Toolkit.Tests;
+
+public class RemoteApplicationInsightsConfigurationProviderTests
+{
+    [Fact]
+    public async Task GetAllAsync_Returns_Configurations_When_Server_Returns_200()
+    {
+        var port = GetFreePort();
+        var prefix = $"http://127.0.0.1:{port}/";
+        using var listener = new HttpListener();
+        listener.Prefixes.Add(prefix);
+        listener.Start();
+
+        var listenerTask = Task.Run(async () =>
+        {
+            var ctx = await listener.GetContextAsync();
+            ctx.Response.StatusCode = 200;
+            ctx.Response.ContentType = "application/json";
+            var body = """
+                [
+                    {"id":"a","name":"Prod","tenantId":"t1","workspaceId":"w1","clientId":"c1","clientSecret":"s1"},
+                    {"id":"b","name":"Test","tenantId":"t2","workspaceId":"w2","clientId":"c2","clientSecret":"s2"}
+                ]
+                """;
+            var buf = System.Text.Encoding.UTF8.GetBytes(body);
+            await ctx.Response.OutputStream.WriteAsync(buf);
+            ctx.Response.Close();
+        });
+
+        try
+        {
+            var host = Host.CreateDefaultBuilder()
+                .ConfigureServices(services =>
+                {
+                    services.AddQuilt4NetApplicationInsightsClientRemote(null, o =>
+                    {
+                        o.Quilt4NetAddress = prefix;
+                        o.ApiKey = "test-key";
+                    });
+                })
+                .Build();
+
+            var provider = host.Services.GetRequiredService<IApplicationInsightsConfigurationProvider>();
+            var configs = await provider.GetAllAsync();
+
+            configs.Should().HaveCount(2);
+            configs[0].Id.Should().Be("a");
+            configs[0].Name.Should().Be("Prod");
+            configs[0].TenantId.Should().Be("t1");
+            configs[1].ClientSecret.Should().Be("s2");
+        }
+        finally
+        {
+            listener.Stop();
+        }
+    }
+
+    [Fact]
+    public async Task GetAllAsync_Returns_Empty_When_Server_Returns_401()
+    {
+        var port = GetFreePort();
+        var prefix = $"http://127.0.0.1:{port}/";
+        using var listener = new HttpListener();
+        listener.Prefixes.Add(prefix);
+        listener.Start();
+
+        var listenerTask = Task.Run(async () =>
+        {
+            var ctx = await listener.GetContextAsync();
+            ctx.Response.StatusCode = 401;
+            ctx.Response.Close();
+        });
+
+        try
+        {
+            var host = Host.CreateDefaultBuilder()
+                .ConfigureServices(services =>
+                {
+                    services.AddQuilt4NetApplicationInsightsClientRemote(null, o =>
+                    {
+                        o.Quilt4NetAddress = prefix;
+                        o.ApiKey = "test-key";
+                    });
+                })
+                .Build();
+
+            var provider = host.Services.GetRequiredService<IApplicationInsightsConfigurationProvider>();
+            var configs = await provider.GetAllAsync();
+
+            configs.Should().BeEmpty("missing scope or invalid key must not throw — graceful empty list");
+        }
+        finally
+        {
+            listener.Stop();
+        }
+    }
+
+    [Fact]
+    public async Task GetAllAsync_Returns_Empty_When_Server_Unreachable()
+    {
+        var port = GetFreePort();
+        var host = Host.CreateDefaultBuilder()
+            .ConfigureServices(services =>
+            {
+                services.AddQuilt4NetApplicationInsightsClientRemote(null, o =>
+                {
+                    o.Quilt4NetAddress = $"http://127.0.0.1:{port}/";
+                    o.ApiKey = "test-key";
+                    o.HttpTimeout = TimeSpan.FromMilliseconds(500);
+                });
+            })
+            .Build();
+
+        var provider = host.Services.GetRequiredService<IApplicationInsightsConfigurationProvider>();
+        var configs = await provider.GetAllAsync();
+
+        configs.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task GetAllAsync_Caches_Within_Ttl()
+    {
+        var port = GetFreePort();
+        var prefix = $"http://127.0.0.1:{port}/";
+        using var listener = new HttpListener();
+        listener.Prefixes.Add(prefix);
+        listener.Start();
+
+        var hits = 0;
+        var listenerTask = Task.Run(async () =>
+        {
+            while (listener.IsListening)
+            {
+                HttpListenerContext ctx;
+                try { ctx = await listener.GetContextAsync(); }
+                catch { return; }
+                Interlocked.Increment(ref hits);
+                ctx.Response.StatusCode = 200;
+                ctx.Response.ContentType = "application/json";
+                var body = """[{"id":"a","name":"Prod","tenantId":"t","workspaceId":"w","clientId":"c","clientSecret":"s"}]""";
+                var buf = System.Text.Encoding.UTF8.GetBytes(body);
+                await ctx.Response.OutputStream.WriteAsync(buf);
+                ctx.Response.Close();
+            }
+        });
+
+        try
+        {
+            var host = Host.CreateDefaultBuilder()
+                .ConfigureServices(services =>
+                {
+                    services.AddQuilt4NetApplicationInsightsClientRemote(null, o =>
+                    {
+                        o.Quilt4NetAddress = prefix;
+                        o.ApiKey = "test-key";
+                        o.Ttl = TimeSpan.FromMinutes(10);
+                    });
+                })
+                .Build();
+
+            var provider = host.Services.GetRequiredService<IApplicationInsightsConfigurationProvider>();
+
+            await provider.GetAllAsync();
+            await provider.GetAllAsync();
+            await provider.GetAllAsync();
+
+            hits.Should().Be(1, "subsequent calls within Ttl serve from cache");
+        }
+        finally
+        {
+            listener.Stop();
+        }
+    }
+
+    [Fact]
+    public void Registration_Resolves_Required_Services()
+    {
+        var host = Host.CreateDefaultBuilder()
+            .ConfigureServices(services =>
+            {
+                services.AddQuilt4NetApplicationInsightsClientRemote(null, o =>
+                {
+                    o.Quilt4NetAddress = "http://127.0.0.1:9999/";
+                    o.ApiKey = "test-key";
+                });
+            })
+            .Build();
+
+        host.Services.GetService<IApplicationInsightsConfigurationProvider>().Should().NotBeNull();
+        host.Services.GetService<IApplicationInsightsService>().Should().NotBeNull();
+        host.Services.GetService<IVersionMatrixService>().Should().NotBeNull();
+    }
+
+    private static int GetFreePort()
+    {
+        using var l = new System.Net.Sockets.TcpListener(IPAddress.Loopback, 0);
+        l.Start();
+        var port = ((IPEndPoint)l.LocalEndpoint).Port;
+        l.Stop();
+        return port;
+    }
+}

--- a/Quilt4Net.Toolkit.Tests/RemoteApplicationInsightsConfigurationProviderTests.cs
+++ b/Quilt4Net.Toolkit.Tests/RemoteApplicationInsightsConfigurationProviderTests.cs
@@ -5,6 +5,10 @@ using Microsoft.Extensions.Hosting;
 using Quilt4Net.Toolkit.Features.ApplicationInsights;
 using Xunit;
 
+// Matches the surrounding test files (FeatureToggleTests etc.) — these HttpListener-backed
+// tests are short-lived and don't need TestContext-driven cancellation.
+#pragma warning disable xUnit1051
+
 namespace Quilt4Net.Toolkit.Tests;
 
 public class RemoteApplicationInsightsConfigurationProviderTests

--- a/Quilt4Net.Toolkit/ApplicationInsightsRegistration.cs
+++ b/Quilt4Net.Toolkit/ApplicationInsightsRegistration.cs
@@ -78,4 +78,64 @@ public static class ApplicationInsightsRegistration
             });
         });
     }
+
+    /// <summary>
+    /// Register the Application Insights client for consumers that pull configurations from
+    /// Quilt4Net.Server instead of from their own <c>appsettings.json</c>. The API key is
+    /// resolved from <c>Quilt4Net:RemoteConfiguration</c> (or the top-level <c>Quilt4Net:ApiKey</c>
+    /// fallback) and must carry the <c>monitor:read</c> scope. Mutually exclusive with
+    /// <see cref="AddQuilt4NetApplicationInsightsClient(IHostApplicationBuilder, Action{ApplicationInsightsOptions})"/>:
+    /// use one or the other, not both.
+    /// </summary>
+    public static void AddQuilt4NetApplicationInsightsClientRemote(this IHostApplicationBuilder builder, Action<RemoteConfigurationOptions> options = null)
+    {
+        builder.Services.AddQuilt4NetApplicationInsightsClientRemote(builder.Configuration, options);
+    }
+
+    /// <summary>
+    /// Register the Application Insights client for consumers that pull configurations from
+    /// Quilt4Net.Server.
+    /// </summary>
+    public static void AddQuilt4NetApplicationInsightsClientRemote(this IServiceCollection services, IConfiguration configuration, Action<RemoteConfigurationOptions> options = null)
+    {
+        var apiKey = configuration?.GetSection("Quilt4Net").GetSection("ApiKey").Value;
+        var address = configuration?.GetSection("Quilt4Net").GetSection("Quilt4NetAddress").Value;
+
+        var config = configuration?.GetSection("Quilt4Net:RemoteConfiguration").Get<RemoteConfigurationOptions>();
+        var o = new RemoteConfigurationOptions
+        {
+            ApiKey = config?.ApiKey ?? apiKey,
+            Quilt4NetAddress = config?.Quilt4NetAddress ?? address ?? "https://quilt4net.com/",
+            Ttl = config?.Ttl,
+            HttpTimeout = config?.HttpTimeout ?? TimeSpan.FromSeconds(5)
+        };
+
+        if (!Uri.TryCreate(o.Quilt4NetAddress, UriKind.Absolute, out _))
+            throw new InvalidOperationException($"Configuration {nameof(o.Quilt4NetAddress)} with value '{o.Quilt4NetAddress}' cannot be parsed to an absolute uri.");
+
+        options?.Invoke(o);
+        services.AddSingleton(Options.Create(o));
+
+        // Local ApplicationInsightsOptions is empty in remote mode — every call must
+        // supply an IApplicationInsightsContext, which the Blazor selector provides
+        // from the IApplicationInsightsConfigurationProvider list.
+        services.AddSingleton(Options.Create(new ApplicationInsightsOptions()));
+
+        services.AddSingleton<IApplicationInsightsConfigurationProvider, RemoteApplicationInsightsConfigurationProvider>();
+
+        services.AddTransient<IApplicationInsightsService, ApplicationInsightsService>();
+        services.AddSingleton<IVersionMatrixService, VersionMatrixService>();
+        services.AddTransient<IHealthClient, HealthClient>();
+
+        services.AddCache(s =>
+        {
+            s.RegisterType<EnvironmentOption[], IMemory>(x => { x.DefaultFreshSpan = TimeSpan.FromHours(1); });
+            s.RegisterType<LogItem[], IMemory>(x => { x.DefaultFreshSpan = TimeSpan.FromSeconds(30); });
+            s.RegisterType<MeasureData[], IMemory>(x => { x.DefaultFreshSpan = TimeSpan.FromMinutes(1); });
+            s.RegisterType<CountData[], IMemory>(x => { x.DefaultFreshSpan = TimeSpan.FromMinutes(1); });
+            s.RegisterType<SummaryData, IMemory>(x => { x.DefaultFreshSpan = TimeSpan.FromMinutes(1); });
+            s.RegisterType<SummarySubset[], IMemory>(x => { x.DefaultFreshSpan = TimeSpan.FromMinutes(1); });
+            s.RegisterType<VersionMatrixCell[], IMemory>(x => { x.DefaultFreshSpan = TimeSpan.FromMinutes(5); });
+        });
+    }
 }

--- a/Quilt4Net.Toolkit/Features/ApplicationInsights/ApplicationInsightsConfigurationResponse.cs
+++ b/Quilt4Net.Toolkit/Features/ApplicationInsights/ApplicationInsightsConfigurationResponse.cs
@@ -1,0 +1,23 @@
+namespace Quilt4Net.Toolkit.Features.ApplicationInsights;
+
+/// <summary>
+/// Wire shape returned by <c>GET /Api/Monitoring/ApplicationInsights</c> on Quilt4Net.Server.
+/// Implements <see cref="IApplicationInsightsContext"/> so it can be passed directly to
+/// <see cref="IApplicationInsightsService"/> / <see cref="IVersionMatrixService"/> without a
+/// shim record. Property names mirror the server DTO exactly so JSON round-trips one-to-one.
+/// </summary>
+public record ApplicationInsightsConfigurationResponse : IApplicationInsightsContext
+{
+    /// <summary>Server-side ObjectId, as a string. Used to identify a configuration in the in-component selector.</summary>
+    public string Id { get; init; }
+
+    /// <summary>Human-readable name shown in the selector dropdown.</summary>
+    public string Name { get; init; }
+
+    public string TenantId { get; init; }
+    public string WorkspaceId { get; init; }
+    public string ClientId { get; init; }
+    public string ClientSecret { get; init; }
+
+    public ApplicationInsightsAuthMode AuthMode { get; init; } = ApplicationInsightsAuthMode.ClientSecret;
+}

--- a/Quilt4Net.Toolkit/Features/ApplicationInsights/IApplicationInsightsConfigurationProvider.cs
+++ b/Quilt4Net.Toolkit/Features/ApplicationInsights/IApplicationInsightsConfigurationProvider.cs
@@ -1,0 +1,17 @@
+namespace Quilt4Net.Toolkit.Features.ApplicationInsights;
+
+/// <summary>
+/// Source of Application Insights configurations for the toolkit. Registered by
+/// <c>AddQuilt4NetApplicationInsightsClientRemote</c>; consumed by Blazor components
+/// that need to pick a configuration at render time (or render a selector when there
+/// is more than one).
+/// </summary>
+public interface IApplicationInsightsConfigurationProvider
+{
+    /// <summary>
+    /// Get all Application Insights configurations available to the calling team.
+    /// Implementations cache and use stale-while-revalidate so a transient server outage
+    /// does not break the consuming page.
+    /// </summary>
+    Task<ApplicationInsightsConfigurationResponse[]> GetAllAsync(CancellationToken cancellationToken = default);
+}

--- a/Quilt4Net.Toolkit/Features/ApplicationInsights/RemoteApplicationInsightsConfigurationProvider.cs
+++ b/Quilt4Net.Toolkit/Features/ApplicationInsights/RemoteApplicationInsightsConfigurationProvider.cs
@@ -1,0 +1,127 @@
+using System.Net.Http.Json;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Quilt4Net.Toolkit.Features.ApplicationInsights;
+
+internal class RemoteApplicationInsightsConfigurationProvider : IApplicationInsightsConfigurationProvider
+{
+    private static readonly TimeSpan DefaultTtl = TimeSpan.FromMinutes(5);
+
+    private readonly RemoteConfigurationOptions _options;
+    private readonly ILogger<RemoteApplicationInsightsConfigurationProvider> _logger;
+    private readonly SemaphoreSlim _refreshGate = new(1, 1);
+
+    private ApplicationInsightsConfigurationResponse[] _cached;
+    private DateTime _cachedAt = DateTime.MinValue;
+    private volatile bool _refreshInProgress;
+
+    public RemoteApplicationInsightsConfigurationProvider(
+        IOptions<RemoteConfigurationOptions> options,
+        ILogger<RemoteApplicationInsightsConfigurationProvider> logger)
+    {
+        _options = options.Value;
+        _logger = logger;
+    }
+
+    public async Task<ApplicationInsightsConfigurationResponse[]> GetAllAsync(CancellationToken cancellationToken = default)
+    {
+        var ttl = _options.Ttl ?? DefaultTtl;
+        var cached = _cached;
+        var age = DateTime.UtcNow - _cachedAt;
+
+        if (cached != null && age < ttl) return cached;
+
+        // Stale-while-revalidate: if we have any cached value, return it immediately and refresh in the background.
+        if (cached != null)
+        {
+            StartBackgroundRefresh();
+            return cached;
+        }
+
+        // No cache yet — must wait for the first fetch.
+        return await FetchAsync(cancellationToken);
+    }
+
+    private async Task<ApplicationInsightsConfigurationResponse[]> FetchAsync(CancellationToken cancellationToken)
+    {
+        await _refreshGate.WaitAsync(cancellationToken);
+        try
+        {
+            // Another caller may have populated the cache while we waited.
+            var cached = _cached;
+            var ttl = _options.Ttl ?? DefaultTtl;
+            if (cached != null && DateTime.UtcNow - _cachedAt < ttl) return cached;
+
+            using var timeoutCts = new CancellationTokenSource(_options.HttpTimeout);
+            using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, timeoutCts.Token);
+            using var client = CreateHttpClient();
+
+            var response = await client.GetAsync("Api/Monitoring/ApplicationInsights", linkedCts.Token);
+            if (!response.IsSuccessStatusCode)
+            {
+                _logger.LogError(
+                    "Unable to get Application Insights configurations. Response was {StatusCode} {ReasonPhrase}.",
+                    response.StatusCode, response.ReasonPhrase);
+                return cached ?? [];
+            }
+
+            var data = await response.Content.ReadFromJsonAsync<ApplicationInsightsConfigurationResponse[]>(linkedCts.Token)
+                       ?? [];
+
+            _cached = data;
+            _cachedAt = DateTime.UtcNow;
+            return data;
+        }
+        catch (OperationCanceledException)
+        {
+            _logger.LogWarning(
+                "HTTP request for Application Insights configurations timed out after {Timeout}ms.",
+                _options.HttpTimeout.TotalMilliseconds);
+            return _cached ?? [];
+        }
+        catch (Exception e)
+        {
+            _logger.LogError(e, "Failed to fetch Application Insights configurations: {Message}.", e.Message);
+            return _cached ?? [];
+        }
+        finally
+        {
+            _refreshGate.Release();
+        }
+    }
+
+    private void StartBackgroundRefresh()
+    {
+        if (_refreshInProgress) return;
+        _refreshInProgress = true;
+
+        _ = Task.Run(async () =>
+        {
+            try
+            {
+                await FetchAsync(CancellationToken.None);
+            }
+            finally
+            {
+                _refreshInProgress = false;
+            }
+        });
+    }
+
+    private HttpClient CreateHttpClient()
+    {
+        HttpClient client = null;
+        try
+        {
+            client = new HttpClient { BaseAddress = new Uri(_options.Quilt4NetAddress) };
+            client.DefaultRequestHeaders.Add("X-API-KEY", _options.ApiKey);
+            return client;
+        }
+        catch
+        {
+            client?.Dispose();
+            throw;
+        }
+    }
+}

--- a/Quilt4Net.Toolkit/Quilt4Net.Toolkit.csproj
+++ b/Quilt4Net.Toolkit/Quilt4Net.Toolkit.csproj
@@ -41,16 +41,16 @@
     <PackageReference Include="Microsoft.ApplicationInsights" Version="3.1.1" />
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.15.3" />
     <PackageReference Include="Azure.Monitor.Query.Logs" Version="1.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.7" />
-    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.7" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.7" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.7" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.203">
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.8" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.8" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.8" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.8" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.300">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="System.Management" Version="10.0.7" />
+    <PackageReference Include="System.Management" Version="10.0.8" />
     <PackageReference Include="System.Linq.Async" Version="7.0.1" />
-    <PackageReference Include="Tharga.Cache" Version="0.4.4" />
+    <PackageReference Include="Tharga.Cache" Version="0.4.6" />
   </ItemGroup>
 </Project>

--- a/Quilt4Net.Toolkit/README.md
+++ b/Quilt4Net.Toolkit/README.md
@@ -124,11 +124,18 @@ Configuration path: `Quilt4Net:HealthClient`
 
 ## Application Insights client
 
-Client for querying Application Insights data (logs, metrics, exceptions).
+Client for querying Application Insights data (logs, metrics, exceptions). The toolkit supports two mutually exclusive registration modes:
 
+**Local mode** — credentials in the consumer's `appsettings.json`:
 ```csharp
 builder.AddQuilt4NetApplicationInsightsClient();
 ```
+
+**Remote mode** — credentials fetched from Quilt4Net.Server at runtime using an API key with the `monitor:read` scope. Consumers no longer need to keep `TenantId` / `WorkspaceId` / `ClientId` / `ClientSecret` in their own configuration:
+```csharp
+builder.AddQuilt4NetApplicationInsightsClientRemote();
+```
+The remote provider caches the configuration list per the `RemoteConfigurationOptions.Ttl` (default 5 min) with stale-while-revalidate, so transient server outages don't break the consuming page. When more than one workspace is configured on the server for the team, every workspace is reachable; the Blazor `LogView` / `VersionMatrixDisplay` components render an in-component dropdown to switch between them (see [Quilt4Net.Toolkit.Blazor README](https://github.com/Quilt4/Quilt4Net.Toolkit/blob/master/Quilt4Net.Toolkit.Blazor/README.md)).
 
 ### ApplicationInsightsOptions
 


### PR DESCRIPTION
## Summary

- Adds `AddQuilt4NetApplicationInsightsClientRemote` so consumers (Eplicta, PlutusWave, Florida, …) read Application Insights credentials from Quilt4Net.Server instead of keeping `TenantId` / `WorkspaceId` / `ClientId` / `ClientSecret` in their own `appsettings.json`.
- Adds an in-component configuration selector to `LogView` and `VersionMatrixDisplay`. When the team has more than one workspace, a dropdown lets the user switch between them; selection persists in `localStorage` keyed by `FilterStorageScope`.
- Server-side endpoint `GET /Api/Monitoring/ApplicationInsights` gated by a new `monitor:read` scope — implemented in the Quilt4Net.Server companion PR (Server repo, also `feature/remote-ai-config`).

## Modes

| | Local mode (today) | Remote mode (new) |
|---|---|---|
| Registration | `AddQuilt4NetApplicationInsightsClient()` | `AddQuilt4NetBlazorApplicationInsightsClientRemote()` |
| Credentials | `Quilt4Net:ApplicationInsights` in appsettings | Fetched at runtime via API key (scope: `monitor:read`) |
| Multi-workspace | One config only | Selector renders when team has >1 |

Mutually exclusive — pick one or the other. Existing consumers stay unchanged.

## Architecture notes

- `ApplicationInsightsService` already accepts a per-call `IApplicationInsightsContext`, so remote mode just feeds the selected config into the existing `Context` parameter. No `IOptionsMonitor` plumbing needed.
- `RemoteApplicationInsightsConfigurationProvider` caches the list (default 5 min `Ttl`) with stale-while-revalidate, so a transient server outage doesn't break the consuming page.
- `IApplicationInsightsConfigurationSelector` is scoped per Blazor circuit and shared between `LogView` and `VersionMatrixDisplay` on the same page, so switching configs in one re-queries the other.

## Test plan

- [ ] Build clean across `net8.0`, `net9.0`, `net10.0` (CI)
- [ ] All 267 toolkit tests pass (5 new on `RemoteApplicationInsightsConfigurationProviderTests`, 5 new on `ApplicationInsightsConfigurationSelectorTests`)
- [ ] Warning baseline ratchet OK (Toolkit warnings ≤ ceil(248 × 1.05) = 260)
- [ ] Verify prerelease NuGet published by CI
- [ ] User-test: a Blazor host calling `AddQuilt4NetBlazorApplicationInsightsClientRemote()` with a `monitor:read`-scoped API key renders LogView against a remote config (single workspace → no dropdown; multiple workspaces → dropdown lets you switch)
- [ ] User-test: existing local-mode consumers continue to render unchanged

## Dependencies

- Server-side endpoint must be deployed before any consumer can use remote mode. Server PR is in the Quilt4Net.Server repo on the same branch name.
- After Server merges and Toolkit prerelease publishes, Eplicta and PlutusWave migration is a follow-up (drop their appsettings AI block, switch registration call, grant `monitor:read` on their API key).