### PR TITLE
Release: Atlas firewall proxy-key client

### DIFF
--- a/Quilt4Net.Toolkit.Tests/AtlasFirewallClientTests.cs
+++ b/Quilt4Net.Toolkit.Tests/AtlasFirewallClientTests.cs
@@ -1,0 +1,159 @@
+using System.Net;
+using System.Net.Sockets;
+using System.Text;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Quilt4Net.Toolkit;
+using Quilt4Net.Toolkit.Features.Atlas;
+using Quilt4Net.Toolkit.Features.ValueGroup;
+using Xunit;
+
+#pragma warning disable xUnit1051
+
+namespace Quilt4Net.Toolkit.Tests;
+
+public class AtlasFirewallClientTests
+{
+    private const string GroupId = "507f1f77bcf86cd799439011";
+
+    [Fact]
+    public async Task OpenAsync_sends_key_group_ip_and_parses_outcome()
+    {
+        var port = GetFreePort();
+        var prefix = $"http://127.0.0.1:{port}/";
+        using var listener = new HttpListener();
+        listener.Prefixes.Add(prefix);
+        listener.Start();
+
+        string capturedKey = null, capturedPath = null, capturedBody = null;
+        _ = Task.Run(async () =>
+        {
+            var ctx = await listener.GetContextAsync();
+            capturedKey = ctx.Request.Headers["X-API-KEY"];
+            capturedPath = ctx.Request.Url!.AbsolutePath;
+            using (var reader = new StreamReader(ctx.Request.InputStream, Encoding.UTF8))
+                capturedBody = await reader.ReadToEndAsync();
+            ctx.Response.StatusCode = 200;
+            ctx.Response.ContentType = "application/json";
+            var buf = Encoding.UTF8.GetBytes("""{"outcome":"Opened","ip":"1.2.3.4","openedUtc":"2026-06-04T10:00:00Z"}""");
+            await ctx.Response.OutputStream.WriteAsync(buf);
+            ctx.Response.Close();
+        });
+
+        try
+        {
+            var client = BuildFactory(prefix).Create(Entry(canManage: true));
+
+            var result = await client.OpenAsync("1.2.3.4", "my laptop");
+
+            result.Outcome.Should().Be("Opened");
+            result.Ip.Should().Be("1.2.3.4");
+            capturedKey.Should().Be("fw-key");
+            capturedPath.Should().Be("/Api/AtlasFirewall/open");
+            capturedBody.Should().Contain(GroupId).And.Contain("1.2.3.4");
+        }
+        finally
+        {
+            listener.Stop();
+        }
+    }
+
+    [Fact]
+    public async Task OpenAsync_on_usage_only_key_throws_without_calling_server()
+    {
+        var client = BuildFactory("http://127.0.0.1:1/").Create(Entry(canManage: false));
+
+        var act = () => client.OpenAsync("1.2.3.4");
+
+        await act.Should().ThrowAsync<InvalidOperationException>().WithMessage("*usage-only*");
+    }
+
+    [Fact]
+    public async Task ReportUsedAsync_works_with_a_usage_only_key()
+    {
+        var port = GetFreePort();
+        var prefix = $"http://127.0.0.1:{port}/";
+        using var listener = new HttpListener();
+        listener.Prefixes.Add(prefix);
+        listener.Start();
+
+        string capturedPath = null;
+        _ = Task.Run(async () =>
+        {
+            var ctx = await listener.GetContextAsync();
+            capturedPath = ctx.Request.Url!.AbsolutePath;
+            ctx.Response.StatusCode = 200;
+            ctx.Response.ContentType = "application/json";
+            var buf = Encoding.UTF8.GetBytes("""{"outcome":"Recorded"}""");
+            await ctx.Response.OutputStream.WriteAsync(buf);
+            ctx.Response.Close();
+        });
+
+        try
+        {
+            var client = BuildFactory(prefix).Create(Entry(canManage: false));
+
+            var result = await client.ReportUsedAsync("1.2.3.4");
+
+            result.Outcome.Should().Be("Recorded");
+            capturedPath.Should().Be("/Api/AtlasFirewall/used");
+        }
+        finally
+        {
+            listener.Stop();
+        }
+    }
+
+    [Fact]
+    public async Task Firewall_call_throws_AtlasFirewallAuthorizationException_on_403()
+    {
+        var port = GetFreePort();
+        var prefix = $"http://127.0.0.1:{port}/";
+        using var listener = new HttpListener();
+        listener.Prefixes.Add(prefix);
+        listener.Start();
+
+        _ = Task.Run(async () =>
+        {
+            var ctx = await listener.GetContextAsync();
+            ctx.Response.StatusCode = 403;
+            ctx.Response.Close();
+        });
+
+        try
+        {
+            var client = BuildFactory(prefix).Create(Entry(canManage: true));
+
+            var act = () => client.OpenAsync("1.2.3.4");
+
+            await act.Should().ThrowAsync<AtlasFirewallAuthorizationException>().WithMessage("*403*");
+        }
+        finally
+        {
+            listener.Stop();
+        }
+    }
+
+    private static AtlasFirewallProxyKeyEntry Entry(bool canManage) =>
+        new() { Name = "fw", ApiKey = "fw-key", GroupId = GroupId, CanManage = canManage };
+
+    private static IAtlasFirewallClientFactory BuildFactory(string address)
+        => Host.CreateDefaultBuilder()
+            .ConfigureServices(services => services.AddQuilt4NetAtlasFirewallClient(null, o =>
+            {
+                o.Quilt4NetAddress = address;
+                o.HttpTimeout = TimeSpan.FromSeconds(2);
+            }))
+            .Build()
+            .Services.GetRequiredService<IAtlasFirewallClientFactory>();
+
+    private static int GetFreePort()
+    {
+        using var l = new TcpListener(IPAddress.Loopback, 0);
+        l.Start();
+        var port = ((IPEndPoint)l.LocalEndpoint).Port;
+        l.Stop();
+        return port;
+    }
+}

