### PR TITLE
Toolkit refresh: close #106, #107, #108 + package bumps

### DIFF
--- a/Quilt4Net.Toolkit.Api.Sample/Quilt4Net.Toolkit.Api.Sample.csproj
+++ b/Quilt4Net.Toolkit.Api.Sample/Quilt4Net.Toolkit.Api.Sample.csproj
@@ -12,7 +12,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="10.2.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="10.2.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Quilt4Net.Toolkit.Api.Tests/Quilt4Net.Toolkit.Api.Tests.csproj
+++ b/Quilt4Net.Toolkit.Api.Tests/Quilt4Net.Toolkit.Api.Tests.csproj
@@ -11,7 +11,7 @@
 		<PackageReference Include="JetBrains.Annotations" Version="2025.2.4" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
 		<PackageReference Include="Moq" Version="4.20.72" />
-		<PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.8" />
+		<PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.9" />
 		<PackageReference Include="OneOf" Version="3.0.271" />
 		<PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
 			<PrivateAssets>all</PrivateAssets>

--- a/Quilt4Net.Toolkit.Blazor.Tests/Quilt4ContentTests.cs
+++ b/Quilt4Net.Toolkit.Blazor.Tests/Quilt4ContentTests.cs
@@ -1,0 +1,146 @@
+using Bunit;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Quilt4Net.Toolkit.Features.Content;
+using Quilt4Net.Toolkit.Features.FeatureToggle;
+using Radzen;
+using Xunit;
+
+namespace Quilt4Net.Toolkit.Blazor.Tests;
+
+public class Quilt4ContentTests : BunitContext
+{
+    private readonly StubContentService _contentService = new();
+    private readonly RecordingLoggerProvider _loggerProvider = new();
+
+    public Quilt4ContentTests()
+    {
+        // Quilt4Content imports a dynamic data: URL and invokes getInnerHtml on the holder ref.
+        // Loose mode satisfies the import; an explicit module stub makes getInnerHtml return a
+        // non-empty string so the post-render condition (string.IsNullOrEmpty(_content)) becomes
+        // false and OnAfterRenderAsync doesn't loop forever.
+        JSInterop.Mode = JSRuntimeMode.Loose;
+        JSInterop.SetupModule(_ => true)
+            .Setup<string>("getInnerHtml", _ => true)
+            .SetResult("Default fallback");
+
+        Services.AddSingleton<IContentService>(_contentService);
+        Services.AddSingleton<IEditContentService>(new StubEditContentService());
+        Services.AddSingleton<ILanguageStateService>(new StubLanguageState());
+        Services.AddScoped<DialogService>();
+        Services.AddLogging(b => b.AddProvider(_loggerProvider));
+    }
+
+    [Fact]
+    public void Render_does_not_throw_when_auto_register_SetContentAsync_fails()
+    {
+        // Repro for issue #107: a 401 (or any other failure) on the first-render
+        // SetContentAsync write used to escape OnAfterRenderAsync and crash the page.
+        // The reads-degrade-gracefully contract now applies to the auto-register write too.
+        _contentService.SetContentThrow = new HttpRequestException(
+            "Response status code does not indicate success: 401 (Unauthorized).");
+
+        var act = () => Render<Quilt4Content>(p => p
+            .Add(x => x.Key, "test-key")
+            .AddChildContent("Default fallback"));
+
+        act.Should().NotThrow();
+    }
+
+    [Fact]
+    public void Failed_auto_register_logs_a_warning_naming_the_key()
+    {
+        _contentService.SetContentThrow = new HttpRequestException("401");
+
+        Render<Quilt4Content>(p => p
+            .Add(x => x.Key, "about-page")
+            .AddChildContent("Default"));
+
+        _loggerProvider.Entries.Should().Contain(e =>
+            e.Level == LogLevel.Warning && e.Message.Contains("about-page"));
+    }
+
+    [Fact]
+    public void Successful_auto_register_does_not_log_a_warning()
+    {
+        // Sanity-check the happy path didn't get noisier: a successful SetContentAsync should
+        // still pass through silently (no warning emitted from the new try/catch).
+        Render<Quilt4Content>(p => p
+            .Add(x => x.Key, "ok-key")
+            .AddChildContent("Default"));
+
+        _loggerProvider.Entries.Should().NotContain(e => e.Level == LogLevel.Warning);
+    }
+
+    private sealed class StubContentService : IContentService
+    {
+        public Exception SetContentThrow { get; set; }
+
+        public Task<(string Value, bool Success)> GetContentAsync(string key, string defaultValue,
+            Guid languageKey, ContentFormat? contentType, string application = null)
+            => Task.FromResult<(string, bool)>(("", true));
+
+        public Task SetContentAsync(string key, string value, Guid languageKey,
+            ContentFormat contentType, string application = null)
+        {
+            if (SetContentThrow != null) throw SetContentThrow;
+            return Task.CompletedTask;
+        }
+
+        public Task ClearCacheAsync() => Task.CompletedTask;
+    }
+
+    private sealed class StubEditContentService : IEditContentService
+    {
+        public event EventHandler<EditModeEventArgs> EditModeEvent;
+        public bool Enabled { get; set; }
+        private void Unused() => EditModeEvent?.Invoke(this, null);
+    }
+
+    private sealed class StubLanguageState : ILanguageStateService
+    {
+        public event EventHandler<LanguageLoadedEventArgs> LanguageLoadedEvent;
+        public event EventHandler<LanguageChangedEventArgs> LanguageChangedEvent;
+        public event EventHandler<DeveloperModeEventArgs> DeveloperModeEvent;
+
+        public Language Selected { get; set; } = new() { Name = "Default", Key = Guid.Empty };
+        public Language[] Languages { get; set; } = [];
+        public bool DeveloperMode { get; set; }
+
+        public Task<Language[]> ReloadAsync() => Task.FromResult(Languages);
+
+        private void Unused()
+        {
+            LanguageLoadedEvent?.Invoke(this, null);
+            LanguageChangedEvent?.Invoke(this, null);
+            DeveloperModeEvent?.Invoke(this, null);
+        }
+    }
+
+    private sealed class RecordingLoggerProvider : ILoggerProvider
+    {
+        public List<(LogLevel Level, string Message)> Entries { get; } = new();
+        public ILogger CreateLogger(string categoryName) => new RecordingLogger(Entries);
+        public void Dispose() { }
+
+        private sealed class RecordingLogger : ILogger
+        {
+            private readonly List<(LogLevel, string)> _entries;
+            public RecordingLogger(List<(LogLevel, string)> entries) => _entries = entries;
+            public IDisposable BeginScope<TState>(TState state) where TState : notnull => NullScope.Instance;
+            public bool IsEnabled(LogLevel logLevel) => true;
+            public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception,
+                Func<TState, Exception, string> formatter)
+            {
+                lock (_entries) _entries.Add((logLevel, formatter(state, exception)));
+            }
+        }
+
+        private sealed class NullScope : IDisposable
+        {
+            public static readonly NullScope Instance = new();
+            public void Dispose() { }
+        }
+    }
+}

