### PR TITLE
refactor(value-group): drop GroupId option — key alone identifies the group

### DIFF
--- a/Quilt4Net.Toolkit.Tests/ValueGroupClientTests.cs
+++ b/Quilt4Net.Toolkit.Tests/ValueGroupClientTests.cs
@@ -222,21 +222,20 @@ public class ValueGroupClientTests
     [Fact]
     public void Registration_Validates_Required_Options()
     {
-        // Missing GroupId
+        // Missing ApiKey
         var host = Host.CreateDefaultBuilder()
             .ConfigureServices(services =>
             {
                 services.AddQuilt4NetValueGroupClient(null, o =>
                 {
                     o.Quilt4NetAddress = "http://127.0.0.1:9999/";
-                    o.ApiKey = "test-key";
-                    o.GroupId = null;
+                    o.ApiKey = null;
                 });
             })
             .Build();
 
         var act = () => host.Services.GetRequiredService<IValueGroupClient>();
-        act.Should().Throw<InvalidOperationException>().WithMessage("*GroupId*");
+        act.Should().Throw<InvalidOperationException>().WithMessage("*ApiKey*");
     }
 
     private static IHost BuildHost(string address, TimeSpan? ttl = null)
@@ -247,7 +246,6 @@ public class ValueGroupClientTests
                 {
                     o.Quilt4NetAddress = address;
                     o.ApiKey = "test-key";
-                    o.GroupId = GroupId;
                     o.Ttl = ttl;
                     o.HttpTimeout = TimeSpan.FromSeconds(2);
                 });

--- a/Quilt4Net.Toolkit/Features/ValueGroup/ValueGroupClient.cs
+++ b/Quilt4Net.Toolkit/Features/ValueGroup/ValueGroupClient.cs
@@ -30,8 +30,6 @@ internal class ValueGroupClient : IValueGroupClient
 
         if (string.IsNullOrWhiteSpace(_options.ApiKey))
             throw new InvalidOperationException("ValueGroupClientOptions.ApiKey is required.");
-        if (string.IsNullOrWhiteSpace(_options.GroupId))
-            throw new InvalidOperationException("ValueGroupClientOptions.GroupId is required.");
         if (!Uri.TryCreate(_options.Quilt4NetAddress, UriKind.Absolute, out _))
             throw new InvalidOperationException($"ValueGroupClientOptions.Quilt4NetAddress '{_options.Quilt4NetAddress}' is not an absolute URI.");
     }
@@ -68,26 +66,26 @@ internal class ValueGroupClient : IValueGroupClient
             using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, timeoutCts.Token);
             using var client = CreateHttpClient();
 
-            var response = await client.GetAsync($"Api/ValueGroup/{_options.GroupId}", linkedCts.Token);
+            var response = await client.GetAsync("Api/ValueGroup", linkedCts.Token);
 
             if (response.StatusCode == HttpStatusCode.Unauthorized || response.StatusCode == HttpStatusCode.Forbidden)
             {
                 // Revoked / unbound / wrong scope. Don't fall back to cached data — surface explicitly.
                 throw new ValueGroupAuthorizationException(
-                    $"Server returned {(int)response.StatusCode} {response.StatusCode} for value group '{_options.GroupId}'. The API key may have been revoked or is not bound to this group.");
+                    $"Server returned {(int)response.StatusCode} {response.StatusCode} for value group fetch. The API key may have been revoked, has no value-group tag, or is missing the valuegroup:read scope.");
             }
 
             if (!response.IsSuccessStatusCode)
             {
                 _logger.LogError(
-                    "Unable to fetch value group '{GroupId}'. Response was {StatusCode} {ReasonPhrase}.",
-                    _options.GroupId, response.StatusCode, response.ReasonPhrase);
+                    "Unable to fetch value group bundle. Response was {StatusCode} {ReasonPhrase}.",
+                    response.StatusCode, response.ReasonPhrase);
                 if (cached != null) return cached;
                 response.EnsureSuccessStatusCode(); // throws
             }
 
             var bundle = await response.Content.ReadFromJsonAsync<ValueGroupBundle>(linkedCts.Token)
-                         ?? throw new InvalidOperationException($"Server returned an empty body for value group '{_options.GroupId}'.");
+                         ?? throw new InvalidOperationException("Server returned an empty body for the value group bundle.");
 
             _cached = bundle;
             _cachedAt = DateTime.UtcNow;
@@ -100,14 +98,14 @@ internal class ValueGroupClient : IValueGroupClient
         catch (OperationCanceledException)
         {
             _logger.LogWarning(
-                "Value group '{GroupId}' fetch timed out after {Timeout}ms.",
-                _options.GroupId, _options.HttpTimeout.TotalMilliseconds);
+                "Value group bundle fetch timed out after {Timeout}ms.",
+                _options.HttpTimeout.TotalMilliseconds);
             if (_cached != null) return _cached;
             throw;
         }
         catch (Exception e)
         {
-            _logger.LogError(e, "Failed to fetch value group '{GroupId}': {Message}.", _options.GroupId, e.Message);
+            _logger.LogError(e, "Failed to fetch value group bundle: {Message}.", e.Message);
             if (_cached != null) return _cached;
             throw;
         }