--- a/Quilt4Net.Toolkit/AtlasFirewallClientRegistration.cs
+++ b/Quilt4Net.Toolkit/AtlasFirewallClientRegistration.cs
@@ -1,0 +1,40 @@
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Quilt4Net.Toolkit.Features.Atlas;
+
+namespace Quilt4Net.Toolkit;
+
+public static class AtlasFirewallClientRegistration
+{
+    /// <summary>
+    /// Registers <see cref="IAtlasFirewallClientFactory"/>, which builds an
+    /// <see cref="IAtlasFirewallClient"/> for a firewall key obtained from a value-group bundle.
+    /// The Quilt4Net server address comes from <c>Quilt4Net:Quilt4NetAddress</c> (default
+    /// <c>https://quilt4net.com/</c>); the per-call API key and group ride on each bundle entry.
+    /// </summary>
+    public static IServiceCollection AddQuilt4NetAtlasFirewallClient(this IHostApplicationBuilder builder, Action<AtlasFirewallClientOptions> options = null)
+        => builder.Services.AddQuilt4NetAtlasFirewallClient(builder.Configuration, options);
+
+    public static IServiceCollection AddQuilt4NetAtlasFirewallClient(this IServiceCollection services, IConfiguration configuration, Action<AtlasFirewallClientOptions> options = null)
+    {
+        var topLevelAddress = configuration?.GetSection("Quilt4Net:Quilt4NetAddress").Value;
+
+        var o = new AtlasFirewallClientOptions
+        {
+            Quilt4NetAddress = topLevelAddress ?? "https://quilt4net.com/",
+        };
+        options?.Invoke(o);
+
+        services.AddQuilt4NetCorrelationId();
+        services.AddHttpClient(AtlasFirewallClientFactory.HttpClientName, client =>
+            {
+                client.BaseAddress = new Uri(o.Quilt4NetAddress);
+                client.Timeout = o.HttpTimeout;
+            })
+            .AddQuilt4NetCorrelationId();
+
+        services.AddSingleton<IAtlasFirewallClientFactory, AtlasFirewallClientFactory>();
+        return services;
+    }
+}