--- a/Quilt4Net.Toolkit.Blazor.Wasm.Sample/Quilt4Net.Toolkit.Blazor.Wasm.Sample.csproj
+++ b/Quilt4Net.Toolkit.Blazor.Wasm.Sample/Quilt4Net.Toolkit.Blazor.Wasm.Sample.csproj
@@ -8,8 +8,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.8" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="10.0.8" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.9" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="10.0.9" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Quilt4Net.Toolkit.Blazor/Features/ApplicationInsights/ApplicationInsightsConfigurationSelector.cs
+++ b/Quilt4Net.Toolkit.Blazor/Features/ApplicationInsights/ApplicationInsightsConfigurationSelector.cs
@@ -7,6 +7,15 @@ internal class ApplicationInsightsConfigurationSelector : IApplicationInsightsCo
 {
     private const string StorageKeyPrefix = "Quilt4Net.Monitor.SelectedConfig.";
 
+    /// <summary>
+    /// Scope used when the caller doesn't pass one to <see cref="LoadAsync"/>. Without this, every
+    /// view that didn't opt in (MetricsView, LogCountByServiceView, VersionMatrixDisplay, plus
+    /// LogView when the host omits <c>FilterStorageScope</c>) silently dropped the selection on
+    /// every reload. Hosts that need per-team isolation still pass an explicit scope and get a
+    /// separate key.
+    /// </summary>
+    private const string DefaultStorageScope = "default";
+
     private readonly IApplicationInsightsConfigurationProvider _provider;
     private readonly ILocalStorageService _localStorage;
     private readonly SemaphoreSlim _loadGate = new(1, 1);
@@ -34,7 +43,12 @@ internal class ApplicationInsightsConfigurationSelector : IApplicationInsightsCo
         {
             if (IsLoaded) return;
 
-            _storageKey = !string.IsNullOrEmpty(storageScope) ? StorageKeyPrefix + storageScope : null;
+            // Fall back to the default scope when the caller doesn't supply one, so the dropdown
+            // remembers the operator's choice across page reloads without each view having to opt
+            // in. Explicit scopes (LogView's FilterStorageScope, anything host-supplied) still win
+            // and keep their per-team / per-tenant isolation.
+            var effectiveScope = !string.IsNullOrEmpty(storageScope) ? storageScope : DefaultStorageScope;
+            _storageKey = StorageKeyPrefix + effectiveScope;
             Available = await _provider.GetAllAsync(cancellationToken);
             IsLoaded = true;
 

--- a/Quilt4Net.Toolkit.Blazor/Features/ApplicationInsights/IApplicationInsightsConfigurationSelector.cs
+++ b/Quilt4Net.Toolkit.Blazor/Features/ApplicationInsights/IApplicationInsightsConfigurationSelector.cs
@@ -4,9 +4,12 @@ namespace Quilt4Net.Toolkit.Blazor.Features.ApplicationInsights;
 
 /// <summary>
 /// Holds the currently selected Application Insights configuration for a Blazor circuit.
-/// LogView and VersionMatrixDisplay both consume this in remote mode so they pick the
-/// same configuration when rendered side-by-side on one page. Selection optionally
-/// persists in localStorage when a storage scope is supplied.
+/// LogView, MetricsView, and VersionMatrixDisplay all consume this in remote mode so they pick
+/// the same configuration when rendered side-by-side on one page. Selection persists in
+/// localStorage by default — pages remember the operator's choice across reloads under a shared
+/// key (<c>Quilt4Net.Monitor.SelectedConfig.default</c>). Hosts that need per-team or per-tenant
+/// isolation can pass an explicit <c>storageScope</c> to <see cref="LoadAsync"/> to get a
+/// separate key.
 /// </summary>
 public interface IApplicationInsightsConfigurationSelector
 {
@@ -14,6 +17,12 @@ public interface IApplicationInsightsConfigurationSelector
     IReadOnlyList<ApplicationInsightsConfigurationResponse> Available { get; }
     bool IsLoaded { get; }
 
+    /// <summary>
+    /// Loads the available configurations and restores the previously selected one (if any) from
+    /// localStorage. <paramref name="storageScope"/> picks the localStorage key suffix; pass null
+    /// or empty to use the shared default scope. Idempotent — only the first call per circuit
+    /// hits the network; subsequent calls return immediately.
+    /// </summary>
     Task LoadAsync(string storageScope = null, CancellationToken cancellationToken = default);
     Task SelectAsync(string id);
 

--- a/Quilt4Net.Toolkit.Blazor/Features/Metrics/MetricLatestChart.razor
+++ b/Quilt4Net.Toolkit.Blazor/Features/Metrics/MetricLatestChart.razor
@@ -2,7 +2,7 @@
 
 @* Bar-per-host snapshot of the most recent value, with a delta-vs-window-start badge and a tiny
    sparkline of the trend. Used in place of <MetricChart> for metrics where the absolute current
-   value matters more than its shape over time (disk free is the canonical case — disk space
+   value matters more than its shape over time (disk used is the canonical case — disk space
    doesn't fluctuate minute-to-minute so a line chart degenerates into N flat lines that all
    require the operator to read the y-axis to make sense of them). *@
 <RadzenCard Style="padding: 1rem; min-height: 320px; display: flex; flex-direction: column;">
@@ -77,9 +77,10 @@
         border-radius: 4px;
         height: 10px;
         overflow: hidden;
-        /* Fill grows from the LEFT — the colored portion (free space) sits at the bar's left
-           edge, the empty portion fills the right. Natural reading direction: a longer fill
-           means more free, shorter means filling up. */
+        /* Fill grows from the LEFT — the coloured portion shows the metric value as a percent of
+           capacity. For disk-used (the LessIsBad=false case), a longer fill = more used = bar
+           amber over 80% and red over 90%; for free-style metrics (LessIsBad=true) a longer fill
+           means more available. Either way the fill represents the value, not the inverse. */
     }
     .quilt-metric-bar-fill {
         background: var(--rz-primary, #2196f3);
@@ -126,10 +127,10 @@
     [Parameter] public DiskCapacity[] Capacity { get; set; } = [];
 
     /// <summary>
-    /// True when a downward trend is bad — appropriate for "free / available" metrics like
-    /// Disk free where less is worse. When false (utilisation metrics like CPU/memory %),
-    /// an upward trend is bad instead. The colour and arrow direction of the delta badge
-    /// follows this flag.
+    /// True (default) when a downward trend is bad — appropriate for "free / available" metrics
+    /// where less is worse. False flips it: an upward trend is bad (utilisation metrics like CPU,
+    /// memory %, or disk used) — the bar turns amber over 80% of capacity and red over 90%. The
+    /// colour and arrow direction of the delta badge follows this flag too.
     /// </summary>
     [Parameter] public bool LessIsBad { get; set; } = true;
 

--- a/Quilt4Net.Toolkit.Blazor/Features/Metrics/MetricsView.razor
+++ b/Quilt4Net.Toolkit.Blazor/Features/Metrics/MetricsView.razor
@@ -65,12 +65,13 @@
     <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(420px, 1fr)); gap: 1rem;">
         <MetricChart Title="CPU %" Unit="%" Samples="@_cpu" Loading="@_busy" FullPercentScale="@_fullPercentScale" />
         <MetricChart Title="Memory %" Unit="%" Samples="@_memory" Loading="@_busy" FullPercentScale="@_fullPercentScale" />
-        @* Disk free uses a bar-per-host snapshot — over a 1h/24h/7d window the value barely
-           moves so a line chart degenerates into N flat lines. The bar gives the current value
-           at a glance, the delta badge (▼ −1.2 GB / 24h) signals trend direction with a
-           free-space-is-good colour scheme, and the inline sparkline keeps the shape visible
-           for cases where a sudden drop matters. *@
-        <MetricLatestChart Title="Disk free (GB)" Unit="GB" Samples="@_disk" Capacity="@_diskCapacity" Range="@_window" Loading="@_busy" LessIsBad="true" />
+        @* Disk used uses a bar-per-host snapshot — over a 1h/24h/7d window the value barely
+           moves so a line chart degenerates into N flat lines. The bar fills as the volume fills
+           up (longer = more used), and the chart's LessIsBad=false threshold logic turns the bar
+           amber over 80% and red over 90% of capacity. The delta badge (▲ +1.2 GB / 24h) signals
+           growth with a utilisation-is-bad colour scheme; the inline sparkline keeps the shape
+           visible for cases where a sudden spike matters. *@
+        <MetricLatestChart Title="Disk used (GB)" Unit="GB" Samples="@_disk" Capacity="@_diskCapacity" Range="@_window" Loading="@_busy" LessIsBad="false" />
         @* Network values commonly span 3-4 orders of magnitude across hosts — idle web boxes sit
            at ~0.01 MB/s while a single backup job spikes to 50+ MB/s. On a linear axis the idle
            hosts vanish into a flat line at the bottom; log scale gives each host's shape its own
@@ -195,11 +196,16 @@
             StateHasChanged();
             _memory = await Ai.GetMemoryUtilizationAsync(ctx, _window).ToArrayAsync();
             StateHasChanged();
-            _disk = await Ai.GetDiskFreeAsync(ctx, _window).ToArrayAsync();
+            var freeSamples = await Ai.GetDiskFreeAsync(ctx, _window).ToArrayAsync();
             StateHasChanged();
             // Capacity is sequenced with the other queries so a single-query failure can't leave
             // the bars half-rendered. It's quick — one KQL pass that aggregates per volume.
             _diskCapacity = await Ai.GetDiskCapacityAsync(ctx, _window).ToArrayAsync();
+            // The server still queries disk-free (operator-meaningful in the KQL view), but the UI
+            // shows disk-used so the bar fills as the volume fills. We transform per series here
+            // because the cache stores whatever we display, and we want a cache hit to skip the
+            // capacity-join the second time.
+            _disk = ToDiskUsed(freeSamples, _diskCapacity);
             StateHasChanged();
             _network = await Ai.GetNetworkThroughputAsync(ctx, _window).ToArrayAsync();
             // Stamp the load completion. Only on success — a failed load shouldn't claim freshness.
@@ -237,5 +243,39 @@
     public void Dispose()
     {
         if (_selector != null) _selector.OnChanged -= OnSelectorChanged;
+    }
+
+    /// <summary>
+    /// Turn a disk-free series into disk-used by subtracting each sample's value from the volume's
+    /// total capacity (joined on <see cref="MetricSample.Series"/>). Volumes with no matching
+    /// capacity entry fall through to their original free value — a degraded state, but the
+    /// alternative is dropping the row entirely which is worse for the operator. Negative deltas
+    /// (free &gt; reported capacity, possible during a brief capacity expansion window) clamp to 0.
+    /// </summary>
+    private static MetricSample[] ToDiskUsed(MetricSample[] freeSamples, DiskCapacity[] capacities)
+    {
+        if (freeSamples == null || freeSamples.Length == 0) return [];
+
+        var capacityByVolume = (capacities ?? [])
+            .Where(c => c.TotalGb > 0)
+            .GroupBy(c => c.Series ?? "", System.StringComparer.OrdinalIgnoreCase)
+            .ToDictionary(g => g.Key, g => g.First().TotalGb, System.StringComparer.OrdinalIgnoreCase);
+
+        var transformed = new MetricSample[freeSamples.Length];
+        for (var i = 0; i < freeSamples.Length; i++)
+        {
+            var s = freeSamples[i];
+            if (capacityByVolume.TryGetValue(s.Series ?? "", out var total))
+            {
+                var used = total - s.Value;
+                if (used < 0) used = 0;
+                transformed[i] = s with { Value = used };
+            }
+            else
+            {
+                transformed[i] = s;        // no capacity → leave the value alone
+            }
+        }
+        return transformed;
     }
 }

--- a/Quilt4Net.Toolkit.Blazor/Quilt4Content.razor
+++ b/Quilt4Net.Toolkit.Blazor/Quilt4Content.razor
@@ -1,6 +1,7 @@
 ﻿@using System.Net.Http.Json
 @using System.Text.RegularExpressions
 @using Microsoft.AspNetCore.Components.Web
+@using Microsoft.Extensions.Logging
 @using Microsoft.JSInterop
 @using Quilt4Net.Toolkit.Features.Content
 @using Quilt4Net.Toolkit.Features.FeatureToggle
@@ -9,6 +10,7 @@
 @inject IEditContentService EditContentService
 @inject ILanguageStateService LanguageStateService
 @inject DialogService DialogService
+@inject ILogger<Quilt4Content> Logger
 
 <span style="@(string.IsNullOrEmpty(_content) ? "display:none" : _edit)" @onclick="OpenDialog" role="button" tabindex="0" @onkeydown="OnKeyDown">
     @((MarkupString)(_content ?? ""))
@@ -91,12 +93,21 @@
 
             if (_response.Success)
             {
-                await ContentService.SetContentAsync(Key, defaultHtml, Guid.Empty, ContentFormat.Html);
+                // Auto-registering the default value is best-effort: a transient HTTP failure
+                // (401, server unreachable, etc.) must not crash the consuming page — the
+                // component still renders the Default fallback below. Reads already behave this
+                // way; this matches them.
+                try
+                {
+                    await ContentService.SetContentAsync(Key, defaultHtml, Guid.Empty, ContentFormat.Html);
+                }
+                catch (Exception e)
+                {
+                    Logger.LogWarning(e, "Failed to auto-register default content for key '{Key}'. Rendering fallback.", Key);
+                }
             }
 
             _content = defaultHtml;
-
-
             StateHasChanged();
         }
     }

--- a/Quilt4Net.Toolkit.Blazor/Quilt4Net.Toolkit.Blazor.csproj
+++ b/Quilt4Net.Toolkit.Blazor/Quilt4Net.Toolkit.Blazor.csproj
@@ -25,9 +25,9 @@
        add). With those removed, dotnet pack now produces a nupkg with staticwebassets/, and
        consumers can fetch _content/Quilt4Net.Toolkit.Blazor/<asset> at runtime. -->
   <ItemGroup>
