### PR TITLE
feat: Value Groups foundation — IValueGroupClient + bundle DTO

### DIFF
--- a/Quilt4Net.Toolkit.Blazor/Quilt4Net.Toolkit.Blazor.csproj
+++ b/Quilt4Net.Toolkit.Blazor/Quilt4Net.Toolkit.Blazor.csproj
@@ -26,7 +26,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Authentication.WebAssembly.Msal" Version="10.0.8" />
-    <PackageReference Include="Microsoft.Identity.Client" Version="4.84.0" />
+    <PackageReference Include="Microsoft.Identity.Client" Version="4.84.1" />
     <PackageReference Include="Tharga.Blazor" Version="2.1.6" />
   </ItemGroup>
   <ItemGroup>

--- a/Quilt4Net.Toolkit.Tests/ValueGroupClientTests.cs
+++ b/Quilt4Net.Toolkit.Tests/ValueGroupClientTests.cs
@@ -1,0 +1,265 @@
+using System.Net;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Quilt4Net.Toolkit.Features.ValueGroup;
+using Xunit;
+
+#pragma warning disable xUnit1051
+
+namespace Quilt4Net.Toolkit.Tests;
+
+public class ValueGroupClientTests
+{
+    private const string GroupId = "507f1f77bcf86cd799439011";
+
+    [Fact]
+    public async Task GetAsync_Returns_Bundle_On_200()
+    {
+        var port = GetFreePort();
+        var prefix = $"http://127.0.0.1:{port}/";
+        using var listener = new HttpListener();
+        listener.Prefixes.Add(prefix);
+        listener.Start();
+
+        _ = Task.Run(async () =>
+        {
+            var ctx = await listener.GetContextAsync();
+            ctx.Response.StatusCode = 200;
+            ctx.Response.ContentType = "application/json";
+            var body = $$"""
+                {
+                    "groupId":"{{GroupId}}",
+                    "groupName":"prod-eu",
+                    "fetchedAtUtc":"2026-05-26T12:00:00Z",
+                    "featureToggles":[{"key":"enabled","application":"App","environment":"Prod","instance":null,"value":"true","defaultValue":"false","valueType":"Boolean","lastUsed":"2026-05-26T12:00:00Z","ttl":null}],
+                    "applicationInsightsConfigurations":[{"id":"a","name":"prod","tenantId":"t","workspaceId":"w","clientId":"c","clientSecret":"s"}]
+                }
+                """;
+            var buf = System.Text.Encoding.UTF8.GetBytes(body);
+            await ctx.Response.OutputStream.WriteAsync(buf);
+            ctx.Response.Close();
+        });
+
+        try
+        {
+            var host = BuildHost(prefix);
+            var client = host.Services.GetRequiredService<IValueGroupClient>();
+
+            var bundle = await client.GetAsync();
+
+            bundle.GroupId.Should().Be(GroupId);
+            bundle.GroupName.Should().Be("prod-eu");
+            bundle.FeatureToggles.Should().HaveCount(1);
+            bundle.ApplicationInsightsConfigurations.Should().HaveCount(1);
+            bundle.ApplicationInsightsConfigurations[0].ClientSecret.Should().Be("s");
+        }
+        finally
+        {
+            listener.Stop();
+        }
+    }
+
+    [Fact]
+    public async Task GetAsync_Throws_ValueGroupAuthorizationException_On_401()
+    {
+        var port = GetFreePort();
+        var prefix = $"http://127.0.0.1:{port}/";
+        using var listener = new HttpListener();
+        listener.Prefixes.Add(prefix);
+        listener.Start();
+
+        _ = Task.Run(async () =>
+        {
+            var ctx = await listener.GetContextAsync();
+            ctx.Response.StatusCode = 401;
+            ctx.Response.Close();
+        });
+
+        try
+        {
+            var host = BuildHost(prefix);
+            var client = host.Services.GetRequiredService<IValueGroupClient>();
+
+            var act = () => client.GetAsync();
+            await act.Should().ThrowAsync<ValueGroupAuthorizationException>()
+                .WithMessage("*401*");
+        }
+        finally
+        {
+            listener.Stop();
+        }
+    }
+
+    [Fact]
+    public async Task GetAsync_Throws_ValueGroupAuthorizationException_On_403()
+    {
+        var port = GetFreePort();
+        var prefix = $"http://127.0.0.1:{port}/";
+        using var listener = new HttpListener();
+        listener.Prefixes.Add(prefix);
+        listener.Start();
+
+        _ = Task.Run(async () =>
+        {
+            var ctx = await listener.GetContextAsync();
+            ctx.Response.StatusCode = 403;
+            ctx.Response.Close();
+        });
+
+        try
+        {
+            var host = BuildHost(prefix);
+            var client = host.Services.GetRequiredService<IValueGroupClient>();
+
+            var act = () => client.GetAsync();
+            await act.Should().ThrowAsync<ValueGroupAuthorizationException>()
+                .WithMessage("*403*");
+        }
+        finally
+        {
+            listener.Stop();
+        }
+    }
+
+    [Fact]
+    public async Task GetAsync_Caches_Within_Ttl()
+    {
+        var port = GetFreePort();
+        var prefix = $"http://127.0.0.1:{port}/";
+        using var listener = new HttpListener();
+        listener.Prefixes.Add(prefix);
+        listener.Start();
+
+        var hits = 0;
+        _ = Task.Run(async () =>
+        {
+            while (listener.IsListening)
+            {
+                HttpListenerContext ctx;
+                try { ctx = await listener.GetContextAsync(); }
+                catch { return; }
+                Interlocked.Increment(ref hits);
+                ctx.Response.StatusCode = 200;
+                ctx.Response.ContentType = "application/json";
+                var body = $$"""{"groupId":"{{GroupId}}","groupName":"prod-eu","featureToggles":[],"applicationInsightsConfigurations":[]}""";
+                var buf = System.Text.Encoding.UTF8.GetBytes(body);
+                await ctx.Response.OutputStream.WriteAsync(buf);
+                ctx.Response.Close();
+            }
+        });
+
+        try
+        {
+            var host = BuildHost(prefix, ttl: TimeSpan.FromMinutes(10));
+            var client = host.Services.GetRequiredService<IValueGroupClient>();
+
+            await client.GetAsync();
+            await client.GetAsync();
+            await client.GetAsync();
+
+            hits.Should().Be(1, "subsequent calls within Ttl serve from cache");
+        }
+        finally
+        {
+            listener.Stop();
+        }
+    }
+
+    [Fact]
+    public async Task GetAsync_Returns_Stale_On_Server_Error_When_Cache_Exists()
+    {
+        var port = GetFreePort();
+        var prefix = $"http://127.0.0.1:{port}/";
+        using var listener = new HttpListener();
+        listener.Prefixes.Add(prefix);
+        listener.Start();
+
+        var requestCount = 0;
+        _ = Task.Run(async () =>
+        {
+            while (listener.IsListening)
+            {
+                HttpListenerContext ctx;
+                try { ctx = await listener.GetContextAsync(); }
+                catch { return; }
+                var n = Interlocked.Increment(ref requestCount);
+                if (n == 1)
+                {
+                    ctx.Response.StatusCode = 200;
+                    ctx.Response.ContentType = "application/json";
+                    var body = $$"""{"groupId":"{{GroupId}}","groupName":"prod-eu","featureToggles":[],"applicationInsightsConfigurations":[]}""";
+                    var buf = System.Text.Encoding.UTF8.GetBytes(body);
+                    await ctx.Response.OutputStream.WriteAsync(buf);
+                }
+                else
+                {
+                    ctx.Response.StatusCode = 500;
+                }
+                ctx.Response.Close();
+            }
+        });
+
+        try
+        {
+            // Very short Ttl so the second call goes to the server and gets the 500.
+            var host = BuildHost(prefix, ttl: TimeSpan.FromMilliseconds(1));
+            var client = host.Services.GetRequiredService<IValueGroupClient>();
+
+            var first = await client.GetAsync();
+            first.GroupName.Should().Be("prod-eu");
+
+            await Task.Delay(50);
+            var second = await client.GetAsync();
+            second.GroupName.Should().Be("prod-eu", "transient 500 must serve the stale-cache, not throw");
+        }
+        finally
+        {
+            listener.Stop();
+        }
+    }
+
+    [Fact]
+    public void Registration_Validates_Required_Options()
+    {
+        // Missing GroupId
+        var host = Host.CreateDefaultBuilder()
+            .ConfigureServices(services =>
+            {
+                services.AddQuilt4NetValueGroupClient(null, o =>
+                {
+                    o.Quilt4NetAddress = "http://127.0.0.1:9999/";
+                    o.ApiKey = "test-key";
+                    o.GroupId = null;
+                });
+            })
+            .Build();
+
+        var act = () => host.Services.GetRequiredService<IValueGroupClient>();
+        act.Should().Throw<InvalidOperationException>().WithMessage("*GroupId*");
+    }
+
+    private static IHost BuildHost(string address, TimeSpan? ttl = null)
+        => Host.CreateDefaultBuilder()
+            .ConfigureServices(services =>
+            {
+                services.AddQuilt4NetValueGroupClient(null, o =>
+                {
+                    o.Quilt4NetAddress = address;
+                    o.ApiKey = "test-key";
+                    o.GroupId = GroupId;
+                    o.Ttl = ttl;
+                    o.HttpTimeout = TimeSpan.FromSeconds(2);
+                });
+            })
+            .Build();
+
+    private static int GetFreePort()
+    {
+        using var l = new System.Net.Sockets.TcpListener(IPAddress.Loopback, 0);
+        l.Start();
+        var port = ((IPEndPoint)l.LocalEndpoint).Port;
+        l.Stop();
+        return port;
+    }
+}

