### PR TITLE
0.8: shared-scope default for toggles/config + version-matrix resilience

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@ on:
     branches: [master]
 
 env:
-  MAJOR_MINOR: '0.7'
+  MAJOR_MINOR: '0.8'
 
 permissions:
   contents: write

--- a/Quilt4Net.Toolkit.Api.Sample/Controllers/DataSampleController.cs
+++ b/Quilt4Net.Toolkit.Api.Sample/Controllers/DataSampleController.cs
@@ -40,14 +40,11 @@ public class DataSampleController : ControllerBase
 
         if (toggle) return Unauthorized();
 
-        var intValue = await _remoteConfigurationService.GetValueAsync("MyInt", 42);
-        var stringValue = await _remoteConfigurationService.GetValueAsync("MyString", "yeee");
-        var myDateValue = await _remoteConfigurationService.GetValueAsync("MyDate", DateTime.UtcNow);
-        //var myTimeSpanValue = await _featureToggleService.GetValueAsync("MyTimeSpanX", TimeSpan.FromSeconds(10));
-        var myDecimalValue = await _remoteConfigurationService.GetValueAsync("MyDecimal", 1.2M);
-        var mySingleValue = await _remoteConfigurationService.GetValueAsync("MySingle", 1.2F);
-        //var myNBool = await _featureToggleService.GetValueAsync<bool?>("MyNBool", false);
-        //var mySampleData = await _remoteConfigurationService.GetValueAsync("MySampleData", new SampleData { SomeDate = myDateValue, SomeInt = 123 });
+        var intValue = await _remoteConfigurationService.GetAsync("MyInt", 42);
+        var stringValue = await _remoteConfigurationService.GetAsync("MyString", "yeee");
+        var myDateValue = await _remoteConfigurationService.GetAsync("MyDate", DateTime.UtcNow);
+        var myDecimalValue = await _remoteConfigurationService.GetAsync("MyDecimal", 1.2M);
+        var mySingleValue = await _remoteConfigurationService.GetAsync("MySingle", 1.2F);
 
         _logger.LogInformation("{Method} {Function} called with header {Header} and query {Query}.", "HttpGet", nameof(GetPayload), header, query);
         var data = new SampleData { SomeInt = intValue, SomeDate = myDateValue };

--- a/Quilt4Net.Toolkit.Api/Quilt4Net.Toolkit.Api.csproj
+++ b/Quilt4Net.Toolkit.Api/Quilt4Net.Toolkit.Api.csproj
@@ -10,7 +10,7 @@
 		<Product>Quilt4Net Toolkit Api</Product>
 		<Tag>Api health liveness readiness</Tag>
 		<Description>Support for API health, liveness, readiness, startup, metrics, version and dependencies.</Description>
-		<PackageIconUrl>https://quilt4net.com/quilt4net-48x48.png</PackageIconUrl>
+		<PackageIconUrl>https://thargelion.net/assets/product-quilt4net.png</PackageIconUrl>
 		<GenerateDocumentationFile>True</GenerateDocumentationFile>
 		<PackageReadmeFile>README.md</PackageReadmeFile>
 		<PackageProjectUrl>https://github.com/Quilt4/Quilt4Net.Toolkit</PackageProjectUrl>

--- a/Quilt4Net.Toolkit.Blazor.Server.Sample/Components/Pages/Home.razor
+++ b/Quilt4Net.Toolkit.Blazor.Server.Sample/Components/Pages/Home.razor
@@ -33,7 +33,7 @@
 
     protected override async Task OnInitializedAsync()
     {
-        _val = await RemoteConfigurationService.GetValueAsync<bool>("A");
+        _val = await RemoteConfigurationService.GetAsync<bool>("A");
         await base.OnInitializedAsync();
     }
 

