### PR TITLE
Reusable monitor components: version-matrix toggles & Configs, LogView Configs (+ docs)

### DIFF
--- a/Quilt4Net.Toolkit.Blazor/Features/Log/LogView.razor
+++ b/Quilt4Net.Toolkit.Blazor/Features/Log/LogView.razor
@@ -21,11 +21,21 @@
 <CascadingValue Name="ApplicationAliasMap" Value="@_effectiveAliasMap">
 <CascadingValue Name="FilterStorageScope" Value="@FilterStorageScope">
 <CascadingValue Name="SourcePathRoots" Value="@SourcePathRoots">
-    <RadzenRow Style="margin-bottom: 6px;" Visible="@(_selector != null || ShowRangeSelector || ShowEnvironmentSelector)">
+    <RadzenRow Style="margin-bottom: 6px;" Visible="@(_selector != null || Configs is { Count: > 1 } || ShowRangeSelector || ShowEnvironmentSelector)">
         @if (_selector != null && _selector.Available.Count > 1)
         {
             <RadzenColumn>
                 <ApplicationInsightsConfigurationDropdown />
+            </RadzenColumn>
+        }
+        else if (Configs is { Count: > 1 })
+        {
+            <RadzenColumn>
+                <RadzenStack Orientation="Orientation.Vertical" Gap="0">
+                    <RadzenText TextStyle="TextStyle.Caption" Text="Configuration" />
+                    <RadzenDropDown Data="@Configs" @bind-Value="_selectedConfig" TValue="ApplicationInsightsConfigurationResponse"
+                                    TextProperty="Name" Change="@(_ => OnConfigChanged())" />
+                </RadzenStack>
             </RadzenColumn>
         }
         <RadzenColumn Visible="@ShowRangeSelector">
@@ -90,9 +100,10 @@
     private string _configError;
     private LoggingErrorBoundary _errorBoundary;
     private IApplicationInsightsConfigurationSelector _selector;
+    private ApplicationInsightsConfigurationResponse _selectedConfig;
 
     private IApplicationInsightsContext EffectiveContext
-        => Context ?? _selector?.Selected;
+        => Context ?? _selectedConfig ?? _selector?.Selected;
 
     [Parameter]
     public bool ShowRangeSelector { get; set; } = true;
@@ -108,6 +119,16 @@
 
     [Parameter]
     public IApplicationInsightsContext Context { get; set; }
+
+    /// <summary>
+    /// Explicit set of configurations to choose from, each carrying its own credentials. Use this when
+    /// the host already has the configurations in hand (e.g. a team's workspaces) rather than via the
+    /// DI <see cref="IApplicationInsightsConfigurationSelector"/>. A dropdown is shown when more than
+    /// one is supplied; the selected one is queried. Ignored when <see cref="Context"/> is set; takes
+    /// precedence over the DI selector.
+    /// </summary>
+    [Parameter]
+    public IReadOnlyList<ApplicationInsightsConfigurationResponse> Configs { get; set; }
 
     /// <summary>
     /// Optional path for the log detail page, e.g. "/log/detail".
@@ -201,7 +222,8 @@
             return;
         }
 