--- a/Quilt4Net.Toolkit/Features/ValueGroup/IValueGroupClient.cs
+++ b/Quilt4Net.Toolkit/Features/ValueGroup/IValueGroupClient.cs
@@ -1,0 +1,17 @@
+namespace Quilt4Net.Toolkit.Features.ValueGroup;
+
+/// <summary>
+/// Fetches the configured Value Group's bundle from Quilt4Net.Server. One client = one group
+/// (the group id is bound at registration). Apps that need multiple groups register multiple
+/// clients via keyed services.
+/// </summary>
+public interface IValueGroupClient
+{
+    /// <summary>
+    /// Fetches the bundle, returning cached values when available. Throws
+    /// <see cref="ValueGroupAuthorizationException"/> on 401/403 (revoked key, wrong scope, or
+    /// the key is no longer bound to this group). Transient HTTP failures return the last-cached
+    /// bundle if any, otherwise rethrow the underlying exception.
+    /// </summary>
+    Task<ValueGroupBundle> GetAsync(CancellationToken cancellationToken = default);
+}

--- a/Quilt4Net.Toolkit/Features/ValueGroup/KeyValueEntry.cs
+++ b/Quilt4Net.Toolkit/Features/ValueGroup/KeyValueEntry.cs
@@ -1,0 +1,14 @@
+namespace Quilt4Net.Toolkit.Features.ValueGroup;
+
+/// <summary>
+/// Plain key/value entry inside a <see cref="ValueGroupBundle"/>. Values are transported as-is
+/// (no encryption). Future feature extensions (an <c>IsSecret</c> flag, encryption at rest,
+/// masking) are planned in a coordinated follow-up that also addresses today's
+/// <c>ApplicationInsightsConfigurationResponse.ClientSecret</c> plain-text storage.
+/// </summary>
+public record KeyValueEntry
+{
+    public string Name { get; init; }
+    public string Value { get; init; }
+    public string Description { get; init; }
+}