--- a/Quilt4Net.Toolkit.Blazor.Tests/VersionMatrixDisplayResilienceTests.cs
+++ b/Quilt4Net.Toolkit.Blazor.Tests/VersionMatrixDisplayResilienceTests.cs
@@ -1,0 +1,116 @@
+using Bunit;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Quilt4Net.Toolkit;
+using Quilt4Net.Toolkit.Blazor.Features.VersionMatrix;
+using Quilt4Net.Toolkit.Features.ApplicationInsights;
+using Xunit;
+
+namespace Quilt4Net.Toolkit.Blazor.Tests;
+
+/// <summary>
+/// The version matrix fans out across every configured workspace and merges them into one grid.
+/// A single broken configuration (e.g. a stale ClientSecret on one workspace) must not blank the
+/// whole page — the working workspaces still render and the broken one is downgraded to a non-fatal
+/// "skipped" warning. Only when <i>every</i> configuration fails does the page show a fatal error.
+/// Regression for the prod incident where one bad AI config blanked /monitor/version while
+/// /monitor/log (single-config) kept working.
+/// </summary>
+public class VersionMatrixDisplayResilienceTests : BunitContext
+{
+    private const string GoodWorkspace = "good-workspace-id";
+    private const string BadWorkspace = "bad-workspace-id";
+
+    public VersionMatrixDisplayResilienceTests()
+    {
+        Services.AddLogging();
+        Services.AddSingleton(Options.Create(new ApplicationInsightsOptions()));
+    }
+
+    private static ApplicationInsightsConfigurationResponse Config(string name, string workspaceId) => new()
+    {
+        Id = workspaceId,
+        Name = name,
+        TenantId = "tenant",
+        WorkspaceId = workspaceId,
+        ClientId = "client",
+        ClientSecret = "secret",
+    };
+
+    [Fact]
+    public void One_failing_config_still_renders_the_others_and_warns()
+    {
+        Services.AddSingleton<IVersionMatrixService>(new PartialFailureVersionMatrixService());
+
+        var cut = Render<VersionMatrixDisplay>(p => p
+            .Add(c => c.Configs, new[] { Config("Good config", GoodWorkspace), Config("Bad config", BadWorkspace) })
+            .Add(c => c.ConfigurationPath, "/monitor/configuration"));
+
+        cut.WaitForAssertion(() =>
+        {
+            // The healthy workspace's data renders.
+            cut.Markup.Should().Contain("WebApp");
+            cut.Markup.Should().Contain("1.2.3");
+            // The broken one is a non-fatal warning that names the config and offers the fix link.
+            cut.Markup.Should().Contain("skipped");
+            cut.Markup.Should().Contain("Bad config");
+            cut.Markup.Should().Contain("Edit configuration");
+            // ...and NOT the fatal "whole page failed" alert.
+            cut.Markup.Should().NotContain("Failed to load version matrix");
+        });
+    }
+
+    [Fact]
+    public void All_failing_configs_show_the_fatal_error_with_an_incident_id()
+    {
+        Services.AddSingleton<IVersionMatrixService>(new AllFailVersionMatrixService());
+
+        var cut = Render<VersionMatrixDisplay>(p => p
+            .Add(c => c.Configs, new[] { Config("First", BadWorkspace), Config("Second", BadWorkspace + "-2") })
+            .Add(c => c.ConfigurationPath, "/monitor/configuration"));
+
+        cut.WaitForAssertion(() =>
+        {
+            cut.Markup.Should().Contain("Failed to load version matrix");
+            cut.Markup.Should().MatchRegex(@"\[Incident:\s+[2-9A-HJ-NP-Z]{6}\]");
+            cut.Markup.Should().Contain("Edit configuration");
+            // No grid rendered.
+            cut.Markup.Should().NotContain("WebApp");
+        });
+    }
+
+    private sealed class PartialFailureVersionMatrixService : IVersionMatrixService
+    {
+        public Task<VersionMatrixView> GetAsync(IApplicationInsightsContext context, TimeSpan? lookback = null, CancellationToken cancellationToken = default)
+        {
+            if (context.WorkspaceId == BadWorkspace)
+                // "AADSTS" in the message makes ApplicationInsightsErrorMessage classify it as an auth failure.
+                throw new InvalidOperationException("AADSTS7000215: Invalid client secret provided.");
+
+            return Task.FromResult(VersionMatrixView.FromCells(new[]
+            {
+                new VersionMatrixCell
+                {
+                    ApplicationName = "WebApp",
+                    Environment = "Production",
+                    Version = "1.2.3",
+                    LastSeen = DateTime.UtcNow,
+                    Source = VersionMatrixSource.Startup,
+                },
+            }));
+        }
+
+        public Task<VersionMatrixView> RefreshAsync(IApplicationInsightsContext context, TimeSpan? lookback = null, CancellationToken cancellationToken = default)
+            => GetAsync(context, lookback, cancellationToken);
+    }
+
+    private sealed class AllFailVersionMatrixService : IVersionMatrixService
+    {
+        public Task<VersionMatrixView> GetAsync(IApplicationInsightsContext context, TimeSpan? lookback = null, CancellationToken cancellationToken = default)
+            => throw new InvalidOperationException("AADSTS7000215: Invalid client secret provided.");
+
+        public Task<VersionMatrixView> RefreshAsync(IApplicationInsightsContext context, TimeSpan? lookback = null, CancellationToken cancellationToken = default)
+            => GetAsync(context, lookback, cancellationToken);
+    }
+}

--- a/Quilt4Net.Toolkit.Blazor/Features/Configuration/RemoteConfigurationAdmin.razor
+++ b/Quilt4Net.Toolkit.Blazor/Features/Configuration/RemoteConfigurationAdmin.razor
@@ -106,7 +106,7 @@
 
     private async Task ReloadDataAsync()
     {
-        var model = await RemoteConfigurationService.GetTogglesAsync();
+        var model = await RemoteConfigurationService.GetAsync();
         _model = model.Where(x => !TogglesOnly || x.ValueType == "Boolean").ToArray();
         StateHasChanged();
     }
