### PR TITLE
fix(pack): bundle wwwroot static assets + AI auth docs

### DIFF
--- a/Quilt4Net.Toolkit.Blazor/Quilt4Net.Toolkit.Blazor.csproj
+++ b/Quilt4Net.Toolkit.Blazor/Quilt4Net.Toolkit.Blazor.csproj
@@ -18,12 +18,12 @@
   <ItemGroup>
     <InternalsVisibleTo Include="Quilt4Net.Toolkit.Blazor.Tests" />
   </ItemGroup>
-  <ItemGroup>
-    <Compile Remove="wwwroot\**" />
-    <Content Remove="wwwroot\**" />
-    <EmbeddedResource Remove="wwwroot\**" />
-    <None Remove="wwwroot\**" />
-  </ItemGroup>
+  <!-- wwwroot lives at the project root and the Razor SDK packs it under staticwebassets/ in
+       the nupkg automatically. Earlier <Compile/Content/EmbeddedResource/None Remove="wwwroot\**"/>
+       items were stripping it out of every item collection the SDK uses to discover static web
+       assets — silently shipping a package without browser-time-zone.js (and any future JS we
+       add). With those removed, dotnet pack now produces a nupkg with staticwebassets/, and
+       consumers can fetch _content/Quilt4Net.Toolkit.Blazor/<asset> at runtime. -->
   <ItemGroup>
     <PackageReference Include="Microsoft.Authentication.WebAssembly.Msal" Version="10.0.8" />
     <PackageReference Include="Microsoft.Identity.Client" Version="4.84.1" />

--- a/Quilt4Net.Toolkit.Blazor/README.md
+++ b/Quilt4Net.Toolkit.Blazor/README.md
@@ -308,7 +308,7 @@ View and search Application Insights logs with the `LogView` component. Requires
 builder.AddQuilt4NetApplicationInsightsClient();
 ```
 
-In local mode the host picks the auth flavour via the `AuthMode` option: `ClientSecret` (TenantId + ClientId + ClientSecret), `ManagedIdentity` (Azure-hosted, no secret in config), or `DefaultAzureCredential` (one config that works locally via `az login` and in Azure via MI). See the [`Quilt4Net.Toolkit` README — Managed Identity / DefaultAzureCredential sections](../Quilt4Net.Toolkit/README.md#managed-identity) for the full table, `appsettings.json` shape, and the Azure IAM step (Log Analytics Reader). The Log and Version components inherit whichever auth mode is configured — no per-component setting.
+In local mode the host picks the auth flavour via the `AuthMode` option: `ClientSecret` (TenantId + ClientId + ClientSecret), `ManagedIdentity` (Azure-hosted, no secret in config), or `DefaultAzureCredential` (one config that works locally via `az login` and in Azure via MI). See the [`Quilt4Net.Toolkit` README — Managed Identity / DefaultAzureCredential sections](../Quilt4Net.Toolkit/README.md#managed-identity) for the full table, `appsettings.json` shape, and the Azure IAM step (Log Analytics Reader). **All AI-querying components inherit whichever auth mode is configured** — `LogView`, `VersionMatrixDisplay`, `MetricsView`, `MetricChart`, `MetricLatestChart`, `LogCountView`, `LogCountByServiceView`, and `LogSummaryView` all go through one shared `LogsQueryClient` built once from the configured credential. No per-component setting.
 
 **Remote mode** — credentials are pulled from Quilt4Net.Server using an API key that carries the `monitor:read` scope:
 ```csharp

--- a/Quilt4Net.Toolkit.Blazor/README.md
+++ b/Quilt4Net.Toolkit.Blazor/README.md
@@ -308,6 +308,8 @@ View and search Application Insights logs with the `LogView` component. Requires
 builder.AddQuilt4NetApplicationInsightsClient();
 ```
 
+In local mode the host picks the auth flavour via the `AuthMode` option: `ClientSecret` (TenantId + ClientId + ClientSecret), `ManagedIdentity` (Azure-hosted, no secret in config), or `DefaultAzureCredential` (one config that works locally via `az login` and in Azure via MI). See the [`Quilt4Net.Toolkit` README — Managed Identity / DefaultAzureCredential sections](../Quilt4Net.Toolkit/README.md#managed-identity) for the full table, `appsettings.json` shape, and the Azure IAM step (Log Analytics Reader). The Log and Version components inherit whichever auth mode is configured — no per-component setting.
+
 **Remote mode** — credentials are pulled from Quilt4Net.Server using an API key that carries the `monitor:read` scope:
 ```csharp
 builder.AddQuilt4NetBlazorApplicationInsightsClientRemote();


### PR DESCRIPTION
## Summary

Three commits on develop ahead of master. Cut to release the pack fix as 0.8.2.

### Pack fix (the urgent one)

\`7a6a8ad\` **fix(pack): include wwwroot static assets in the nupkg**

The csproj had four \`<* Remove="wwwroot\**" />\` items stripping \`wwwroot\` out of every item collection the Razor SDK uses to discover static web assets. The nupkg shipped without \`staticwebassets/\` — any \`PackageReference\` consumer trying to fetch \`_content/Quilt4Net.Toolkit.Blazor/<asset>\` got a 404.

The bug was invisible until the metrics work added \`browser-time-zone.js\`. \`BrowserTimeZoneAccessor.LoadAsync()\` imports it dynamically from \`MetricsView.OnAfterRenderAsync\`, so \`/monitor/metrics\` in Quilt4Net.Server started throwing \"Failed to fetch dynamically imported module\" as soon as Server swapped from ProjectReference to PackageReference @ 0.8.1.

Verified by packing locally with the fix — the resulting nupkg now contains \`staticwebassets/browser-time-zone.js\` and the auto-generated \`build/Microsoft.AspNetCore.StaticWebAssets.props\`.

### Docs

\`a9235c7\` **docs(blazor): broaden AI-auth note to cover metrics + log count components** — the auth-mode cross-link previously read like it only applied to \`LogView\`. Reworded to call out that **all** AI-querying components inherit the configured \`AuthMode\` through one shared \`LogsQueryClient\`: \`LogView\`, \`VersionMatrixDisplay\`, \`MetricsView\`, \`MetricChart\`, \`MetricLatestChart\`, \`LogCountView\`, \`LogCountByServiceView\`, \`LogSummaryView\`.

\`8740f60\` **docs(blazor): cross-link AI auth modes from the Log viewer section** — initial cross-link from Toolkit.Blazor README to the Managed Identity / DefaultAzureCredential sections in the Toolkit README. Closes a discovery gap.

## Test plan

- [ ] CI green on this PR (build + tests + CodeQL)
- [ ] Once 0.8.2 is published, bump Quilt4Net.Server's PackageReferences from 0.8.1 → 0.8.2 and verify /monitor/metrics renders without the JS import error
- [ ] Verify the docs-after-release job fires once 0.8.2 cuts and updates the published docs site