@@ -130,8 +128,7 @@ internal class ValueGroupClient : IValueGroupClient
             }
             catch (ValueGroupAuthorizationException ex)
             {
-                _logger.LogWarning(ex, "Background refresh for value group '{GroupId}' was denied; stale cache will continue serving until the next foreground fetch.",
-                    _options.GroupId);
+                _logger.LogWarning(ex, "Background refresh for value group bundle was denied; stale cache will continue serving until the next foreground fetch.");
             }
             catch
             {

--- a/Quilt4Net.Toolkit/Features/ValueGroup/ValueGroupClientOptions.cs
+++ b/Quilt4Net.Toolkit/Features/ValueGroup/ValueGroupClientOptions.cs
@@ -8,11 +8,12 @@ public record ValueGroupClientOptions
     /// <summary>Quilt4Net server base URL. Default is <c>https://quilt4net.com/</c>.</summary>
     public string Quilt4NetAddress { get; set; } = "https://quilt4net.com/";
 
-    /// <summary>The API key minted for this Value Group on the server. Required.</summary>
+    /// <summary>
+    /// The API key minted for this Value Group on the server. Required. The key is tag-bound to
+    /// exactly one Value Group server-side; the server resolves which group from the key itself,
+    /// so no group id is configured on the client.
+    /// </summary>
     public string ApiKey { get; set; }
-
-    /// <summary>The id of the Value Group this client fetches. Required.</summary>
-    public string GroupId { get; set; }
 
     /// <summary>How long the cached bundle is considered fresh. Default 5 minutes.</summary>
     public TimeSpan? Ttl { get; set; }

--- a/Quilt4Net.Toolkit/README.md
+++ b/Quilt4Net.Toolkit/README.md
@@ -219,7 +219,6 @@ Use this when an agent needs least-privilege access to a specific deployment's c
 ```csharp
 builder.AddQuilt4NetValueGroupClient(o =>
 {
-    o.GroupId = "507f1f77bcf86cd799439011";  // the group's ObjectId from the admin UI
     o.ApiKey = builder.Configuration["Quilt4Net:ValueGroup:ApiKey"];
 });
 ```
@@ -243,8 +242,7 @@ public class MyAgent(IValueGroupClient client)
 | Property | Default | Description |
 |----------|---------|-------------|
 | `Quilt4NetAddress` | `https://quilt4net.com/` | Server base URL. |
-| `ApiKey` | — *(required)* | The API key minted for this Value Group in the server's admin UI. Must carry the `valuegroup:read` scope and be tag-bound to `GroupId`. |
-| `GroupId` | — *(required)* | The id of the Value Group this client fetches. |
+| `ApiKey` | — *(required)* | The API key minted for this Value Group in the server's admin UI. Must carry the `valuegroup:read` scope. The key is tag-bound server-side to exactly one Value Group; the server resolves which group from the key, so the client never names a group id. |
 | `Ttl` | `5 min` | Cache freshness window. Subsequent calls within the window serve the cached bundle. |
 | `HttpTimeout` | `5 s` | HTTP timeout. On timeout the cached bundle is served if available. |
 

--- a/Quilt4Net.Toolkit/ValueGroupRegistration.cs
+++ b/Quilt4Net.Toolkit/ValueGroupRegistration.cs
@@ -28,7 +28,6 @@ public static class ValueGroupRegistration
         {
             Quilt4NetAddress = fromConfig?.Quilt4NetAddress ?? topLevelAddress ?? "https://quilt4net.com/",
             ApiKey = fromConfig?.ApiKey ?? topLevelApiKey,
-            GroupId = fromConfig?.GroupId,
             Ttl = fromConfig?.Ttl,
             HttpTimeout = fromConfig?.HttpTimeout ?? TimeSpan.FromSeconds(5)
         };


### PR DESCRIPTION
## Summary

The API key minted for a Value Group is tag-bound server-side to exactly one group (PR #78 tag-on-key). Duplicating that id in the consumer's appsettings as \`GroupId\` only invited misconfiguration. This refactor lets the server resolve the group from the key itself.

- \`ValueGroupClientOptions.GroupId\` removed (only \`ApiKey\` is required now)
- \`ValueGroupClient\` calls \`GET /Api/ValueGroup\` (no path segment)
- Log lines + exception messages refer to "the bundle" instead of a specific group id
- Tests: registration-validates flipped to missing-ApiKey; bundle/auth/TTL tests just drop the GroupId assertions
- README updated

## Companion change

Server-side path drop is on Quilt4Net.Server \`feature/value-group-no-id\`. Both must land together — the Toolkit's new no-path-segment URL only resolves against the Server's no-id endpoint.

## Test plan

- [ ] Build clean across all target frameworks (CI)
- [ ] 300 toolkit tests pass (no new ones; 1 existing flipped, 5 existing simplified)
- [ ] Smoke-test: register \`AddQuilt4NetValueGroupClient\` with just \`ApiKey\`, call \`GetAsync()\`, receive bundle