@@ -125,13 +125,13 @@
         var response = await DialogService.Confirm($"The toggle '{context.Key}' will be reset to default value '{context.DefaultValue}'.", "Confirm reset");
         if (response != true) return;
 
-        await RemoteConfigurationService.SetValueAsync(context.Key, context.Application, context.Environment, context.Instance, context.DefaultValue);
+        await RemoteConfigurationService.SetAsync(context.Key, context.Application, context.Environment, context.Instance, context.DefaultValue);
         await ReloadDataAsync();
     }
 
     private async Task SaveAsync(ConfigurationResponse model, string newValue)
     {
-        await RemoteConfigurationService.SetValueAsync(model.Key, model.Application, model.Environment, model.Instance, newValue);
+        await RemoteConfigurationService.SetAsync(model.Key, model.Application, model.Environment, model.Instance, newValue);
         await ReloadDataAsync();
     }
 }

--- a/Quilt4Net.Toolkit.Blazor/Features/VersionMatrix/VersionMatrixDisplay.razor
+++ b/Quilt4Net.Toolkit.Blazor/Features/VersionMatrix/VersionMatrixDisplay.razor
@@ -37,6 +37,17 @@
         </RadzenStack>
     </RadzenStack>
 
+    @if (_warning != null)
+    {
+        <RadzenAlert AlertStyle="AlertStyle.Warning" Title="Some configurations were skipped" AllowClose="false">
+            @_warning
+            @if (_warningIsAuthFailure && !string.IsNullOrEmpty(ConfigurationPath))
+            {
+                <text> </text><RadzenLink Path="@ConfigurationPath" Text="Edit configuration" />
+            }
+        </RadzenAlert>
+    }
+
     @if (_loading)
     {
         <RadzenText Text="Loading..." />
@@ -179,6 +190,9 @@
     private bool _loading;
     private string _error;
     private bool _errorIsAuthFailure;
+    // Non-fatal: set when some (but not all) configurations failed — the grid still renders for the rest.
+    private string _warning;
+    private bool _warningIsAuthFailure;
     private IApplicationInsightsConfigurationSelector _selector;
     private IEnumerable<string> _selectedIds = [];
 
@@ -271,21 +285,53 @@
         _loading = true;
         _error = null;
         _errorIsAuthFailure = false;
+        _warning = null;
+        _warningIsAuthFailure = false;
         StateHasChanged();
 
-        IApplicationInsightsContext current = null;
         try
         {
+            var contexts = SelectedContexts();
             var cells = new List<VersionMatrixCell>();
-            foreach (var context in SelectedContexts())
+            var failures = new List<(IApplicationInsightsContext Context, Exception Exception, string Message)>();
+
+            // Query each configuration independently. A single broken configuration (e.g. a stale
+            // ClientSecret on one workspace) must not blank the whole matrix — collect its failure and
+            // carry on so the remaining workspaces still render, then surface the skipped ones as a
+            // non-fatal warning. Only when *every* configuration fails do we fall back to a page error.
+            foreach (var context in contexts)
             {
-                current = context;
-                var view = forceRefresh
-                    ? await VersionMatrixService.RefreshAsync(context, Lookback)
-                    : await VersionMatrixService.GetAsync(context, Lookback);
-                cells.AddRange(view.Cells.Values);
+                try
+                {
+                    var view = forceRefresh
+                        ? await VersionMatrixService.RefreshAsync(context, Lookback)
+                        : await VersionMatrixService.GetAsync(context, Lookback);
+                    cells.AddRange(view.Cells.Values);
+                }
+                catch (Exception ex)
+                {
+                    var message = LogIncidentLogger.LogAndFormat(Logger, ex, nameof(VersionMatrixDisplay),
+                        "Failed to load version matrix.", context);
+                    failures.Add((context, ex, message));
+                }
             }
-            current = null;
+
+            if (failures.Count > 0 && failures.Count == contexts.Count)
+            {
+                // Nothing loaded — surface the first failure (incident-tagged) as the page error.
+                _error = failures[0].Message;
+                _errorIsAuthFailure = ApplicationInsightsErrorMessage.IsAuthenticationFailure(failures[0].Exception);
+                return;
+            }
+
+            if (failures.Count > 0)
+            {
+                var skipped = string.Join(", ", failures.Select(f => DescribeContext(f.Context)));
+                _warning = failures.Count == 1
+                    ? $"One configuration could not be loaded and was skipped: {skipped}."
+                    : $"{failures.Count} configurations could not be loaded and were skipped: {skipped}.";
+                _warningIsAuthFailure = failures.Any(f => ApplicationInsightsErrorMessage.IsAuthenticationFailure(f.Exception));
+            }
 
             var raw = VersionMatrixView.FromCells(cells);
 
@@ -309,8 +355,10 @@
         }
         catch (Exception ex)
         {
+            // Safety net for the post-query steps (alias folding / ordering); per-configuration query
+            // failures are already handled above and never reach here.
             _error = LogIncidentLogger.LogAndFormat(Logger, ex, nameof(VersionMatrixDisplay),
-                "Failed to load version matrix.", current);
+                "Failed to load version matrix.");
             _errorIsAuthFailure = ApplicationInsightsErrorMessage.IsAuthenticationFailure(ex);
         }
         finally