--- a/Quilt4Net.Toolkit/Features/ValueGroup/ValueGroupAuthorizationException.cs
+++ b/Quilt4Net.Toolkit/Features/ValueGroup/ValueGroupAuthorizationException.cs
@@ -1,0 +1,13 @@
+namespace Quilt4Net.Toolkit.Features.ValueGroup;
+
+/// <summary>
+/// Thrown by <see cref="IValueGroupClient.GetAsync"/> when the server returns 401 or 403.
+/// Differs from <see cref="Features.FeatureToggle.IRemoteConfigurationService"/>'s silent-fallback
+/// behaviour by design: a revoked agent must learn it has been revoked rather than continue
+/// serving cached secret-bearing data.
+/// </summary>
+public class ValueGroupAuthorizationException : Exception
+{
+    public ValueGroupAuthorizationException(string message) : base(message) { }
+    public ValueGroupAuthorizationException(string message, Exception innerException) : base(message, innerException) { }
+}

--- a/Quilt4Net.Toolkit/Features/ValueGroup/ValueGroupBundle.cs
+++ b/Quilt4Net.Toolkit/Features/ValueGroup/ValueGroupBundle.cs
@@ -15,4 +15,5 @@ public record ValueGroupBundle
     public DateTime FetchedAtUtc { get; init; }
     public ConfigurationResponse[] FeatureToggles { get; init; } = [];
     public ApplicationInsightsConfigurationResponse[] ApplicationInsightsConfigurations { get; init; } = [];
