### PR TITLE
Atlas value-group bundle DTOs + NuGet updates

### DIFF
--- a/Quilt4Net.Toolkit.Api.Sample/Quilt4Net.Toolkit.Api.Sample.csproj
+++ b/Quilt4Net.Toolkit.Api.Sample/Quilt4Net.Toolkit.Api.Sample.csproj
@@ -12,7 +12,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="10.1.7" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="10.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Quilt4Net.Toolkit.Api.Tests/Quilt4Net.Toolkit.Api.Tests.csproj
+++ b/Quilt4Net.Toolkit.Api.Tests/Quilt4Net.Toolkit.Api.Tests.csproj
@@ -9,7 +9,7 @@
 		<PackageReference Include="AutoFixture" Version="4.18.1" />
 		<PackageReference Include="FluentAssertions" Version="8.10.0" />
 		<PackageReference Include="JetBrains.Annotations" Version="2025.2.4" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
 		<PackageReference Include="Moq" Version="4.20.72" />
 		<PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.8" />
 		<PackageReference Include="OneOf" Version="3.0.271" />

--- a/Quilt4Net.Toolkit.Blazor.Tests/Quilt4Net.Toolkit.Blazor.Tests.csproj
+++ b/Quilt4Net.Toolkit.Blazor.Tests/Quilt4Net.Toolkit.Blazor.Tests.csproj
@@ -13,7 +13,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Quilt4Net.Toolkit.Health.Tests/Quilt4Net.Toolkit.Health.Tests.csproj
+++ b/Quilt4Net.Toolkit.Health.Tests/Quilt4Net.Toolkit.Health.Tests.csproj
@@ -9,7 +9,7 @@
 		<PackageReference Include="AutoBogus" Version="2.13.1" />
 		<PackageReference Include="FluentAssertions" Version="8.10.0" />
 		<PackageReference Include="JetBrains.Annotations" Version="2025.2.4" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
 		<PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.8" />
 		<PackageReference Include="Moq" Version="4.20.72" />
 		<PackageReference Include="OneOf" Version="3.0.271" />

--- a/Quilt4Net.Toolkit.Health/Quilt4Net.Toolkit.Health.csproj
+++ b/Quilt4Net.Toolkit.Health/Quilt4Net.Toolkit.Health.csproj
@@ -40,7 +40,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-	  <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="3.1.1" />
+	  <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="3.1.2" />
 	  <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.300">
 		  <PrivateAssets>all</PrivateAssets>
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Quilt4Net.Toolkit.Mcp.Tests/Quilt4Net.Toolkit.Mcp.Tests.csproj
+++ b/Quilt4Net.Toolkit.Mcp.Tests/Quilt4Net.Toolkit.Mcp.Tests.csproj
@@ -7,7 +7,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="FluentAssertions" Version="8.10.0" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
 		<PackageReference Include="Moq" Version="4.20.72" />
 		<PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
 			<PrivateAssets>all</PrivateAssets>

--- a/Quilt4Net.Toolkit.Tests/Quilt4Net.Toolkit.Tests.csproj
+++ b/Quilt4Net.Toolkit.Tests/Quilt4Net.Toolkit.Tests.csproj
@@ -9,7 +9,7 @@
 		<PackageReference Include="AutoFixture" Version="4.18.1" />
 		<PackageReference Include="FluentAssertions" Version="8.10.0" />
 		<PackageReference Include="JetBrains.Annotations" Version="2025.2.4" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
 		<PackageReference Include="Moq" Version="4.20.72" />
 		<PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.8" />
 		<PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">

--- a/Quilt4Net.Toolkit/Features/ValueGroup/AtlasFirewallCredentialEntry.cs
+++ b/Quilt4Net.Toolkit/Features/ValueGroup/AtlasFirewallCredentialEntry.cs
@@ -1,0 +1,30 @@
+namespace Quilt4Net.Toolkit.Features.ValueGroup;
+
+/// <summary>
+/// An Atlas project credential delivered via a value-group bundle for IP-access-list (firewall)
+/// management. Consumers use this credential to call Atlas's <c>/groups/{groupId}/accessList</c>
+/// endpoint directly. <see cref="PrivateSecret"/> is plaintext on the wire (transport over TLS,
+/// behind an API-key-gated bundle fetch).
+/// </summary>
+public record AtlasFirewallCredentialEntry
+{
+    public string Name { get; init; }
+
+    /// <summary>
+    /// <c>"ServiceAccount"</c> (OAuth2 client credentials) or <c>"ProgrammaticApiKey"</c> (HTTP Digest).
+    /// The string form keeps the bundle DTO independent of the Server's enum type.
+    /// </summary>
+    public string CredentialType { get; init; }
+
+    /// <summary>Public identifier — <c>PublicKey</c> for API keys, <c>ClientId</c> for Service Accounts.</summary>
+    public string PublicId { get; init; }
+
+    /// <summary>Plaintext private secret. Treat as sensitive — do not log.</summary>
+    public string PrivateSecret { get; init; }
+
+    /// <summary>Atlas project role assigned to the credential — typically <c>ProjectOwner</c>.</summary>
+    public string Role { get; init; }
+
+    /// <summary>Optional per-credential API access list (CIDRs) that limit which networks may use this credential against Atlas.</summary>
+    public string[] AccessListCidrs { get; init; } = [];
+}