@@ -318,5 +366,13 @@
             _loading = false;
             StateHasChanged();
         }
+    }
+
+    /// <summary>A short label for a configuration, used in the "skipped" warning: its name when known,
+    /// otherwise the workspace id.</summary>
+    private static string DescribeContext(IApplicationInsightsContext context)
+    {
+        if (context is ApplicationInsightsConfigurationResponse { Name: { Length: > 0 } name }) return name;
+        return string.IsNullOrEmpty(context?.WorkspaceId) ? "the configured workspace" : $"workspace {context.WorkspaceId}";
     }
 }

--- a/Quilt4Net.Toolkit.Blazor/Quilt4Net.Toolkit.Blazor.csproj
+++ b/Quilt4Net.Toolkit.Blazor/Quilt4Net.Toolkit.Blazor.csproj
@@ -8,7 +8,7 @@
     <Authors>Thargelion AB</Authors>
     <Company>Thargelion AB</Company>
     <Product>Quilt4Net Blazor Toolkit</Product>
-    <PackageIconUrl>https://quilt4net.com/quilt4net-48x48.png</PackageIconUrl>
+    <PackageIconUrl>https://thargelion.net/assets/product-quilt4net.png</PackageIconUrl>
     <PackageProjectUrl>https://github.com/Quilt4/Quilt4Net.Toolkit</PackageProjectUrl>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>

--- a/Quilt4Net.Toolkit.Console.Sample/Program.cs
+++ b/Quilt4Net.Toolkit.Console.Sample/Program.cs
@@ -30,10 +30,10 @@ Console.WriteLine($"beta-features: {betaFeatures}");
 // Remote configuration
 Console.WriteLine();
 Console.WriteLine("=== Remote Configuration ===");
-var maxRetries = await configService.GetValueAsync("max-retries", fallback: 3);
+var maxRetries = await configService.GetAsync("max-retries", fallback: 3);
 Console.WriteLine($"max-retries: {maxRetries}");
 
-var welcomeMessage = await configService.GetValueAsync("welcome-message", fallback: "Hello!");
+var welcomeMessage = await configService.GetAsync("welcome-message", fallback: "Hello!");
 Console.WriteLine($"welcome-message: {welcomeMessage}");
 
 // Health client

--- a/Quilt4Net.Toolkit.Health/Quilt4Net.Toolkit.Health.csproj
+++ b/Quilt4Net.Toolkit.Health/Quilt4Net.Toolkit.Health.csproj
@@ -10,7 +10,7 @@
 		<Product>Quilt4Net Toolkit Health</Product>
 		<Tag>health liveness readiness</Tag>
 		<Description>Features for health, liveness, readiness, startup, metrics, version and dependencies. Adds a health API.</Description>
-		<PackageIconUrl>https://quilt4net.com/quilt4net-48x48.png</PackageIconUrl>
+		<PackageIconUrl>https://thargelion.net/assets/product-quilt4net.png</PackageIconUrl>
 		<GenerateDocumentationFile>True</GenerateDocumentationFile>
 		<PackageReadmeFile>README.md</PackageReadmeFile>
 		<PackageProjectUrl>https://github.com/Quilt4/Quilt4Net.Toolkit</PackageProjectUrl>

--- a/Quilt4Net.Toolkit.Mcp/Quilt4Net.Toolkit.Mcp.csproj
+++ b/Quilt4Net.Toolkit.Mcp/Quilt4Net.Toolkit.Mcp.csproj
@@ -8,7 +8,7 @@
     <Product>Quilt4Net Toolkit MCP</Product>
     <Tag>MCP ApplicationInsights</Tag>
     <Description>MCP (Model Context Protocol) provider for Quilt4Net.Toolkit. Exposes Application Insights query operations as MCP tools and resources, plugging into the Tharga.Mcp ecosystem so AI agents can look up incidents and correlate logs.</Description>
-    <PackageIconUrl>https://quilt4net.com/quilt4net-48x48.png</PackageIconUrl>
+    <PackageIconUrl>https://thargelion.net/assets/product-quilt4net.png</PackageIconUrl>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageProjectUrl>https://github.com/Quilt4/Quilt4Net.Toolkit</PackageProjectUrl>