+    public KeyValueEntry[] KeyValues { get; init; } = [];
 }

--- a/Quilt4Net.Toolkit/Features/ValueGroup/ValueGroupBundle.cs
+++ b/Quilt4Net.Toolkit/Features/ValueGroup/ValueGroupBundle.cs
@@ -1,0 +1,18 @@
+using Quilt4Net.Toolkit.Features.ApplicationInsights;
+using Quilt4Net.Toolkit.Features.FeatureToggle;
+
+namespace Quilt4Net.Toolkit.Features.ValueGroup;
+
+/// <summary>
+/// Typed bundle returned by <see cref="IValueGroupClient.GetAsync"/>. New member types
+/// (KV pairs, Atlas credentials, …) get added as additional properties when later features ship —
+/// the shape is additive-only so older clients keep deserializing successfully against newer servers.
+/// </summary>
+public record ValueGroupBundle
+{
+    public string GroupId { get; init; }
+    public string GroupName { get; init; }
+    public DateTime FetchedAtUtc { get; init; }
+    public ConfigurationResponse[] FeatureToggles { get; init; } = [];
+    public ApplicationInsightsConfigurationResponse[] ApplicationInsightsConfigurations { get; init; } = [];
+}

--- a/Quilt4Net.Toolkit/Features/ValueGroup/ValueGroupClient.cs
+++ b/Quilt4Net.Toolkit/Features/ValueGroup/ValueGroupClient.cs
@@ -1,0 +1,156 @@
+using System.Net;
+using System.Net.Http.Json;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Quilt4Net.Toolkit.Features.ValueGroup;
+
+internal class ValueGroupClient : IValueGroupClient
+{
+    private static readonly TimeSpan DefaultTtl = TimeSpan.FromMinutes(5);
+
+    private readonly ValueGroupClientOptions _options;
+    private readonly ILogger<ValueGroupClient> _logger;
+    private readonly SemaphoreSlim _refreshGate = new(1, 1);
+
+    private ValueGroupBundle _cached;
+    private DateTime _cachedAt = DateTime.MinValue;
+    private volatile bool _refreshInProgress;
+
+    public ValueGroupClient(IOptions<ValueGroupClientOptions> options, ILogger<ValueGroupClient> logger)
+    {
+        _options = options.Value;
+        _logger = logger;
+
+        if (string.IsNullOrWhiteSpace(_options.ApiKey))
+            throw new InvalidOperationException("ValueGroupClientOptions.ApiKey is required.");
+        if (string.IsNullOrWhiteSpace(_options.GroupId))
+            throw new InvalidOperationException("ValueGroupClientOptions.GroupId is required.");
+        if (!Uri.TryCreate(_options.Quilt4NetAddress, UriKind.Absolute, out _))
+            throw new InvalidOperationException($"ValueGroupClientOptions.Quilt4NetAddress '{_options.Quilt4NetAddress}' is not an absolute URI.");
+    }
+
+    public async Task<ValueGroupBundle> GetAsync(CancellationToken cancellationToken = default)
+    {
+        var ttl = _options.Ttl ?? DefaultTtl;
+        var cached = _cached;
+        var age = DateTime.UtcNow - _cachedAt;
+
+        if (cached != null && age < ttl) return cached;
+
+        // Stale-while-revalidate: hand back the stale bundle and refresh in the background.
+        if (cached != null)
+        {
+            StartBackgroundRefresh();
+            return cached;
+        }
+
+        return await FetchAsync(cancellationToken);
+    }
+
+    private async Task<ValueGroupBundle> FetchAsync(CancellationToken cancellationToken)
+    {
+        await _refreshGate.WaitAsync(cancellationToken);
+        try
+        {
+            // Another caller may have populated the cache while we waited.
+            var cached = _cached;
+            var ttl = _options.Ttl ?? DefaultTtl;
+            if (cached != null && DateTime.UtcNow - _cachedAt < ttl) return cached;
+
+            using var timeoutCts = new CancellationTokenSource(_options.HttpTimeout);
+            using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, timeoutCts.Token);
+            using var client = CreateHttpClient();
+
+            var response = await client.GetAsync($"Api/ValueGroup/{_options.GroupId}", linkedCts.Token);
+
+            if (response.StatusCode == HttpStatusCode.Unauthorized || response.StatusCode == HttpStatusCode.Forbidden)
+            {
+                // Revoked / unbound / wrong scope. Don't fall back to cached data — surface explicitly.
+                throw new ValueGroupAuthorizationException(
+                    $"Server returned {(int)response.StatusCode} {response.StatusCode} for value group '{_options.GroupId}'. The API key may have been revoked or is not bound to this group.");
+            }
+
+            if (!response.IsSuccessStatusCode)
+            {
+                _logger.LogError(
+                    "Unable to fetch value group '{GroupId}'. Response was {StatusCode} {ReasonPhrase}.",
+                    _options.GroupId, response.StatusCode, response.ReasonPhrase);
+                if (cached != null) return cached;
+                response.EnsureSuccessStatusCode(); // throws
+            }
+
+            var bundle = await response.Content.ReadFromJsonAsync<ValueGroupBundle>(linkedCts.Token)
+                         ?? throw new InvalidOperationException($"Server returned an empty body for value group '{_options.GroupId}'.");
+
+            _cached = bundle;
+            _cachedAt = DateTime.UtcNow;
+            return bundle;
+        }
+        catch (ValueGroupAuthorizationException)
+        {
+            throw;
+        }
+        catch (OperationCanceledException)
+        {
+            _logger.LogWarning(
+                "Value group '{GroupId}' fetch timed out after {Timeout}ms.",
+                _options.GroupId, _options.HttpTimeout.TotalMilliseconds);
+            if (_cached != null) return _cached;
+            throw;
+        }
+        catch (Exception e)
+        {
+            _logger.LogError(e, "Failed to fetch value group '{GroupId}': {Message}.", _options.GroupId, e.Message);
+            if (_cached != null) return _cached;
+            throw;
+        }
+        finally
+        {
+            _refreshGate.Release();
+        }
+    }
+
+    private void StartBackgroundRefresh()
+    {
+        if (_refreshInProgress) return;
+        _refreshInProgress = true;
+
+        _ = Task.Run(async () =>
+        {
+            try
+            {
+                await FetchAsync(CancellationToken.None);
+            }
+            catch (ValueGroupAuthorizationException ex)
+            {
+                _logger.LogWarning(ex, "Background refresh for value group '{GroupId}' was denied; stale cache will continue serving until the next foreground fetch.",
+                    _options.GroupId);
+            }
+            catch
+            {
+                // Already logged inside FetchAsync.
+            }
+            finally
+            {
+                _refreshInProgress = false;
+            }
+        });
+    }
+
+    private HttpClient CreateHttpClient()
+    {
+        HttpClient client = null;
+        try
+        {
+            client = new HttpClient { BaseAddress = new Uri(_options.Quilt4NetAddress) };
+            client.DefaultRequestHeaders.Add("X-API-KEY", _options.ApiKey);
+            return client;
+        }
+        catch
+        {
+            client?.Dispose();
+            throw;
+        }
+    }
+}