-    <PackageReference Include="Microsoft.Authentication.WebAssembly.Msal" Version="10.0.8" />
-    <PackageReference Include="Microsoft.Identity.Client" Version="4.84.1" />
-    <PackageReference Include="Tharga.Blazor" Version="2.1.6" />
+    <PackageReference Include="Microsoft.Authentication.WebAssembly.Msal" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Identity.Client" Version="4.84.2" />
+    <PackageReference Include="Tharga.Blazor" Version="2.2.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Quilt4Net.Toolkit\Quilt4Net.Toolkit.csproj" />
@@ -36,6 +36,6 @@
     <PackageReference Include="Microsoft.AspNetCore.Components.Authorization" Version="9.0.15" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
-    <PackageReference Include="Microsoft.AspNetCore.Components.Authorization" Version="10.0.8" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.Authorization" Version="10.0.9" />
   </ItemGroup>
 </Project>

--- a/Quilt4Net.Toolkit.Console.Sample/Quilt4Net.Toolkit.Console.Sample.csproj
+++ b/Quilt4Net.Toolkit.Console.Sample/Quilt4Net.Toolkit.Console.Sample.csproj
@@ -12,7 +12,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.8" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.9" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Quilt4Net.Toolkit.Health.Tests/Quilt4Net.Toolkit.Health.Tests.csproj
+++ b/Quilt4Net.Toolkit.Health.Tests/Quilt4Net.Toolkit.Health.Tests.csproj
@@ -10,7 +10,7 @@
 		<PackageReference Include="FluentAssertions" Version="8.10.0" />
 		<PackageReference Include="JetBrains.Annotations" Version="2025.2.4" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