--- a/Quilt4Net.Toolkit/Features/FeatureToggle/FeatureToggleService.cs
+++ b/Quilt4Net.Toolkit/Features/FeatureToggle/FeatureToggleService.cs
@@ -11,7 +11,8 @@ internal class FeatureToggleService : IFeatureToggleService
         _remoteConfigCallService = remoteConfigCallService;
     }
 
-    public async ValueTask<bool> GetToggleAsync(string key, bool fallback = false, TimeSpan? ttl = null, string application = null)
+    /// <inheritdoc />
+    public async ValueTask<bool> GetToggleAsync(string key, bool fallback = false, TimeSpan? ttl = null, string application = "")
     {
         return await _remoteConfigCallService.MakeCallAsync(key, fallback, ttl, application);
     }

--- a/Quilt4Net.Toolkit/Features/FeatureToggle/IRemoteConfigurationService.cs
+++ b/Quilt4Net.Toolkit/Features/FeatureToggle/IRemoteConfigurationService.cs
@@ -2,15 +2,9 @@
 
 public interface IRemoteConfigurationService
 {
-    [Obsolete($"Use {nameof(GetAsync)} instead.")]
-    ValueTask<T> GetValueAsync<T>(string key, T fallback = default, TimeSpan? ttl = null, string application = null);
     ValueTask<T> GetAsync<T>(string key, T fallback = default, TimeSpan? ttl = null, string application = null);
     ValueTask<bool> GetToggleAsync(string key, bool fallback = default, TimeSpan? ttl = null, string application = null);
-    [Obsolete($"Use {nameof(GetAsync)} instead.")]
-    Task<ConfigurationResponse[]> GetTogglesAsync();
     Task<ConfigurationResponse[]> GetAsync();
     Task DeleteAsync(string key, string application, string environment, string instance);
-    [Obsolete($"Use {nameof(SetAsync)} instead.")]
-    Task SetValueAsync(string key, string application, string environment, string instance, string value);
     Task SetAsync(string key, string application, string environment, string instance, string value);
 }

--- a/Quilt4Net.Toolkit/Features/FeatureToggle/IRemoteConfigurationService.cs
+++ b/Quilt4Net.Toolkit/Features/FeatureToggle/IRemoteConfigurationService.cs
@@ -1,10 +1,71 @@
-﻿namespace Quilt4Net.Toolkit.Features.FeatureToggle;
+namespace Quilt4Net.Toolkit.Features.FeatureToggle;
 
+/// <summary>
+/// Reads — and, for admin scenarios, writes — remote configuration values and feature toggles served by
+/// Quilt4Net. Read results are cached locally with stale-while-revalidate; a failed server call falls back
+/// to the last known value or the supplied <c>fallback</c>, so reads never throw.
+/// </summary>
 public interface IRemoteConfigurationService
 {
-    ValueTask<T> GetAsync<T>(string key, T fallback = default, TimeSpan? ttl = null, string application = null);
-    ValueTask<bool> GetToggleAsync(string key, bool fallback = default, TimeSpan? ttl = null, string application = null);
+    /// <summary>
+    /// Resolves a typed remote configuration value.
+    /// </summary>
+    /// <typeparam name="T">
+    /// Value type. Must be convertible from its string representation (e.g. <see cref="bool"/>,
+    /// <see cref="int"/>, <see cref="string"/>).
+    /// </typeparam>
+    /// <param name="key">Configuration key.</param>
+    /// <param name="fallback">Value returned when the key is unknown or the server is unreachable.</param>
+    /// <param name="ttl">
+    /// Optional client-requested cache lifetime. When <c>null</c>, the team/server-configured default applies.
+    /// </param>
+    /// <param name="application">
+    /// Which application's value to read:
+    /// <list type="bullet">
+    /// <item><description><b>Empty string (the default)</b> — the <b>shared</b>, cross-application value.</description></item>
+    /// <item><description><c>null</c> — the value for the configured <see cref="RemoteConfigurationOptions.Application"/>, or the entry assembly name when that is unset (i.e. "this application").</description></item>
+    /// <item><description>A specific name — the value for that named application.</description></item>
+    /// </list>
+    /// </param>
+    ValueTask<T> GetAsync<T>(string key, T fallback = default, TimeSpan? ttl = null, string application = "");
+
+    /// <summary>
+    /// Resolves a boolean feature toggle — shorthand for <see cref="GetAsync{T}"/> with <c>T</c> = <see cref="bool"/>.
+    /// </summary>
+    /// <param name="key">Toggle key.</param>
+    /// <param name="fallback">Value returned when the key is unknown or the server is unreachable.</param>
+    /// <param name="ttl">
+    /// Optional client-requested cache lifetime. When <c>null</c>, the team/server-configured default applies.
+    /// </param>
+    /// <param name="application">
+    /// Which application's toggle to read: empty string (the default) reads the <b>shared</b> value; <c>null</c>
+    /// reads the configured application's value (or the entry assembly name); a specific name reads that
+    /// application's value. See <see cref="GetAsync{T}"/> for details.
+    /// </param>
+    ValueTask<bool> GetToggleAsync(string key, bool fallback = default, TimeSpan? ttl = null, string application = "");
+
+    /// <summary>
+    /// Lists all configuration entries (feature toggles and configuration values) for the current
+    /// application and environment — for admin / overview UIs.
+    /// </summary>
     Task<ConfigurationResponse[]> GetAsync();
+
+    /// <summary>
+    /// Deletes a configuration entry. Requires a server API key carrying the <c>config:write</c> scope.
+    /// </summary>
+    /// <param name="key">Configuration key.</param>
+    /// <param name="application">Owning application; pass an empty string for a shared entry.</param>
+    /// <param name="environment">Owning environment.</param>
+    /// <param name="instance">Owning instance, or <c>null</c>.</param>
     Task DeleteAsync(string key, string application, string environment, string instance);
+
+    /// <summary>
+    /// Creates or updates a configuration value. Requires a server API key carrying the <c>config:write</c> scope.
+    /// </summary>
+    /// <param name="key">Configuration key.</param>
+    /// <param name="application">Owning application; pass an empty string for a shared entry.</param>
+    /// <param name="environment">Owning environment.</param>
+    /// <param name="instance">Owning instance, or <c>null</c>.</param>
+    /// <param name="value">New value (stored as its string representation).</param>
     Task SetAsync(string key, string application, string environment, string instance, string value);
 }