-        if (Context == null)
+        // Explicit Configs (or a single Context) bypass the DI selector entirely.
+        if (Context == null && Configs is not { Count: > 0 })
         {
             _selector = ServiceProvider.GetService<IApplicationInsightsConfigurationSelector>();
             if (_selector != null)
@@ -245,6 +267,10 @@
 
     protected override void OnParametersSet()
     {
+        // Default to the first explicit config (when supplied) before the first render.
+        if (_selectedConfig == null && Configs is { Count: > 0 })
+            _selectedConfig = Configs[0];
+
         _navOptions = new LogNavigationOptions
         {
             DetailPath = DetailPath,
@@ -276,6 +302,14 @@
 
         if (OnTabChanged.HasDelegate)
             await OnTabChanged.InvokeAsync(tabName);
+    }
+
+    private void OnConfigChanged()
+    {
+        // New workspace selected: drop the environment chosen for the previous one (the environment
+        // selector re-resolves for the new Context), then re-query.
+        _environment = null;
+        StateHasChanged();
     }
 
     private void OnRangeSelected(LogRangeSelector.TimeRangeOption range)

--- a/Quilt4Net.Toolkit.Blazor/Features/VersionMatrix/VersionMatrixDisplay.razor
+++ b/Quilt4Net.Toolkit.Blazor/Features/VersionMatrix/VersionMatrixDisplay.razor
@@ -27,6 +27,14 @@
         {
             <RadzenText TextStyle="TextStyle.Caption" Text="@($"Updated {_view.LastRefreshedUtc:u}")" />
         }
+        <RadzenStack Orientation="Orientation.Horizontal" AlignItems="AlignItems.Center" Gap="0.4rem">
+            <RadzenSwitch @bind-Value="_showDevelopment" TValue="bool" Name="showDevelopment" />
+            <RadzenLabel Component="showDevelopment" Text="Show Development" />
+        </RadzenStack>
+        <RadzenStack Orientation="Orientation.Horizontal" AlignItems="AlignItems.Center" Gap="0.4rem">
+            <RadzenSwitch @bind-Value="_showUnknown" TValue="bool" Name="showUnknown" />
+            <RadzenLabel Component="showUnknown" Text="Show Unknown" />
+        </RadzenStack>
     </RadzenStack>
 
     @if (_loading)
@@ -49,22 +57,24 @@
     }
     else
     {
+        var visibleEnvironments = VisibleEnvironments();
+        var visibleApplications = VisibleApplications(visibleEnvironments);
         <table class="version-matrix">
             <thead>
                 <tr>
                     <th>Application</th>
-                    @foreach (var env in _orderedEnvironments)
+                    @foreach (var env in visibleEnvironments)
                     {
                         <th>@env</th>
                     }
                 </tr>
             </thead>
             <tbody>
-                @foreach (var app in _view.Applications)
+                @foreach (var app in visibleApplications)
                 {
                     <tr>
                         <td><strong>@app</strong></td>
-                        @foreach (var env in _orderedEnvironments)
+                        @foreach (var env in visibleEnvironments)
                         {
                             <td>
                                 @if (_view.TryGetCell(app, env, out var cell))
@@ -162,6 +172,15 @@
     private IApplicationInsightsConfigurationSelector _selector;
     private IEnumerable<string> _selectedIds = [];
 
+    // Column toggles (off by default). When off, the matching environment column is hidden, and any
+    // application row left with no values in the remaining columns is hidden too.
+    private bool _showDevelopment;
+    private bool _showUnknown;
+
+    // EnvironmentOrdering maps a null/blank environment to this sentinel (internal there, so matched literally).
+    private const string DevelopmentEnvironment = "Development";
+    private const string UnknownEnvironment = "(unknown)";
+
     /// <summary>
     /// The configurations to query and merge into one matrix: the explicit <see cref="Context"/> when
     /// given; otherwise the selected configurations — or <b>all</b> of them when none are selected
@@ -209,6 +228,23 @@
     {
         await LoadAsync(forceRefresh: true);
     }
+
+    /// <summary>The ordered environments minus the columns hidden by the toggles.</summary>
+    private IReadOnlyList<string> VisibleEnvironments()
+        => _orderedEnvironments.Where(IsEnvironmentVisible).ToList();
+
+    private bool IsEnvironmentVisible(string environment)
+    {
+        if (!_showDevelopment && string.Equals(environment, DevelopmentEnvironment, StringComparison.OrdinalIgnoreCase)) return false;
+        if (!_showUnknown && string.Equals(environment, UnknownEnvironment, StringComparison.OrdinalIgnoreCase)) return false;
+        return true;
+    }
+
+    /// <summary>Applications that still have at least one value once the hidden columns are removed.</summary>
+    private IReadOnlyList<string> VisibleApplications(IReadOnlyList<string> visibleEnvironments)
+        => _view.Applications
+            .Where(app => visibleEnvironments.Any(env => _view.TryGetCell(app, env, out _)))
+            .ToList();
 
     private async Task LoadAsync(bool forceRefresh)
     {

--- a/Quilt4Net.Toolkit.Blazor/Features/VersionMatrix/VersionMatrixDisplay.razor
+++ b/Quilt4Net.Toolkit.Blazor/Features/VersionMatrix/VersionMatrixDisplay.razor
@@ -12,11 +12,11 @@
 @implements IDisposable
 
 <RadzenStack Orientation="Orientation.Vertical" Gap="1rem">
-    @if (_selector != null && _selector.Available.Count > 1)
+    @if (Context == null && AvailableConfigs().Count > 1)
     {
         <RadzenStack Orientation="Orientation.Vertical" Gap="0">
             <RadzenText TextStyle="TextStyle.Caption" Text="Configurations" />
-            <RadzenSelectBar Data="@_selector.Available" @bind-Value="_selectedIds"
+            <RadzenSelectBar Data="@AvailableConfigs()" @bind-Value="_selectedIds"
                              Change="@(EventCallback.Factory.Create<IEnumerable<string>>(this, _ => LoadAsync(false)))"
                              TextProperty="Name" ValueProperty="Id" Multiple="true" AllowSelectAll="false" />
         </RadzenStack>
@@ -136,6 +136,16 @@
     [Parameter]
     public IApplicationInsightsContext Context { get; set; }
 
+    /// <summary>
+    /// Explicit set of configurations to query and merge, each carrying its own credentials. Use this
+    /// when the host already has the configurations in hand (e.g. a team's workspaces) rather than via
+    /// the DI <see cref="IApplicationInsightsConfigurationSelector"/>. When more than one is supplied,
+    /// a select-bar lets the user choose which to include (none selected = all). Ignored when
+    /// <see cref="Context"/> is set; takes precedence over the DI selector when both are available.
+    /// </summary>
+    [Parameter]
+    public IReadOnlyList<ApplicationInsightsConfigurationResponse> Configs { get; set; }
+
     [Parameter]
     public TimeSpan? Lookback { get; set; }
 
@@ -182,26 +192,36 @@
     private const string UnknownEnvironment = "(unknown)";
 
     /// <summary>
+    /// The available configurations: the explicit <see cref="Configs"/> when supplied, otherwise the
+    /// DI selector's list (empty when neither is present).
+    /// </summary>
+    private IReadOnlyList<ApplicationInsightsConfigurationResponse> AvailableConfigs()
+        => Configs is { Count: > 0 } ? Configs : (_selector?.Available ?? []);
+
+    /// <summary>
     /// The configurations to query and merge into one matrix: the explicit <see cref="Context"/> when
-    /// given; otherwise the selected configurations — or <b>all</b> of them when none are selected
-    /// (the default); otherwise a single <c>null</c> context so the service falls back to the locally
-    /// configured options.
+    /// given; otherwise the selected entries from <see cref="AvailableConfigs"/> — or <b>all</b> of
+    /// them when none are selected (the default); otherwise a single <c>null</c> context so the service
+    /// falls back to the locally configured options.
     /// </summary>
     private IReadOnlyList<IApplicationInsightsContext> SelectedContexts()
     {
         if (Context != null) return [Context];
-        if (_selector == null || _selector.Available.Count == 0) return [null];
+
+        var available = AvailableConfigs();
+        if (available.Count == 0) return [null];
 
         var ids = _selectedIds?.ToArray() ?? [];
         IEnumerable<ApplicationInsightsConfigurationResponse> chosen = ids.Length == 0
-            ? _selector.Available
-            : _selector.Available.Where(c => ids.Contains(c.Id));
+            ? available
+            : available.Where(c => ids.Contains(c.Id));
         return chosen.Cast<IApplicationInsightsContext>().ToArray();
     }
 
     protected override async Task OnInitializedAsync()
     {
-        if (Context == null)
+        // Only engage the DI selector when neither an explicit Context nor explicit Configs are given.
+        if (Context == null && Configs is not { Count: > 0 })
         {
             _selector = ServiceProvider.GetService<IApplicationInsightsConfigurationSelector>();
             if (_selector != null)

--- a/Quilt4Net.Toolkit.Blazor/README.md
+++ b/Quilt4Net.Toolkit.Blazor/README.md
@@ -226,6 +226,7 @@ The host then stops needing any `Quilt4Net:ApplicationInsights` block; only `Qui
 | `ShowEnvironmentSelector` | `true` | Show environment dropdown. |
 | `Environment` | `null` | Override the environment. |
 | `Context` | `null` | Application Insights context. |
+| `Configs` | `null` | Explicit list of `ApplicationInsightsConfigurationResponse` to choose from (e.g. a team's workspaces). When more than one is supplied, `LogView` shows a dropdown and queries the selected one — so a host that already holds the workspaces can render `LogView` directly instead of wrapping it in a custom picker. Precedence: `Context` > selected `Configs` entry > built-in remote selector. |
 | `DetailPath` | `null` | Path for the detail page (see below). |
 | `SummaryPath` | `null` | Path for the summary page (see below). |
 | `Tab` | `null` | Initially selected tab name (e.g. `"summary"`). Typically bound from a `?tab=` query parameter. |
@@ -449,12 +450,15 @@ protected override async Task OnInitializedAsync()
 | Parameter | Default | Description |
 |-----------|---------|-------------|
 | `Context` | `null` | AI context. Leave `null` to use the built-in workspace selector (remote mode) or the configured options (local mode). |
+| `Configs` | `null` | Explicit list of `ApplicationInsightsConfigurationResponse` to merge (e.g. a team's workspaces), with a multi-select bar (none selected = all). Lets a host that already holds the workspaces reuse this component instead of duplicating the grid. Precedence: `Context` > `Configs` > built-in remote selector. |
 | `Lookback` | toolkit default | How far back to scan for version entries. |
 | `EnvironmentOrder` | `ApplicationInsightsOptions.EnvironmentOrder` | Column (environment) ordering. |
 | `AliasFolder` | `null` | Optional `raw → logical` folding delegate. When `null`, falls back to `ApplicationInsightsOptions.ApplicationAlias`. |
 | `ConfigurationPath` | `null` | When set, an "Edit configuration" link is shown on authentication-failure alerts. |
 
-When the team has more than one configured workspace (remote mode) it renders a built-in **multi-select radio bar**: toggle one or more workspaces and their version data is merged into a single matrix; selecting none shows all. (`LogView` uses a single-select dropdown for the same purpose.)
+When the team has more than one configured workspace (remote mode, or an explicit `Configs` list) it renders a built-in **multi-select radio bar**: toggle one or more workspaces and their version data is merged into a single matrix; selecting none shows all. (`LogView` uses a single-select dropdown for the same purpose.)
+
+Two column toggles — **Show Development** and **Show Unknown** — are off by default. Each hides its environment column (`Development` / `(unknown)`) and drops any application row left without values in the remaining columns, so dev-only / unknown-only apps stay out of the default view. Toggling is instant (no re-query).
 
 ## Developer monitoring pages
 

--- a/docs/articles/log-views.md
+++ b/docs/articles/log-views.md
@@ -12,6 +12,24 @@ Drop-in Blazor components that render Application Insights data fetched via `IAp
 
 Renders the Search / Summary / Measure / Count tabs against the AI workspace configured by `AddQuilt4NetApplicationInsightsClient`. Detail and Summary drill-downs open in a Radzen dialog.
 
+## Supplying configurations
+
+`LogView` queries one workspace at a time. Point it at one, in precedence order:
+
+| Source | Use when |
+|---|---|
+| `Context` | A single workspace (or the locally configured one). |
+| `Configs` | You already hold an explicit set (e.g. a team's). `LogView` renders a dropdown to pick one when more than one is supplied. |
+| DI selector | You registered `AddQuilt4NetBlazorApplicationInsightsClientRemote`; the built-in dropdown is driven by it. |
+
+`Configs` is an `IReadOnlyList<ApplicationInsightsConfigurationResponse>`, so a host that already has the team's workspaces in hand can render `LogView` directly instead of wrapping it in a custom picker:
+
+```razor
+<LogView Configs="@_workspaces" FilterStorageScope="@team.Key" />
+```
+
+Precedence: `Context` > selected `Configs` entry > DI selector.
+
 ## Dedicated detail / summary pages
 
 ```razor

--- a/docs/articles/version-matrix.md
+++ b/docs/articles/version-matrix.md
@@ -13,6 +13,33 @@
 
 The component fetches via `IVersionMatrixService` (in-memory cached, singleton — registered automatically by `AddQuilt4NetApplicationInsightsClient`), then renders. The Refresh button bypasses the cache.
 
+## Supplying configurations
+
+Three ways to tell the component which workspace(s) to query, in precedence order:
+
+| Source | Use when |
+|---|---|
+| `Context` | You have one workspace (or the locally configured one via `ApplicationInsightsContextExtensions.Current`). |
+| `Configs` | You already hold an explicit set of workspaces (e.g. a team's). A multi-select bar lets the user choose which to include — none selected merges them all. |
+| DI selector | You registered `AddQuilt4NetBlazorApplicationInsightsClientRemote`; the component resolves the configurations and renders the picker itself. |
+
+`Configs` is an `IReadOnlyList<ApplicationInsightsConfigurationResponse>`, each carrying its own credentials — so a host that already has the team's workspaces in hand can reuse this component instead of duplicating the grid:
+
+```razor
+<VersionMatrixDisplay Configs="@_workspaces" />
+```
+
+Precedence: `Context` > `Configs` > DI selector > locally configured options.
+
+## Showing or hiding environment columns
+
+Two toolbar toggles, **both off by default**:
+
+- **Show Development** — the `Development` column.
+- **Show Unknown** — the `(unknown)` column (cells with no environment tag).
+
+When a toggle is off that column is hidden, **and** any application row left with no values in the remaining columns drops out too — so workspaces that only report dev / unknown data don't clutter the default view. Toggling is instant (no re-query).
+
 ## Environment ordering
 
 By default environments render in the order **Development → CI → Staging → Test → Production**, then any unrecognised names alphabetically, then `(unknown)` last (cells with empty `cloud_RoleInstance` env tags).


### PR DESCRIPTION
Lets a host reuse the shared monitor components with its own set of workspaces (so Quilt4Net.Server's per-team pages can drop their duplicates), plus two new version-matrix column toggles. Additive — **not breaking**.

## VersionMatrixDisplay
- **`Show Development` / `Show Unknown` toggles** (both off by default). Each hides its environment column (`Development` / `(unknown)`) and drops any application row left with no values in the remaining columns. Instant, no re-query.
- **`Configs` input** — explicit `IReadOnlyList<ApplicationInsightsConfigurationResponse>` with the same multi-select merge the DI-selector path offered. Precedence: `Context` > `Configs` > DI selector > local options.

## LogView
- **`Configs` input** — explicit list with a single-select dropdown (logs view one workspace at a time). Precedence: `Context` > selected `Configs` entry > DI selector.

Together with the existing `AliasFolder` / `EnvironmentOrder` / `ApplicationAliasMap` / `FilterStorageScope` parameters, the Server's team monitor + log pages can render these components directly and delete their `AiConfigVersionMatrix` / `AiConfigLog` wrappers (Server-side follow-up after this publishes).

## Docs
- `docs/articles/version-matrix.md`, `docs/articles/log-views.md`, and `Quilt4Net.Toolkit.Blazor/README.md` updated.

5 files changed, +155.