--- a/Quilt4Net.Toolkit/Features/Atlas/AtlasFirewallAuthorizationException.cs
+++ b/Quilt4Net.Toolkit/Features/Atlas/AtlasFirewallAuthorizationException.cs
@@ -1,0 +1,11 @@
+namespace Quilt4Net.Toolkit.Features.Atlas;
+
+/// <summary>
+/// Thrown when a firewall call is rejected with 401/403 — the key was revoked, lacks the required
+/// firewall scope, or targets a group it is not bound to. Distinct from transient HTTP failures so
+/// callers can treat it as a configuration/authorization problem rather than retry.
+/// </summary>
+public sealed class AtlasFirewallAuthorizationException : Exception
+{
+    public AtlasFirewallAuthorizationException(string message) : base(message) { }
+}

--- a/Quilt4Net.Toolkit/Features/Atlas/AtlasFirewallClient.cs
+++ b/Quilt4Net.Toolkit/Features/Atlas/AtlasFirewallClient.cs
@@ -1,0 +1,73 @@
+using System.Net;
+using System.Net.Http.Json;
+using Quilt4Net.Toolkit.Features.ValueGroup;
+
+namespace Quilt4Net.Toolkit.Features.Atlas;
+
+/// <summary>
+/// <see cref="IAtlasFirewallClient"/> bound to one <see cref="AtlasFirewallProxyKeyEntry"/>. Sends the
+/// entry's API key as <c>X-API-KEY</c> per request (the key is per-entry, not per-client) and the
+/// entry's <c>GroupId</c> in each body. The base address is the Quilt4Net server (configured at
+/// registration).
+/// </summary>
+internal sealed class AtlasFirewallClient : IAtlasFirewallClient
+{
+    private readonly HttpClient _httpClient;
+    private readonly AtlasFirewallProxyKeyEntry _entry;
+
+    public AtlasFirewallClient(HttpClient httpClient, AtlasFirewallProxyKeyEntry entry)
+    {
+        _httpClient = httpClient;
+        _entry = entry;
+    }
+
+    public async Task<FirewallOpenResult> OpenAsync(string ip, string name = null, CancellationToken cancellationToken = default)
+    {
+        EnsureManage();
+        return await PostAsync<FirewallOpenResult>("Api/AtlasFirewall/open", new { groupId = _entry.GroupId, ip, name }, cancellationToken);
+    }
+
+    public async Task<FirewallCloseResult> CloseAsync(string ip, CancellationToken cancellationToken = default)
+    {
+        EnsureManage();
+        return await PostAsync<FirewallCloseResult>("Api/AtlasFirewall/close", new { groupId = _entry.GroupId, ip }, cancellationToken);
+    }
+
+    public Task<FirewallUsageResult> ReportUsedAsync(string ip, CancellationToken cancellationToken = default)
+        => PostAsync<FirewallUsageResult>("Api/AtlasFirewall/used", new { groupId = _entry.GroupId, ip }, cancellationToken);
+
+    public async Task<FirewallStateResult> GetStateAsync(string ip, CancellationToken cancellationToken = default)
+    {
+        var uri = $"Api/AtlasFirewall/state?groupId={Uri.EscapeDataString(_entry.GroupId ?? string.Empty)}&ip={Uri.EscapeDataString(ip ?? string.Empty)}";
+        using var request = new HttpRequestMessage(HttpMethod.Get, uri);
+        request.Headers.Add("X-API-KEY", _entry.ApiKey);
+        using var response = await _httpClient.SendAsync(request, cancellationToken);
+        if (response.StatusCode == HttpStatusCode.NotFound) return null;
+        await ThrowIfUnauthorizedOrFailed(response);
+        return await response.Content.ReadFromJsonAsync<FirewallStateResult>(cancellationToken);
+    }
+
+    private async Task<T> PostAsync<T>(string path, object body, CancellationToken cancellationToken)
+    {
+        using var request = new HttpRequestMessage(HttpMethod.Post, path) { Content = JsonContent.Create(body) };
+        request.Headers.Add("X-API-KEY", _entry.ApiKey);
+        using var response = await _httpClient.SendAsync(request, cancellationToken);
+        await ThrowIfUnauthorizedOrFailed(response);
+        return await response.Content.ReadFromJsonAsync<T>(cancellationToken);
+    }
+
+    private void EnsureManage()
+    {
+        if (!_entry.CanManage)
+            throw new InvalidOperationException(
+                "This firewall key is usage-only (firewall:usage) and cannot open or close the firewall. Use a manage key, or call ReportUsedAsync.");
+    }
+
+    private static async Task ThrowIfUnauthorizedOrFailed(HttpResponseMessage response)
+    {
+        if (response.StatusCode is HttpStatusCode.Unauthorized or HttpStatusCode.Forbidden)
+            throw new AtlasFirewallAuthorizationException(
+                $"Server returned {(int)response.StatusCode} {response.StatusCode} for a firewall call. The key may be revoked, lack the required firewall scope, or target a group it is not bound to.");
+        response.EnsureSuccessStatusCode();
+    }
+}