--- a/Quilt4Net.Toolkit/Features/FeatureToggle/RemoteConfigurationService.cs
+++ b/Quilt4Net.Toolkit/Features/FeatureToggle/RemoteConfigurationService.cs
@@ -9,26 +9,31 @@ internal class RemoteConfigurationService : IRemoteConfigurationService
         _remoteConfigCallService = remoteConfigCallService;
     }
 
-    public async ValueTask<T> GetAsync<T>(string key, T fallback = default, TimeSpan? ttl = null, string application = null)
+    /// <inheritdoc />
+    public async ValueTask<T> GetAsync<T>(string key, T fallback = default, TimeSpan? ttl = null, string application = "")
     {
         return await _remoteConfigCallService.MakeCallAsync(key, fallback, ttl, application);
     }
 
-    public ValueTask<bool> GetToggleAsync(string key, bool fallback = default, TimeSpan? ttl = null, string application = null)
+    /// <inheritdoc />
+    public ValueTask<bool> GetToggleAsync(string key, bool fallback = default, TimeSpan? ttl = null, string application = "")
     {
         return GetAsync(key, fallback, ttl, application);
     }
 
+    /// <inheritdoc />
     public Task<ConfigurationResponse[]> GetAsync()
     {
         return _remoteConfigCallService.GetAllAsync();
     }
 
+    /// <inheritdoc />
     public Task DeleteAsync(string key, string application, string environment, string instance)
     {
         return _remoteConfigCallService.DeleteAsync(key, application, environment, instance);
     }
 
+    /// <inheritdoc />
     public Task SetAsync(string key, string application, string environment, string instance, string value)
     {
         return _remoteConfigCallService.SetValueAsync(key, application, environment, instance, value);

--- a/Quilt4Net.Toolkit/Features/FeatureToggle/RemoteConfigurationService.cs
+++ b/Quilt4Net.Toolkit/Features/FeatureToggle/RemoteConfigurationService.cs
@@ -9,12 +9,6 @@ internal class RemoteConfigurationService : IRemoteConfigurationService
         _remoteConfigCallService = remoteConfigCallService;
     }
 
-    [Obsolete($"Use {nameof(GetAsync)} instead.")]
-    public ValueTask<T> GetValueAsync<T>(string key, T fallback = default, TimeSpan? ttl = null, string application = null)
-    {
-        return GetAsync(key, fallback, ttl, application);
-    }
-
     public async ValueTask<T> GetAsync<T>(string key, T fallback = default, TimeSpan? ttl = null, string application = null)
     {
         return await _remoteConfigCallService.MakeCallAsync(key, fallback, ttl, application);
@@ -25,12 +19,6 @@ internal class RemoteConfigurationService : IRemoteConfigurationService
         return GetAsync(key, fallback, ttl, application);
     }
 