--- a/Quilt4Net.Toolkit/Features/ValueGroup/AtlasReadOnlyAccessEntry.cs
+++ b/Quilt4Net.Toolkit/Features/ValueGroup/AtlasReadOnlyAccessEntry.cs
@@ -1,0 +1,19 @@
+namespace Quilt4Net.Toolkit.Features.ValueGroup;
+
+/// <summary>
+/// A read-only MongoDB Atlas database user delivered as part of a <see cref="ValueGroupBundle"/>.
+/// <see cref="ConnectionString"/> is the cluster's SRV connection string with
+/// <see cref="Username"/>/<see cref="Password"/> already embedded — consumers can pass it straight
+/// to a <c>MongoClient</c>. To revoke access, the team admin removes the underlying access in the
+/// Quilt4Net.Server admin UI, which deletes the Atlas database user.
+/// </summary>
+public record AtlasReadOnlyAccessEntry
+{
+    public string Name { get; init; }
+    public string ClusterName { get; init; }
+    public string Username { get; init; }
+    public string Password { get; init; }
+
+    /// <summary>SRV connection string with username:password embedded; ready to hand to a MongoClient.</summary>
+    public string ConnectionString { get; init; }
+}

--- a/Quilt4Net.Toolkit/Features/ValueGroup/ValueGroupBundle.cs
+++ b/Quilt4Net.Toolkit/Features/ValueGroup/ValueGroupBundle.cs
@@ -16,4 +16,6 @@ public record ValueGroupBundle
     public ConfigurationResponse[] FeatureToggles { get; init; } = [];
     public ApplicationInsightsConfigurationResponse[] ApplicationInsightsConfigurations { get; init; } = [];
     public KeyValueEntry[] KeyValues { get; init; } = [];
+    public AtlasReadOnlyAccessEntry[] AtlasReadOnlyAccesses { get; init; } = [];
+    public AtlasFirewallCredentialEntry[] AtlasFirewallCredentials { get; init; } = [];
 }

--- a/Quilt4Net.Toolkit/Quilt4Net.Toolkit.csproj
+++ b/Quilt4Net.Toolkit/Quilt4Net.Toolkit.csproj
@@ -38,7 +38,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Azure.Identity" Version="1.21.0" />
-    <PackageReference Include="Microsoft.ApplicationInsights" Version="3.1.1" />
+    <PackageReference Include="Microsoft.ApplicationInsights" Version="3.1.2" />
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.15.3" />
     <PackageReference Include="Azure.Monitor.Query.Logs" Version="1.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.8" />


### PR DESCRIPTION
## Summary
Adds the Atlas value-group bundle DTOs that Quilt4Net.Server's Atlas integration needs, plus routine NuGet updates. Shipping this publishes a new Toolkit version (CI computes it from tags — next is 0.7.16) so the Server can switch its temporary in-tree `ProjectReference` back to a `PackageReference`.

## Changes
**Atlas bundle DTOs** (`9b7a8d0`)
- New `AtlasReadOnlyAccessEntry` (read-only DB user + ready-to-use SRV connection string).
- New `AtlasFirewallCredentialEntry` (Atlas project credential for IP-access-list management).
- `ValueGroupBundle` gains `AtlasReadOnlyAccesses` and `AtlasFirewallCredentials`. **Additive only** — existing bundle consumers keep deserializing unchanged.

**NuGet updates** (`0a5ef68`)
- `Microsoft.ApplicationInsights` + `.AspNetCore` 3.1.1 → 3.1.2 (shipped packages)
- `Microsoft.NET.Test.Sdk` 18.5.1 → 18.6.0 (all test projects)
- `Swashbuckle.AspNetCore` 10.1.7 → 10.2.0 (Api.Sample)
- Left `Microsoft.AspNetCore.Components.Authorization` as-is: pinned per-TFM (net9 → 9.0.15, net10 → 10.0.8); the "outdated" flag is a false positive comparing the net9 target against the net10 package.

## Verification
- Full solution builds clean.
- 273 tests pass (Toolkit 146, Blazor 63, Health 48, Mcp 15, Api 1).

## Downstream
Once this publishes, Quilt4Net.Server restores its `PackageReference` to `Quilt4Net.Toolkit.{Api,Blazor,Health}` at the new version (currently a temporary `ProjectReference` to the in-tree projects).