--- a/Quilt4Net.Toolkit/Features/Atlas/AtlasFirewallClientFactory.cs
+++ b/Quilt4Net.Toolkit/Features/Atlas/AtlasFirewallClientFactory.cs
@@ -1,0 +1,28 @@
+using Quilt4Net.Toolkit.Features.ValueGroup;
+
+namespace Quilt4Net.Toolkit.Features.Atlas;
+
+internal sealed class AtlasFirewallClientFactory : IAtlasFirewallClientFactory
+{
+    /// <summary>Named <see cref="IHttpClientFactory"/> client (BaseAddress + timeout set at registration).</summary>
+    public const string HttpClientName = "Quilt4Net.AtlasFirewall";
+
+    private readonly IHttpClientFactory _httpClientFactory;
+
+    public AtlasFirewallClientFactory(IHttpClientFactory httpClientFactory)
+    {
+        _httpClientFactory = httpClientFactory;
+    }
+
+    public IAtlasFirewallClient Create(AtlasFirewallProxyKeyEntry entry)
+    {
+        ArgumentNullException.ThrowIfNull(entry);
+        if (string.IsNullOrWhiteSpace(entry.ApiKey))
+            throw new ArgumentException("AtlasFirewallProxyKeyEntry.ApiKey is required.", nameof(entry));
+        if (string.IsNullOrWhiteSpace(entry.GroupId))
+            throw new ArgumentException("AtlasFirewallProxyKeyEntry.GroupId is required.", nameof(entry));
+
+        var httpClient = _httpClientFactory.CreateClient(HttpClientName);
+        return new AtlasFirewallClient(httpClient, entry);
+    }
+}

--- a/Quilt4Net.Toolkit/Features/Atlas/AtlasFirewallClientOptions.cs
+++ b/Quilt4Net.Toolkit/Features/Atlas/AtlasFirewallClientOptions.cs
@@ -1,0 +1,11 @@
+namespace Quilt4Net.Toolkit.Features.Atlas;
+
+/// <summary>
+/// Options for the Atlas firewall proxy client. Only the Quilt4Net server address is needed — the
+/// per-call API key and group come from the <c>AtlasFirewallProxyKeyEntry</c> in the value-group bundle.
+/// </summary>
+public class AtlasFirewallClientOptions
+{
+    public string Quilt4NetAddress { get; set; } = "https://quilt4net.com/";
+    public TimeSpan HttpTimeout { get; set; } = TimeSpan.FromSeconds(10);
+}