--- a/Quilt4Net.Toolkit/Features/ValueGroup/ValueGroupClientOptions.cs
+++ b/Quilt4Net.Toolkit/Features/ValueGroup/ValueGroupClientOptions.cs
@@ -1,0 +1,22 @@
+namespace Quilt4Net.Toolkit.Features.ValueGroup;
+
+/// <summary>
+/// Options for <see cref="IValueGroupClient"/>. Configuration path: <c>Quilt4Net:ValueGroup</c>.
+/// </summary>
+public record ValueGroupClientOptions
+{
+    /// <summary>Quilt4Net server base URL. Default is <c>https://quilt4net.com/</c>.</summary>
+    public string Quilt4NetAddress { get; set; } = "https://quilt4net.com/";
+
+    /// <summary>The API key minted for this Value Group on the server. Required.</summary>
+    public string ApiKey { get; set; }
+
+    /// <summary>The id of the Value Group this client fetches. Required.</summary>
+    public string GroupId { get; set; }
+
+    /// <summary>How long the cached bundle is considered fresh. Default 5 minutes.</summary>
+    public TimeSpan? Ttl { get; set; }
+
+    /// <summary>Timeout for HTTP calls to the server. Default 5 seconds.</summary>
+    public TimeSpan HttpTimeout { get; set; } = TimeSpan.FromSeconds(5);
+}