-		<PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.8" />
+		<PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.9" />
 		<PackageReference Include="Moq" Version="4.20.72" />
 		<PackageReference Include="OneOf" Version="3.0.271" />
 		<PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">

--- a/Quilt4Net.Toolkit.Mcp/Quilt4Net.Toolkit.Mcp.csproj
+++ b/Quilt4Net.Toolkit.Mcp/Quilt4Net.Toolkit.Mcp.csproj
@@ -32,7 +32,7 @@
     <InternalsVisibleTo Include="DynamicProxyGenAssembly2" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Tharga.Mcp" Version="0.1.4" />
+    <PackageReference Include="Tharga.Mcp" Version="0.1.6" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.300">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Quilt4Net.Toolkit.Tests/FeatureToggleTests.cs
+++ b/Quilt4Net.Toolkit.Tests/FeatureToggleTests.cs
@@ -26,7 +26,7 @@ public class FeatureToggleTests
             var ctx = await listener.GetContextAsync();
             ctx.Response.StatusCode = 401;
             ctx.Response.Close();
-        });
+        }, TestContext.Current.CancellationToken);
 
         try
         {
@@ -93,7 +93,7 @@ public class FeatureToggleTests
             var ctx = await listener.GetContextAsync();
             ctx.Response.StatusCode = 500;
             ctx.Response.Close();
-        });
+        }, TestContext.Current.CancellationToken);
 
         try
         {
@@ -162,7 +162,7 @@ public class FeatureToggleTests
                 await ctx.Response.OutputStream.WriteAsync(buf);
                 ctx.Response.Close();
             }
-        });
+        }, TestContext.Current.CancellationToken);
 
         try
         {
@@ -233,7 +233,7 @@ public class FeatureToggleTests
                 await ctx.Response.OutputStream.WriteAsync(buf);
                 ctx.Response.Close();
             }
-        });
+        }, TestContext.Current.CancellationToken);
 
         var recorder = new RecordingLoggerProvider();
         try

--- a/Quilt4Net.Toolkit.Tests/FeatureToggleTests.cs
+++ b/Quilt4Net.Toolkit.Tests/FeatureToggleTests.cs
@@ -2,6 +2,7 @@ using System.Net;
 using FluentAssertions;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
 using Quilt4Net.Toolkit.Features.FeatureToggle;
 using Quilt4Net.Toolkit.Framework;
 using Xunit;
@@ -202,5 +203,100 @@ public class FeatureToggleTests
         var port = ((IPEndPoint)l.LocalEndpoint).Port;
         l.Stop();
         return port;