--- a/Quilt4Net.Toolkit/Features/Atlas/IAtlasFirewallClient.cs
+++ b/Quilt4Net.Toolkit/Features/Atlas/IAtlasFirewallClient.cs
@@ -1,0 +1,56 @@
+namespace Quilt4Net.Toolkit.Features.Atlas;
+
+/// <summary>
+/// Typed client over Quilt4Net's firewall proxy endpoints for a single Atlas project, bound to one
+/// <c>AtlasFirewallProxyKeyEntry</c> (from a value-group bundle). Quilt4Net performs the Atlas change;
+/// the caller never holds an Atlas credential. Create via <see cref="IAtlasFirewallClientFactory"/>.
+/// </summary>
+public interface IAtlasFirewallClient
+{
+    /// <summary>Open <paramref name="ip"/> (IP or CIDR) on the project's access list. Requires a manage key. Idempotent.</summary>
+    Task<FirewallOpenResult> OpenAsync(string ip, string name = null, CancellationToken cancellationToken = default);
+
+    /// <summary>Close (remove) <paramref name="ip"/> from the access list. Requires a manage key.</summary>
+    Task<FirewallCloseResult> CloseAsync(string ip, CancellationToken cancellationToken = default);
+
+    /// <summary>Report that <paramref name="ip"/> is in use so Quilt4Net defers auto-closing it (heartbeat). Works with any firewall key.</summary>
+    Task<FirewallUsageResult> ReportUsedAsync(string ip, CancellationToken cancellationToken = default);
+
+    /// <summary>Current state of <paramref name="ip"/>, or null if it is neither tracked nor open. Works with any firewall key.</summary>
+    Task<FirewallStateResult> GetStateAsync(string ip, CancellationToken cancellationToken = default);
+}
+
+/// <summary>Result of <see cref="IAtlasFirewallClient.OpenAsync"/>. <see cref="Outcome"/>: Opened | AlreadyOpen | Failed.</summary>
+public record FirewallOpenResult
+{
+    public string Outcome { get; init; }
+    public string Ip { get; init; }
+    public DateTime? OpenedUtc { get; init; }
+    public DateTime? LastUsedUtc { get; init; }
+    public DateTime? ClosesAtUtc { get; init; }
+}
+
+/// <summary>Result of <see cref="IAtlasFirewallClient.CloseAsync"/>. <see cref="Outcome"/>: Closed | NotOpen | Failed.</summary>
+public record FirewallCloseResult
+{
+    public string Outcome { get; init; }
+}
+
+/// <summary>Result of <see cref="IAtlasFirewallClient.ReportUsedAsync"/>. <see cref="Outcome"/>: Recorded | RecordedNoCredential.</summary>
+public record FirewallUsageResult
+{
+    public string Outcome { get; init; }
+    public DateTime? LastUsedUtc { get; init; }
+    public DateTime? ClosesAtUtc { get; init; }
+}
+
+/// <summary>Result of <see cref="IAtlasFirewallClient.GetStateAsync"/>.</summary>
+public record FirewallStateResult
+{
+    public string Ip { get; init; }
+    public bool IsOpen { get; init; }
+    public DateTime? OpenedUtc { get; init; }
+    public DateTime? LastUsedUtc { get; init; }
+    public DateTime? ClosesAtUtc { get; init; }
+    public bool IsPermanent { get; init; }
+}

--- a/Quilt4Net.Toolkit/Features/Atlas/IAtlasFirewallClientFactory.cs
+++ b/Quilt4Net.Toolkit/Features/Atlas/IAtlasFirewallClientFactory.cs
@@ -1,0 +1,13 @@
+using Quilt4Net.Toolkit.Features.ValueGroup;
+
+namespace Quilt4Net.Toolkit.Features.Atlas;
+
+/// <summary>
+/// Creates an <see cref="IAtlasFirewallClient"/> for a specific firewall key. The key (and group) are
+/// per-entry — typically obtained from a <see cref="ValueGroupBundle"/> — so clients are created on
+/// demand rather than registered as a singleton with a fixed key.
+/// </summary>
+public interface IAtlasFirewallClientFactory
+{
+    IAtlasFirewallClient Create(AtlasFirewallProxyKeyEntry entry);
+}