--- a/Quilt4Net.Toolkit/README.md
+++ b/Quilt4Net.Toolkit/README.md
@@ -194,6 +194,56 @@ Typical setup:
 
 > **Trade-off**: `DefaultAzureCredential` masks *which* underlying credential succeeded. If authentication fails, the error chain is less specific than the explicit modes. For diagnosis, switch to `ClientSecret` or `ManagedIdentity` to isolate the issue.
 
+## Value Groups
+
+A **Value Group** is a server-curated bundle of references to existing values across multiple stores (today: feature toggles and Application Insights configurations; KV pairs and Atlas credentials come in later features). An external agent uses one HTTP call with its own group-scoped API key to receive a typed bundle containing only the values the operator allowlisted.
+
+Use this when an agent needs least-privilege access to a specific deployment's configuration without exposing the team-wide scope.
+
+```csharp
+builder.AddQuilt4NetValueGroupClient(o =>
+{
+    o.GroupId = "507f1f77bcf86cd799439011";  // the group's ObjectId from the admin UI
+    o.ApiKey = builder.Configuration["Quilt4Net:ValueGroup:ApiKey"];
+});
+```
+
+Then inject and call:
+
+```csharp
+public class MyAgent(IValueGroupClient client)
+{
+    public async Task DoWorkAsync(CancellationToken ct)
+    {
+        var bundle = await client.GetAsync(ct);
+        foreach (var toggle in bundle.FeatureToggles) { /* ... */ }
+        foreach (var ai in bundle.ApplicationInsightsConfigurations) { /* ... */ }
+    }
+}
+```
+
+### ValueGroupClientOptions
+
+| Property | Default | Description |
+|----------|---------|-------------|
+| `Quilt4NetAddress` | `https://quilt4net.com/` | Server base URL. |
+| `ApiKey` | — *(required)* | The API key minted for this Value Group in the server's admin UI. Must carry the `valuegroup:read` scope and be tag-bound to `GroupId`. |
+| `GroupId` | — *(required)* | The id of the Value Group this client fetches. |
+| `Ttl` | `5 min` | Cache freshness window. Subsequent calls within the window serve the cached bundle. |
+| `HttpTimeout` | `5 s` | HTTP timeout. On timeout the cached bundle is served if available. |
+
+Configuration path: `Quilt4Net:ValueGroup` (or top-level `Quilt4Net:ApiKey` + `Quilt4Net:Quilt4NetAddress` for shared keys).
+
+### Behaviour and contract
+
+- **Stale-while-revalidate**: returning a fresh bundle is the default. Stale-cache fallback applies on transient HTTP errors *and* on timeout.
+- **`ValueGroupAuthorizationException` on 401/403**: a revoked key or wrong-binding response *throws*, by design. Unlike `IRemoteConfigurationService` (which silently serves fallback values), Value Groups carry secret-bearing data, so the consumer must learn it has been revoked rather than continue using cached secrets.
+- **One client = one group**: register multiple clients via keyed services if the consumer needs more than one group.
+
+### Minting a key
+
+In the Quilt4Net.Server admin UI under **Value Groups**: select the group → API Keys panel → **Mint new key**. The raw key is shown exactly once — save it immediately. The key carries only the `valuegroup:read` scope and is tag-bound on the server side to this one group; it cannot reach any other team data.
+
 ## Universal telemetry identity
 
 `AddQuilt4NetLogging()` configures OpenTelemetry resource attributes **and** registers two `BaseProcessor`s — one for `LogRecord`, one for `Activity` — that copy a fixed set of identity attributes onto every per-record Properties bag. Works for all app types; the Azure Monitor exporter forwards the per-record attributes into `customDimensions`, where KQL can read them.