+    }
+
+    [Fact]
+    public async Task GetToggleAsync_Logs_Resolution_Result_At_Debug_Not_Information()
+    {
+        // Issue #108: the per-resolution "Configuration '{Key}' resolved … Source: …" lines fired
+        // on every flag check and dwarfed any actionable telemetry (~449k Information traces/week
+        // per app at Eplicta, ~99% Cache hits). They must log at Debug now so Application Insights
+        // (default Information threshold) doesn't ingest them. Errors / warnings / background-
+        // refresh value-change lines stay at their original levels.
+        var port = GetFreePort();
+        var prefix = $"http://127.0.0.1:{port}/";
+        using var listener = new HttpListener();
+        listener.Prefixes.Add(prefix);
+        listener.Start();
+
+        var listenerTask = Task.Run(async () =>
+        {
+            while (listener.IsListening)
+            {
+                HttpListenerContext ctx;
+                try { ctx = await listener.GetContextAsync(); }
+                catch { return; }
+                ctx.Response.StatusCode = 200;
+                ctx.Response.ContentType = "application/json";
+                var body = $$"""{"value":"True","validTo":"{{DateTime.UtcNow.AddHours(1):o}}"}""";
+                var buf = System.Text.Encoding.UTF8.GetBytes(body);
+                await ctx.Response.OutputStream.WriteAsync(buf);
+                ctx.Response.Close();
+            }
+        });
+
+        var recorder = new RecordingLoggerProvider();
+        try
+        {
+            var host = Host.CreateDefaultBuilder()
+                .ConfigureServices(services =>
+                {
+                    services.AddQuilt4NetRemoteConfiguration(null, o =>
+                    {
+                        o.Quilt4NetAddress = prefix;
+                        o.ApiKey = "test-key";
+                    });
+                    services.AddLogging(b =>
+                    {
+                        b.ClearProviders();
+                        b.SetMinimumLevel(LogLevel.Debug);
+                        b.AddProvider(recorder);
+                    });
+                })
+                .Build();
+
+            var service = host.Services.GetRequiredService<IFeatureToggleService>();
+
+            await service.GetToggleAsync("my-toggle", fallback: false);
+            await service.GetToggleAsync("my-toggle", fallback: false); // second call: cache hit
+
+            var resolvedEntries = recorder.Entries
+                .Where(e => e.Message.Contains("resolved in") && e.Message.Contains("Source:"))
+                .ToArray();
+
+            resolvedEntries.Should().NotBeEmpty("the resolution-result line should still be logged, just at Debug");
+            resolvedEntries.Should().OnlyContain(e => e.Level == LogLevel.Debug,
+                "per-resolution result lines must be Debug to avoid flooding Application Insights");
+        }
+        finally
+        {
+            listener.Stop();
+        }
+    }
+
+    private sealed class RecordingLoggerProvider : ILoggerProvider
+    {
+        public List<(LogLevel Level, string Message)> Entries { get; } = new();
+        public ILogger CreateLogger(string categoryName) => new RecordingLogger(Entries);
+        public void Dispose() { }
+
+        private sealed class RecordingLogger : ILogger
+        {
+            private readonly List<(LogLevel, string)> _entries;
+            public RecordingLogger(List<(LogLevel, string)> entries) => _entries = entries;
+            public IDisposable BeginScope<TState>(TState state) where TState : notnull => NullScope.Instance;
+            public bool IsEnabled(LogLevel logLevel) => true;
+            public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception,
+                Func<TState, Exception, string> formatter)
+            {
+                lock (_entries) _entries.Add((logLevel, formatter(state, exception)));
+            }
+        }
+
+        private sealed class NullScope : IDisposable
+        {
+            public static readonly NullScope Instance = new();
+            public void Dispose() { }
+        }
     }
 }

--- a/Quilt4Net.Toolkit.Tests/Quilt4Net.Toolkit.Tests.csproj
+++ b/Quilt4Net.Toolkit.Tests/Quilt4Net.Toolkit.Tests.csproj
@@ -11,7 +11,7 @@
 		<PackageReference Include="JetBrains.Annotations" Version="2025.2.4" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
 		<PackageReference Include="Moq" Version="4.20.72" />
-		<PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.8" />
+		<PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.9" />
 		<PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Quilt4Net.Toolkit/ContentRegistration.cs
+++ b/Quilt4Net.Toolkit/ContentRegistration.cs
@@ -58,7 +58,14 @@ public static class ContentRegistration
         services.AddHttpClient(RemoteContentCallService.HttpClientName, client =>
             {
                 client.BaseAddress = new Uri(o.Quilt4NetAddress);
-                if (!string.IsNullOrEmpty(o.ApiKey)) client.DefaultRequestHeaders.Add("X-API-KEY", o.ApiKey);
+                if (!string.IsNullOrEmpty(o.ApiKey))
+                {
+                    // Remove-then-Add so a duplicate registration (e.g. a host calling both AddQuilt4NetContent
+                    // and AddQuilt4NetBlazorContent — the latter calls AddQuilt4NetContent internally) can't send
+                    // X-API-KEY twice; the server rejects a doubled header value as "Invalid API key" (401).
+                    client.DefaultRequestHeaders.Remove("X-API-KEY");
+                    client.DefaultRequestHeaders.Add("X-API-KEY", o.ApiKey);
+                }
             })
             .AddQuilt4NetCorrelationId();
 

--- a/Quilt4Net.Toolkit/Features/FeatureToggle/RemoteConfigCallService.cs
+++ b/Quilt4Net.Toolkit/Features/FeatureToggle/RemoteConfigCallService.cs
@@ -53,10 +53,13 @@ internal class RemoteConfigCallService : IRemoteConfigCallService
             _localCache.TryGetValue(cacheKey, out var cached);
             var needRefresh = cached == null || DateTime.UtcNow > cached.ValidTo;
 