--- a/Quilt4Net.Toolkit/Features/ValueGroup/AtlasFirewallProxyKeyEntry.cs
+++ b/Quilt4Net.Toolkit/Features/ValueGroup/AtlasFirewallProxyKeyEntry.cs
@@ -1,0 +1,25 @@
+namespace Quilt4Net.Toolkit.Features.ValueGroup;
+
+/// <summary>
+/// A Quilt4Net firewall API key delivered in a <see cref="ValueGroupBundle"/>. It lets a consumer open
+/// the Atlas firewall (and/or report usage) for one Atlas project <b>through the Quilt4Net proxy</b> —
+/// the Atlas Project-Owner Service Account never leaves the server, and no Atlas credential is handed
+/// out. Build a typed client with <c>IAtlasFirewallClientFactory.Create(entry)</c>.
+/// </summary>
+public record AtlasFirewallProxyKeyEntry
+{
+    public string Name { get; init; }
+
+    /// <summary>
+    /// The Quilt4Net API key (bearer for the firewall endpoints). Treat as a secret — do not log.
+    /// Carries <c>firewall:manage</c> when <see cref="CanManage"/> is true (open/close), otherwise
+    /// <c>firewall:usage</c> (report-used / state only).
+    /// </summary>
+    public string ApiKey { get; init; }
+
+    /// <summary>The Atlas project (group) this key is bound to; sent with every firewall call.</summary>
+    public string GroupId { get; init; }
+
+    /// <summary>True if the key can open/close the firewall; false if it can only report usage.</summary>
+    public bool CanManage { get; init; }
+}

--- a/Quilt4Net.Toolkit/Features/ValueGroup/ValueGroupBundle.cs
+++ b/Quilt4Net.Toolkit/Features/ValueGroup/ValueGroupBundle.cs
@@ -18,4 +18,5 @@ public record ValueGroupBundle
     public KeyValueEntry[] KeyValues { get; init; } = [];
     public AtlasDatabaseAccessEntry[] AtlasDatabaseAccesses { get; init; } = [];
     public AtlasFirewallCredentialEntry[] AtlasFirewallCredentials { get; init; } = [];
+    public AtlasFirewallProxyKeyEntry[] AtlasFirewallProxyKeys { get; init; } = [];
 }


### PR DESCRIPTION
Release PR: **develop → master**. Changes on develop since the 0.7.18 release.

## Added — Atlas firewall proxy-key client
Lets a consumer open the Atlas firewall (and report usage) **through the Quilt4Net proxy** using a scoped key delivered in a value-group bundle — the Atlas Project-Owner Service Account never leaves the server, and no Atlas credential is handed out.

- `AtlasFirewallProxyKeyEntry` { Name, ApiKey, GroupId, CanManage } added to `ValueGroupBundle.AtlasFirewallProxyKeys` (additive — older clients keep deserializing).
- `IAtlasFirewallClient` — `OpenAsync` / `CloseAsync` (require a manage key) / `ReportUsedAsync` / `GetStateAsync` (any firewall key), over `/Api/AtlasFirewall/{open,close,used,state}`.
- `IAtlasFirewallClientFactory.Create(entry)` + `AddQuilt4NetAtlasFirewallClient` registration (X-API-KEY + groupId are per bundle entry).
- `AtlasFirewallAuthorizationException` on 401/403.

Additive only — **not breaking**. This is the client `Tharga/MongoDB#111` can consume.

After merge + publish, the Server bumps `Quilt4Net.Toolkit.*` and delivers the proxy key via the bundle resolver.