-    [Obsolete($"Use {nameof(GetAsync)} instead.")]
-    public Task<ConfigurationResponse[]> GetTogglesAsync()
-    {
-        return GetAsync();
-    }
-
     public Task<ConfigurationResponse[]> GetAsync()
     {
         return _remoteConfigCallService.GetAllAsync();
@@ -39,12 +27,6 @@ internal class RemoteConfigurationService : IRemoteConfigurationService
     public Task DeleteAsync(string key, string application, string environment, string instance)
     {
         return _remoteConfigCallService.DeleteAsync(key, application, environment, instance);
-    }
-
-    [Obsolete($"Use {nameof(SetAsync)} instead.")]
-    public Task SetValueAsync(string key, string application, string environment, string instance, string value)
-    {
-        return SetAsync(key, application, environment, instance, value);
     }
 
     public Task SetAsync(string key, string application, string environment, string instance, string value)

--- a/Quilt4Net.Toolkit/Framework/IFeatureToggleService.cs
+++ b/Quilt4Net.Toolkit/Framework/IFeatureToggleService.cs
@@ -1,6 +1,23 @@
-﻿namespace Quilt4Net.Toolkit.Framework;
+namespace Quilt4Net.Toolkit.Framework;
 
+/// <summary>
+/// Minimal feature-toggle accessor: resolves a boolean flag from Quilt4Net remote configuration.
+/// </summary>
 public interface IFeatureToggleService
 {
-    ValueTask<bool> GetToggleAsync(string key, bool fallback = false, TimeSpan? ttl = null, string application = null);
+    /// <summary>
+    /// Resolves a boolean feature toggle. The value is cached locally with stale-while-revalidate and
+    /// falls back to <paramref name="fallback"/> when the key is unknown or the server is unreachable.
+    /// </summary>
+    /// <param name="key">Toggle key.</param>
+    /// <param name="fallback">Value returned when the key is unknown or the server is unreachable.</param>
+    /// <param name="ttl">
+    /// Optional client-requested cache lifetime. When <c>null</c>, the team/server-configured default applies.
+    /// </param>
+    /// <param name="application">
+    /// Which application's toggle to read: <b>empty string (the default)</b> reads the <b>shared</b>,
+    /// cross-application value; <c>null</c> reads the configured application's value (or the entry assembly
+    /// name); a specific name reads that named application's value.
+    /// </param>
+    ValueTask<bool> GetToggleAsync(string key, bool fallback = false, TimeSpan? ttl = null, string application = "");
 }

--- a/Quilt4Net.Toolkit/Quilt4Net.Toolkit.csproj
+++ b/Quilt4Net.Toolkit/Quilt4Net.Toolkit.csproj
@@ -8,7 +8,7 @@
     <Product>Quilt4Net Toolkit Client</Product>
     <Tag>Health ApplicationInsights</Tag>
     <Description>Tools for Health checks via Quilt4Net.Toolkit.Api and Application Insigts.</Description>
-    <PackageIconUrl>https://quilt4net.com/quilt4net-48x48.png</PackageIconUrl>
+    <PackageIconUrl>https://thargelion.net/assets/product-quilt4net.png</PackageIconUrl>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageProjectUrl>https://github.com/Quilt4/Quilt4Net.Toolkit</PackageProjectUrl>

--- a/Quilt4Net.Toolkit/README.md
+++ b/Quilt4Net.Toolkit/README.md
@@ -58,8 +58,31 @@ public class MyService
 Inject `IRemoteConfigurationService` for typed configuration values.
 
 ```csharp
-var maxRetries = await _configService.GetValueAsync("MaxRetries", fallback: 3);
+var maxRetries = await _configService.GetAsync("MaxRetries", fallback: 3);
 ```
+
+### Application scoping (shared by default)
+
+Toggles and configuration are **shared across applications by default** — a call with just a key reads
+the team's shared value, so one flag controls every application that asks for it:
+
+```csharp
+// Shared (default): every application sees the same value.
+await _featureToggle.GetToggleAsync("new-feature");
+```
+
+To read a value specific to **one application**, pass its name explicitly:
+
+```csharp
+await _featureToggle.GetToggleAsync("new-feature", application: "billing-service");
+```
+
+Passing `application: null` resolves to the configured `RemoteConfigurationOptions.Application`, falling
+back to the entry assembly name — i.e. "this application".
+
+> **Changed in 0.8.0:** the default scope is now **shared** (`application: ""`). Previously a bare call
+> resolved to the current application. Pass `application: null` (or set `RemoteConfigurationOptions.Application`)
+> for the previous per-application behavior.
 
 ### RemoteConfigurationOptions
 
@@ -67,7 +90,9 @@ var maxRetries = await _configService.GetValueAsync("MaxRetries", fallback: 3);
 |----------|---------|-------------|
 | `ApiKey` | `null` | API key from [Quilt4Net Web](https://quilt4net.com). |
 | `Quilt4NetAddress` | `"https://quilt4net.com/"` | Quilt4Net server address. |
-| `Ttl` | `null` | Time-to-live for cached values. |
+| `Application` | `null` | Application used when a read passes `application: null`. When `null`, the entry assembly name is used; set to `""` to read shared values. The read methods' own `application` parameter defaults to `""` (shared), so this option only takes effect when a call explicitly passes `null`. |
+| `Ttl` | `null` | Client-requested time-to-live for cached values. When `null`, the team/server-configured default applies. |
+| `HttpTimeout` | `5s` | Timeout for HTTP calls to the server. |
 | `StaleWhileRevalidate` | `true` | When `true`, an expired value is returned immediately and refreshed in the background. Set `false` to refresh synchronously so callers always get a fresh value (subject to `HttpTimeout`). |
 
 Configuration path: `Quilt4Net:RemoteConfiguration`
@@ -149,7 +174,7 @@ builder.AddQuilt4NetApplicationInsightsClientRemote();
 ```
 Configuration path: `Quilt4Net:RemoteConfiguration` (the API key is also accepted at the top-level `Quilt4Net:ApiKey`). Keep the key in user-secrets or environment variables, not in committed config.
 
-The remote provider caches the configuration list per the `RemoteConfigurationOptions.Ttl` (default 5 min) with stale-while-revalidate, so transient server outages don't break the consuming page. When more than one workspace is configured on the server for the team, every workspace is reachable; the Blazor `LogView` renders an in-component **dropdown** (one workspace) and `VersionMatrixDisplay` a **multi-select radio bar** that merges the matrix across the selected workspaces — selecting none shows all (see [Quilt4Net.Toolkit.Blazor README](https://github.com/Quilt4/Quilt4Net.Toolkit/blob/master/Quilt4Net.Toolkit.Blazor/README.md)).
+The remote provider caches the configuration list per its configured TTL (`RemoteConfigurationOptions.Ttl`, or the server default when unset) with stale-while-revalidate, so transient server outages don't break the consuming page. When more than one workspace is configured on the server for the team, every workspace is reachable; the Blazor `LogView` renders an in-component **dropdown** (one workspace) and `VersionMatrixDisplay` a **multi-select radio bar** that merges the matrix across the selected workspaces — selecting none shows all (see [Quilt4Net.Toolkit.Blazor README](https://github.com/Quilt4/Quilt4Net.Toolkit/blob/master/Quilt4Net.Toolkit.Blazor/README.md)).
 
 > **Local and remote are mutually exclusive.** Register one or the other. If both a `Quilt4Net:ApplicationInsights` block and a remote `Quilt4Net:RemoteConfiguration` API key are configured, the remote source wins and the local block is silently ignored. In a Blazor host, use `AddQuilt4NetBlazorApplicationInsightsClientRemote()` so the workspace selector is wired up.
 

--- a/Quilt4Net.Toolkit/RemoteConfigurationOptions.cs
+++ b/Quilt4Net.Toolkit/RemoteConfigurationOptions.cs
@@ -13,10 +13,13 @@ public record RemoteConfigurationOptions
     public string ApiKey { get; set; }
 
     /// <summary>
-    /// Application name sent to the server when requesting toggle values.
-    /// If null (default), the entry assembly name is used.
-    /// Set to an empty string to always request shared (cross-application) values.
-    /// Set to a specific name to impersonate another application.
+    /// Application name used when a read passes <c>application: null</c> (i.e. "this application").
+    /// When <c>null</c> (the default), the entry assembly name is used. Set to an empty string to resolve
+    /// such calls to shared (cross-application) values, or to a specific name to impersonate another application.
+    /// <para>
+    /// Note: the read methods' own <c>application</c> parameter defaults to an empty string (shared), so
+    /// this option only takes effect for calls that explicitly pass <c>null</c>.
+    /// </para>
     /// </summary>
     public string Application { get; set; }
 


### PR DESCRIPTION
## Summary
Promotes the current `develop` to `master` for the **0.8** release.

### Changes
- **`feat(remote-config)!` — shared scope is now the default for feature toggles & remote config** (`9f2dece`).
  `GetAsync<T>` / `GetToggleAsync`'s `application` parameter now defaults to `""` (shared, cross-application)
  instead of `null` (current application). **Breaking**: a bare call with just a key now reads the team's
  shared value. Migration — pass `application: null` (or set `RemoteConfigurationOptions.Application`) for the
  previous per-application behavior. Includes XML docs on the public interfaces and a README "Application
  scoping" section. Version bumped to **0.8** (`build.yml` `MAJOR_MINOR`).
- **`fix(version-matrix)` — one bad workspace can't blank the grid** (`aca7e3a`).
  `VersionMatrixDisplay` now queries each configured workspace independently; a single failing configuration
  (e.g. a stale ClientSecret) is downgraded to a non-fatal "skipped" warning while the healthy workspaces
  still render. Only an all-fail case shows the page error. Adds `VersionMatrixDisplayResilienceTests`.
- **`refactor cleanup`** (`0d94a3c`) — sample/config tidy-up.
- **`chore`** (`9c6afe4`) — point `PackageIconUrl` at the thargelion.net asset.

### Tests
Core 163/163 and Blazor 65/65 green locally; build clean.