+            // Per-resolution result lines are Debug — they fire on every flag check (typically a
+            // 0ms cache hit) and produced ~449k Information traces/week per app in production.
+            // Errors / warnings / actual value changes still log at their original levels.
             if (!needRefresh)
             {
                 var cachedValue = GetCachedOrDefault(cached, defaultValue);
-                _logger.LogInformation("Configuration '{Key}' resolved in {Elapsed}ms. Source: Cache, Stale: false, Value: '{Value}'.",
+                _logger.LogDebug("Configuration '{Key}' resolved in {Elapsed}ms. Source: Cache, Stale: false, Value: '{Value}'.",
                     key, sw.ElapsedMilliseconds, cachedValue);
                 return cachedValue;
             }
@@ -68,7 +71,7 @@ internal class RemoteConfigCallService : IRemoteConfigCallService
             {
                 StartBackgroundRefresh(key, cacheKey, defaultValue, ttl, effectiveApplication);
                 var staleValue = GetCachedOrDefault(cached, defaultValue);
-                _logger.LogInformation("Configuration '{Key}' resolved in {Elapsed}ms. Source: StaleCache, Stale: true, Value: '{Value}'.",
+                _logger.LogDebug("Configuration '{Key}' resolved in {Elapsed}ms. Source: StaleCache, Stale: true, Value: '{Value}'.",
                     key, sw.ElapsedMilliseconds, staleValue);
                 return staleValue;
             }
@@ -84,11 +87,11 @@ internal class RemoteConfigCallService : IRemoteConfigCallService
             {
                 CacheFailure(cacheKey, stale);
                 var staleValue = GetCachedOrDefault(stale, defaultValue);
-                _logger.LogInformation("Configuration '{Key}' resolved in {Elapsed}ms. Source: StaleCache, Stale: true, Value: '{Value}'.",
+                _logger.LogDebug("Configuration '{Key}' resolved in {Elapsed}ms. Source: StaleCache, Stale: true, Value: '{Value}'.",
                     key, sw.ElapsedMilliseconds, staleValue);
                 return staleValue;
             }
-            _logger.LogInformation("Configuration '{Key}' resolved in {Elapsed}ms. Source: Default, Stale: true, Value: '{Value}'.",
+            _logger.LogDebug("Configuration '{Key}' resolved in {Elapsed}ms. Source: Default, Stale: true, Value: '{Value}'.",
                 key, sw.ElapsedMilliseconds, defaultValue);
             return defaultValue;
         }
@@ -122,7 +125,7 @@ internal class RemoteConfigCallService : IRemoteConfigCallService
                 _logger.LogError("Unable to get feature toggle for key '{Key}'. Response was {StatusCode} {ReasonPhrase}.",
                     key, response.StatusCode, response.ReasonPhrase);
                 CacheFailure(cacheKey, null);
-                _logger.LogInformation("Configuration '{Key}' resolved in {Elapsed}ms. Source: Default, Stale: true, Value: '{Value}'.",
+                _logger.LogDebug("Configuration '{Key}' resolved in {Elapsed}ms. Source: Default, Stale: true, Value: '{Value}'.",
                     key, sw.ElapsedMilliseconds, defaultValue);
                 return defaultValue;
             }
@@ -136,7 +139,7 @@ internal class RemoteConfigCallService : IRemoteConfigCallService
             _localCache.AddOrUpdate(cacheKey, result, (_, _) => result);
 
             var serverValue = GetCachedOrDefault(result, defaultValue);
-            _logger.LogInformation("Configuration '{Key}' resolved in {Elapsed}ms. Source: Server, Stale: false, Value: '{Value}'.",
+            _logger.LogDebug("Configuration '{Key}' resolved in {Elapsed}ms. Source: Server, Stale: false, Value: '{Value}'.",
                 key, sw.ElapsedMilliseconds, serverValue);
             return serverValue;
         }
@@ -145,7 +148,7 @@ internal class RemoteConfigCallService : IRemoteConfigCallService
             _logger.LogWarning("HTTP request timed out for configuration '{Key}' after {Timeout}ms. Using default value.",
                 key, _options.HttpTimeout.TotalMilliseconds);
             CacheFailure(cacheKey, null);
-            _logger.LogInformation("Configuration '{Key}' resolved in {Elapsed}ms. Source: Default, Stale: true, Value: '{Value}'.",
+            _logger.LogDebug("Configuration '{Key}' resolved in {Elapsed}ms. Source: Default, Stale: true, Value: '{Value}'.",
                 key, sw.ElapsedMilliseconds, defaultValue);
             return defaultValue;
         }
@@ -153,7 +156,7 @@ internal class RemoteConfigCallService : IRemoteConfigCallService
         {
             _logger.LogError(e, "{Message} Using default for key {Key}.", e.Message, key);
             CacheFailure(cacheKey, null);
-            _logger.LogInformation("Configuration '{Key}' resolved in {Elapsed}ms. Source: Default, Stale: true, Value: '{Value}'.",
+            _logger.LogDebug("Configuration '{Key}' resolved in {Elapsed}ms. Source: Default, Stale: true, Value: '{Value}'.",
                 key, sw.ElapsedMilliseconds, defaultValue);
             return defaultValue;
         }

--- a/Quilt4Net.Toolkit/Quilt4Net.Toolkit.csproj
+++ b/Quilt4Net.Toolkit/Quilt4Net.Toolkit.csproj
@@ -39,19 +39,19 @@
   <ItemGroup>
     <PackageReference Include="Azure.Identity" Version="1.21.0" />
     <PackageReference Include="Microsoft.ApplicationInsights" Version="3.1.2" />
-    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.15.3" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.16.0" />
     <PackageReference Include="Azure.Monitor.Query.Logs" Version="1.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.8" />
-    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.8" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.8" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.8" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.8" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.9" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.300">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="System.Management" Version="10.0.8" />
+    <PackageReference Include="System.Management" Version="10.0.9" />
     <PackageReference Include="System.Linq.Async" Version="7.0.1" />
-    <PackageReference Include="Tharga.Cache" Version="0.4.6" />
+    <PackageReference Include="Tharga.Cache" Version="0.4.7" />
   </ItemGroup>
 </Project>

--- a/Quilt4Net.Toolkit/RemoteConfigurationRegistration.cs
+++ b/Quilt4Net.Toolkit/RemoteConfigurationRegistration.cs
@@ -52,7 +52,13 @@ public static class RemoteConfigurationRegistration
         services.AddHttpClient(Features.FeatureToggle.RemoteConfigCallService.HttpClientName, client =>
             {
                 client.BaseAddress = new Uri(o.Quilt4NetAddress);
-                if (!string.IsNullOrEmpty(o.ApiKey)) client.DefaultRequestHeaders.Add("X-API-KEY", o.ApiKey);
+                if (!string.IsNullOrEmpty(o.ApiKey))
+                {
+                    // Remove-then-Add so a duplicate registration can't send X-API-KEY twice; the server
+                    // rejects a doubled header value as "Invalid API key" (401). (Idempotent across reruns.)
+                    client.DefaultRequestHeaders.Remove("X-API-KEY");
+                    client.DefaultRequestHeaders.Add("X-API-KEY", o.ApiKey);
+                }
             })
             .AddQuilt4NetCorrelationId();
 

--- a/docs/articles/log-views.md
+++ b/docs/articles/log-views.md
@@ -119,7 +119,54 @@ The Stack Trace tab is exception-only; trace and request rows show a friendly "n
 
 Adds a tab that triggers traces and exceptions at every `LogLevel` via `ILogger`, plus an uncaught throw caught by `Tharga.Blazor.CustomErrorBoundary` so the correlation guid surfaces in the recovery banner and in `customDimensions["CorrelationId"]`. Off by default so external apps don't accidentally expose log-injection controls.
 
+## Standalone count components
+
+`LogView` exposes a `Count` tab, but the two underlying components — `LogCountView` and `LogCountByServiceView` — can also be placed on their own when a host wants the volume view without the search / summary / measure tabs around it.
+
+### `LogCountView` — per-action histogram
+
+A bar chart (and tabular companion) of log volume grouped by Action, optionally faceted by Environment. Same component Quilt4Net Server's `/developer/log` Count tab uses.
+
+```razor
+@using Quilt4Net.Toolkit.Blazor.Features.Log
+@using Quilt4Net.Toolkit.Features.ApplicationInsights
+
+<LogCountView Context="@ApplicationInsightsContextExtensions.Current"
+              Range="TimeSpan.FromHours(1)" />
+```
+
+| Parameter | Type | Default | Notes |
+|---|---|---|---|
+| `Context` | `IApplicationInsightsContext` | `null` | The workspace to query. When null, resolved via the DI selector / configured options. |
+| `Environment` | `string` | `null` | Restrict the query to one environment. When null, every environment in the workspace is included and each series is keyed `Environment.Action`. |
+| `Range` | `TimeSpan` | `1 day` | Lookback window. |
+
+Cascading `LogNavigationOptions` is honoured for detail drill-downs — when a host sets `DetailPath`, clicking a grid row navigates instead of opening the Radzen dialog.
+
+### `LogCountByServiceView` — service × severity pivot
+
+A pivot of log counts grouped by service across the Verbose / Information / Warning / Error / Critical severity columns, with multi-select filters for Configuration, Environment and Source, plus a "Per machine" toggle that splits each service row by machine. Every filter except Range is a local regroup over the cached cell cube — only Range changes hit AI. Same component Quilt4Net Server's `/developer/log-count` page uses.
+
+```razor
+@using Quilt4Net.Toolkit.Blazor.Features.Log
+
+<LogCountByServiceView Configs="@_workspaces" />
+```
+
+| Parameter | Type | Default | Notes |
+|---|---|---|---|
+| `Context` | `IApplicationInsightsContext` | `null` | Explicit single workspace. Bypasses the configuration multi-select. |
+| `Configs` | `IReadOnlyList<ApplicationInsightsConfigurationResponse>` | `null` | Explicit set; multi-select bar lists each as a chip — *nothing selected* means aggregate across all. Takes precedence over the DI selector; ignored when `Context` is set. |
+| `EnvironmentOrder` | `IReadOnlyList<string>` | `null` | Preferred display order for environment chips. Named entries come first; extras fall back to alphabetical. When null, `EnvironmentOrdering.DefaultOrder` (Development, CI, Staging, Test, Production) is used. Hosts pulling team-specific ordering from their own config (e.g. via `IEnvironmentService` on Quilt4Net.Server) should pass it here. |
+
+Ranges (1h / 24h / 7d) and the Refresh button work the same way as in [`MetricsView`](metrics.md) — the cell cube is cached per circuit in a scoped `LogCountCellCache` for 10 minutes so range flips and page-navigation revisits skip the AI round-trip.
+
+### Remote vs local mode
+
+The same `Context` precedence applies to `LogView` / `VersionMatrixDisplay` / `MetricsView` / `LogCountByServiceView`. Hosts that already resolved a `Context` from local options *and* registered the remote selector can pick one explicitly — see [Metrics → Remote vs local mode](metrics.md#remote-vs-local-mode).
+
 ## Where next
 
+- **[Metrics](metrics.md)** — host telemetry (CPU, memory, disk, network) from the same workspace.
 - **[Telemetry identity & correlation](telemetry-identity.md)** — how the data shown by these components reaches AI in the first place.
 - **API reference** for the new types: `xref:Quilt4Net.Toolkit.Features.ApplicationInsights.LogItem.CorrelationId`, `xref:Quilt4Net.Toolkit.Features.ApplicationInsights.StackFrameParser`.

--- a/docs/articles/metrics.md
+++ b/docs/articles/metrics.md
@@ -1,0 +1,124 @@
+# Metrics
+
+Three Blazor components in `Quilt4Net.Toolkit.Blazor.Features.Metrics` plot machine-level telemetry (CPU, memory, disk, network) sourced from the AI workspace via `IApplicationInsightsService`. The composite `MetricsView` is the drop-in surface that powers Quilt4Net Server's `/developer/metrics`; `MetricChart` and `MetricLatestChart` are the two primitives it renders and are exported so custom dashboards can compose their own charts off the same `MetricSample[]` stream.
+
+## Minimum
+
+```razor
+@using Quilt4Net.Toolkit.Blazor.Features.Metrics
+
+<MetricsView />
+```
+
+Renders CPU %, Memory %, Disk used (GB) and Network (MB/s) for the AI workspace configured by `AddQuilt4NetApplicationInsightsClient`. The Refresh button bypasses the per-circuit cache.
+
+## Supplying configurations
+
+`MetricsView` queries one workspace at a time. Point it at one, in precedence order:
+
+| Source | Use when |
+|---|---|
+| `Context` | A single workspace (or the locally configured one). |
+| `Configs` | You already hold an explicit set (e.g. a team's). The component renders a dropdown when more than one is supplied. |
+| DI selector | You registered `AddQuilt4NetBlazorApplicationInsightsClientRemote`; the built-in dropdown is driven by it. |
+
+```razor
+<MetricsView Configs="@_workspaces" />
+```
+
+Precedence: `Context` > selected `Configs` entry > DI selector.
+
+### Remote vs local mode
+
+The same `Context` precedence applies to `LogView`, `VersionMatrixDisplay`, `MetricsView` and `LogCountByServiceView`. Hosts that already resolved a `Context` from local options *and* registered the remote selector can pick one explicitly:
+
+```razor
+@inject IServiceProvider Services
+
+<MetricsView Context="@_context" />
+
+@code {
+    private IApplicationInsightsContext _context;
+
+    protected override void OnInitialized()
+    {
+        _context = Services.GetService<IApplicationInsightsConfigurationSelector>() != null
+            ? null                                          // remote mode → toolkit's in-component selector
+            : ApplicationInsightsContextExtensions.Current; // local mode → configured options
+    }
+}
+```
+
+Passing `null` for `Context` lets the component resolve the workspace itself via the registered selector — the recommended shape for hosts that want the user-visible workspace picker in the chart's filter row.
+
+## Range and refresh
+
+The filter row offers fixed range buttons — **1h**, **24h**, **7d** — and a Refresh button. Each `(Context, Range)` pair is cached for 10 minutes in a per-circuit `MetricsSeriesCache`, so flipping back to a previously-loaded range is instant and survives page navigation within the same Blazor circuit. Refresh evicts the current `(Context, Range)` entry and re-fetches.
+
+## The four charts
+
+| Chart | Renderer | Behaviour |
+|---|---|---|
+| **CPU %** | `MetricChart` | Line chart per host. `FullPercentScale="true"` pins the y-axis to 0–100, preventing an idle "always between 8 and 12 %" host from looking saturated. |
+| **Memory %** | `MetricChart` | Line chart per host, same 0–100 pin. |
+| **Disk used (GB)** | `MetricLatestChart` | One bar per (host, volume). Bar fill represents the latest value as a fraction of capacity; turns amber > 80%, red > 90%. A delta badge (▲ +1.2 GB / 24h) signals growth. `LessIsBad="false"` because more-used is worse. |
+| **Network (MB/s)** | `MetricChart` | Line chart per host with `LogScale="true"`. On a linear axis, idle hosts (~0.01 MB/s) vanish into a flat line at the bottom when one host spikes to 50 MB/s; log scale gives each host's shape its own band. |
+
+## Composing your own dashboard
+
+Both primitives accept a `MetricSample[]` you fetch yourself, so a host that already has `IApplicationInsightsService` injected can drop one chart anywhere:
+
+```razor
+@inject IApplicationInsightsService Ai
+
+<MetricChart Title="CPU %" Unit="%" Samples="@_cpu" Loading="@_busy" />
+
+@code {
+    private MetricSample[] _cpu = [];
+    private bool _busy;
+
+    protected override async Task OnInitializedAsync()
+    {
+        _busy = true;
+        _cpu = await Ai.GetCpuUtilizationAsync(ApplicationInsightsContextExtensions.Current, TimeSpan.FromHours(1)).ToArrayAsync();
+        _busy = false;
+    }
+}
+```
+
+## `MetricChart` parameters
+
+| Parameter | Type | Default | Notes |
+|---|---|---|---|
+| `Title` | `string` | (required) | Card header. |
+| `Unit` | `string` | `null` | Suffix on y-axis tick labels (`"%"`, `"MB/s"`, …). |
+| `Samples` | `MetricSample[]` | `[]` | Time-series points; grouped into one line per `Series`. |
+| `Loading` | `bool` | `false` | When true, shows a spinner in the card header and an empty body. |
+| `LogScale` | `bool` | `false` | Plot on a log10 y-axis. Reverses tick formatting back to the natural unit. Overrides `FullPercentScale` (log10(0) is −∞). |
+| `FullPercentScale` | `bool` | `true` | Pin the y-axis to 0–100. Ignored when `LogScale` is on. |
+| `LogScaleEpsilon` | `double` | `0.001` | Floor applied before log10 so zero / sub-noise samples don't crash the transform. |
+
+## `MetricLatestChart` parameters
+
+| Parameter | Type | Default | Notes |
+|---|---|---|---|
+| `Title` | `string` | (required) | Card header. |
+| `Unit` | `string` | `null` | Suffix on bar labels and the delta badge. |
+| `Samples` | `MetricSample[]` | `[]` | Latest value per `Series` is bar-rendered; the full series powers an inline sparkline. |
+| `Range` | `TimeSpan` | `default` | Window the samples cover — formats the delta-badge suffix ("/ 24h"). |
+| `Loading` | `bool` | `false` | Header spinner; bars hidden while true. |
+| `Capacity` | `DiskCapacity[]` | `[]` | Optional per-series total. When matched, the bar fill is `latest / capacity` instead of `latest / max-across-hosts`. |
+| `LessIsBad` | `bool` | `true` | Direction of "bad". `true` (default) → less is worse (free / available); `false` → more is worse (utilisation). Drives the bar's threshold colours and the delta badge's arrow. |
+
+## `MetricsView` parameters
+
+| Parameter | Type | Default | Notes |
+|---|---|---|---|
+| `Context` | `IApplicationInsightsContext` | `null` | Explicit single workspace. Bypasses the selector / `Configs` dropdown. |
+| `Configs` | `IReadOnlyList<ApplicationInsightsConfigurationResponse>` | `null` | Explicit set; rendered as a dropdown when count > 1. Takes precedence over the DI selector; ignored when `Context` is set. |
+
+## Where next
+
+- **[Log views](log-views.md)** — the sibling AI-data surface (search, summary, exceptions, counts).
+- **[Version matrix](version-matrix.md)** — application × environment grid sourced from the same workspace.
+- **[Telemetry identity & correlation](telemetry-identity.md)** — how the data these charts query reaches AI in the first place.

--- a/docs/articles/toc.yml
+++ b/docs/articles/toc.yml
@@ -6,5 +6,7 @@
   href: telemetry-identity.md
 - name: Log views
   href: log-views.md
+- name: Metrics
+  href: metrics.md
 - name: Version matrix
   href: version-matrix.md


### PR DESCRIPTION
## Summary

Closes three open GitHub issues and rolls up the rest of the work that has accumulated on `develop` since the last release.

**Issues closed**
- Closes #107 — `Quilt4Content` no longer crashes the consuming page when the first-render auto-register `SetContentAsync` fails (401, server unreachable, etc.). The optional write is now wrapped in try/catch and logs a warning; the component falls back to the default exactly the way reads already do.
- Closes #108 — Per-resolution `"Configuration '{Key}' resolved … Source: …"` lines in `RemoteConfigCallService` demoted from `LogInformation` to `LogDebug`. Cuts the bulk Application Insights volume (one consumer reported ~449k Information traces/week per app, ~99% cache hits) without losing any actionable signal — errors / warnings / background-refresh value-change lines stay at their original levels.
- Closes #106 — Documentation for `LogCountView` / `LogCountByServiceView` as standalone components, plus a new `docs/articles/metrics.md` article covering `MetricsView` / `MetricChart` / `MetricLatestChart`. Also documents the remote-vs-local `Context` resolution pattern shared by `LogView` / `VersionMatrixDisplay` / `MetricsView` / `LogCountByServiceView`.

**Other work shipping with this PR (already on `develop`)**
- NuGet package refresh — `Microsoft.Extensions.*` / `Components.Authorization` / `Mvc.Testing` / `WebAssembly*` 10.0.8 → 10.0.9, `OpenTelemetry.Extensions.Hosting` 1.15.3 → 1.16.0, `System.Management` 10.0.8 → 10.0.9, `Tharga.Cache` 0.4.6 → 0.4.7, `Tharga.Blazor` 2.1.6 → 2.2.0 (pulls Radzen.Blazor 10.x), `Tharga.Mcp` 0.1.4 → 0.1.6, `Microsoft.Identity.Client` 4.84.1 → 4.84.2, `Swashbuckle.AspNetCore` 10.2.0 → 10.2.1. `Markdig` 0.42 → 1.2 held back for separate review (major jump).
- `fix(content/config)`: `X-API-KEY` header registration is now idempotent.
- `feat(monitor)`: single-select Configuration dropdown persists across reloads.
- `feat(metrics)`: charts now show *disk used* (bar fills as the volume fills) instead of *disk free*.

## Test plan

- [x] `dotnet test Toolkit/Quilt4Net.Toolkit.sln -c Release` — 327/327 green on `develop` tip (Toolkit 165, Blazor 84, Health 48, Api 15, Mcp 15).
- [x] `docfx metadata && docfx build` clean — 0 build errors, 0 build warnings.
- [x] New bUnit tests for #107 — 3 cases: no-throw, warning logged with key, no warning on success.
- [x] New unit test for #108 — verifies the resolution-result line is logged at Debug (not Information) using a recording `ILoggerProvider`.
- [ ] Manual smoke test of `Quilt4Content` fallback rendering on a consumer.
- [ ] Verify in Application Insights that the consumer no longer ingests Information-level "Configuration resolved" lines after the bump.