--- a/Quilt4Net.Toolkit/ValueGroupRegistration.cs
+++ b/Quilt4Net.Toolkit/ValueGroupRegistration.cs
@@ -1,0 +1,41 @@
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Options;
+using Quilt4Net.Toolkit.Features.ValueGroup;
+
+namespace Quilt4Net.Toolkit;
+
+public static class ValueGroupRegistration
+{
+    /// <summary>
+    /// Registers <see cref="IValueGroupClient"/> against the Value Group configured in
+    /// <c>Quilt4Net:ValueGroup</c>. The bound API key must carry the <c>valuegroup:read</c>
+    /// scope and be tag-bound to the group on the server.
+    /// </summary>
+    public static IServiceCollection AddQuilt4NetValueGroupClient(this IHostApplicationBuilder builder, Action<ValueGroupClientOptions> options = null)
+    {
+        return builder.Services.AddQuilt4NetValueGroupClient(builder.Configuration, options);
+    }
+
+    public static IServiceCollection AddQuilt4NetValueGroupClient(this IServiceCollection services, IConfiguration configuration, Action<ValueGroupClientOptions> options = null)
+    {
+        var fromConfig = configuration?.GetSection("Quilt4Net:ValueGroup").Get<ValueGroupClientOptions>();
+        var topLevelApiKey = configuration?.GetSection("Quilt4Net:ApiKey").Value;
+        var topLevelAddress = configuration?.GetSection("Quilt4Net:Quilt4NetAddress").Value;
+
+        var o = new ValueGroupClientOptions
+        {
+            Quilt4NetAddress = fromConfig?.Quilt4NetAddress ?? topLevelAddress ?? "https://quilt4net.com/",
+            ApiKey = fromConfig?.ApiKey ?? topLevelApiKey,
+            GroupId = fromConfig?.GroupId,
+            Ttl = fromConfig?.Ttl,
+            HttpTimeout = fromConfig?.HttpTimeout ?? TimeSpan.FromSeconds(5)
+        };
+
+        options?.Invoke(o);
+        services.AddSingleton(Options.Create(o));
+        services.AddSingleton<IValueGroupClient, ValueGroupClient>();
+        return services;
+    }
+}


### PR DESCRIPTION
## Summary

Foundation for the Value Groups roadmap (planned/01–planned/05). Adds the Toolkit-side client + DTO + auth-failure exception that consumer apps use to fetch a curated bundle of values from Quilt4Net.Server with a single group-scoped API key.

- `IValueGroupClient.GetAsync(ct)` returns a typed `ValueGroupBundle`
- `ValueGroupBundle` composes existing toolkit-side types (`ConfigurationResponse`, `ApplicationInsightsConfigurationResponse`) — additive-only shape so future features (KV pairs, Atlas credentials) add new properties without breaking older consumers
- `ValueGroupClient`: stale-while-revalidate cache (default 5-min `Ttl`), 5s HTTP timeout
- `ValueGroupAuthorizationException` explicitly thrown on 401/403 — a revoked key must learn it's been revoked; differs from `IRemoteConfigurationService`'s silent-fallback by design because Value Groups carry secret-bearing data
- `AddQuilt4NetValueGroupClient` registers as singleton (one client = one group; multi-group consumers use keyed services)
- 6 HttpListener tests: 200/401/403/TTL caching/stale-cache on 500/missing-required-option

Companion Server change is in Quilt4Net.Server `feature/value-groups-foundation` and adds the actual `GET /Api/ValueGroup/{id}` endpoint, the admin UI, key binding model, and usage log.

## Test plan

- [ ] All 273 toolkit tests pass (+6 new on `ValueGroupClientTests`)
- [ ] Warning baseline OK (234, well under 261 ceiling)
- [ ] Verify prerelease NuGet published by CI
- [ ] End-to-end: a Blazor host registers `AddQuilt4NetValueGroupClient` with a `monitor:read`-equivalent `valuegroup:read`-scoped API key minted in Server's admin UI, calls `IValueGroupClient.GetAsync()`, receives the typed bundle
- [ ] Revoking the key on the server causes the next fetch to throw `ValueGroupAuthorizationException`

## Dependencies

- Server-side endpoint must deploy before any consumer can use this. Server PR target follows the same pattern as `remote-ai-config`.