### PR TITLE
feat(health): expose SemVer InformationalVersion on /api/Health/Version

### DIFF
--- a/Quilt4Net.Toolkit.Api.Tests/VersionServiceTests.cs
+++ b/Quilt4Net.Toolkit.Api.Tests/VersionServiceTests.cs
@@ -1,4 +1,5 @@
-﻿using AutoFixture;
+﻿using System.Reflection;
+using AutoFixture;
 using FluentAssertions;
 using Microsoft.Extensions.Hosting;
 using Moq;
@@ -20,11 +21,48 @@ public class VersionServiceTests
         var sut = new VersionService(hostEnvironment.Object, new Quilt4NetHealthApiOptions());
 
         //Act
-        var result = await sut.GetVersionAsync(CancellationToken.None);
+        var result = await sut.GetVersionAsync(TestContext.Current.CancellationToken);
 
         //Assert
         result.Should().NotBeNull();
         result.Environment.Should().Be(environmentName);
         result.Machine.Should().Be(Environment.MachineName);
+    }
+
+    // Issue #110: AssemblyVersion is a 4-part numeric and can't carry "-pre.n". A SemVer-aware
+    // field has to come from AssemblyInformationalVersionAttribute, with SourceLink's optional
+    // "+commit-hash" build metadata stripped so the value is clean SemVer.
+
+    [Theory]
+    [InlineData(null, null)]
+    [InlineData("", null)]
+    [InlineData("1.0.0", "1.0.0")]
+    [InlineData("1.4.12-pre.1", "1.4.12-pre.1")]
+    [InlineData("1.4.12+abc123", "1.4.12")]
+    [InlineData("1.4.12-pre.1+abc123", "1.4.12-pre.1")]
+    public void StripBuildMetadata_returns_SemVer_without_plus_suffix(string input, string expected)
+    {
+        VersionService.StripBuildMetadata(input).Should().Be(expected);
+    }
+
+    [Fact]
+    public void ReadInformationalVersion_returns_null_for_null_assembly()
+    {
+        VersionService.ReadInformationalVersion(null).Should().BeNull();
+    }
+
+    [Fact]
+    public void ReadInformationalVersion_reads_attribute_from_assembly()
+    {
+        // The Quilt4Net.Toolkit assembly is built with GenerateDocumentationFile + the
+        // default MSBuild version pipeline, so AssemblyInformationalVersionAttribute is
+        // always present. The value should match whatever MSBuild stamped, after the
+        // "+commit-hash" SourceLink suffix is stripped — so use StripBuildMetadata as the
+        // oracle. Locks behaviour without coupling the test to a specific version literal.
+        var asm = typeof(VersionService).Assembly;
+        var expected = VersionService.StripBuildMetadata(
+            asm.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion);
+
+        VersionService.ReadInformationalVersion(asm).Should().Be(expected);
     }
 }

--- a/Quilt4Net.Toolkit/Features/Health/Version/VersionService.cs
+++ b/Quilt4Net.Toolkit/Features/Health/Version/VersionService.cs
@@ -24,6 +24,7 @@ internal class VersionService : IVersionService
         var result = new VersionResponse
         {
             Version = $"{asm?.GetName().Version}",
+            InformationalVersion = ReadInformationalVersion(asm),
             Machine = Environment.MachineName,
             Environment = name,
             IpAddress = ipAddress,
@@ -31,6 +32,20 @@ internal class VersionService : IVersionService
         };
 
         return result;
+    }
+
+    // The numeric AssemblyVersion drops any "-pre.n" tag (it has to — it's a 4-part numeric).
+    // For deploy-verification flows that need to identify the exact build serving traffic, read
+    // the full SemVer string from AssemblyInformationalVersionAttribute and strip SourceLink's
+    // optional "+commit-hash" build-metadata suffix so the field carries clean SemVer.
+    internal static string ReadInformationalVersion(Assembly asm)
+        => StripBuildMetadata(asm?.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion);
+
+    internal static string StripBuildMetadata(string version)
+    {
+        if (string.IsNullOrEmpty(version)) return null;
+        var plus = version.IndexOf('+');
+        return plus >= 0 ? version[..plus] : version;
     }
 
     private async Task<string> GetExternalIpAsync(Uri ipAddressCheck)

--- a/Quilt4Net.Toolkit/Features/Health/VersionResponse.cs
+++ b/Quilt4Net.Toolkit/Features/Health/VersionResponse.cs
@@ -8,11 +8,23 @@ namespace Quilt4Net.Toolkit.Features.Health;
 public record VersionResponse
 {
     /// <summary>
-    /// Version number.
+    /// Numeric four-part assembly version (<see cref="System.Reflection.AssemblyName.Version"/>).
+    /// Pre-release SemVer tags are stripped here — use <see cref="InformationalVersion"/> when
+    /// the build's <c>-pre.n</c> / SemVer identity matters (e.g. post-deploy verification).
     /// </summary>
     /// <example>1.0.0.0</example>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public string Version { get; init; }
+
+    /// <summary>
+    /// Informational / SemVer version sourced from
+    /// <see cref="System.Reflection.AssemblyInformationalVersionAttribute"/>, including any
+    /// pre-release tag. SourceLink build metadata (anything after <c>+</c>) is stripped.
+    /// Null when the attribute is absent on the entry assembly.
+    /// </summary>
+    /// <example>1.0.0-pre.1</example>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string InformationalVersion { get; init; }
 
     /// <summary>
     /// Name of the machine where the application is running.


### PR DESCRIPTION
## Summary

Closes #110.

`AssemblyName.Version` is a four-part numeric value, so any `-pre.n` SemVer tag is silently dropped when the version flows through `/api/Health/Version`. Consumers running post-deploy verification (poll the endpoint until it reports the just-deployed build) couldn't distinguish consecutive pre-release builds, and couldn't verify a `-pre.n` build at all — every `-pre.*` of the same patch collapsed to `1.4.12.0`.

Adds a sibling `InformationalVersion` field on `VersionResponse`, sourced from `AssemblyInformationalVersionAttribute` with SourceLink's optional `+commit-hash` build-metadata suffix stripped so the value is clean SemVer (`1.4.12-pre.1`, not `1.4.12-pre.1+abc123`). The numeric `Version` field is preserved unchanged — strictly additive on the wire; `JsonIgnore` when null so older payloads still validate against the schema.

Extraction logic is split into two `internal static` helpers (`ReadInformationalVersion` / `StripBuildMetadata`) so the SemVer rules are unit-testable in isolation via the existing `[InternalsVisibleTo("Quilt4Net.Toolkit.Api.Tests")]`.

## Test plan

- [x] `dotnet test Toolkit/Quilt4Net.Toolkit.sln -c Release` — 335/335 green (was 327; +8 new VersionService tests).
- [x] `StripBuildMetadata` Theory covers null / empty / plain SemVer / pre-release / build-metadata / pre-release-plus-metadata.
- [x] `ReadInformationalVersion(typeof(VersionService).Assembly)` uses the SUT's own assembly + `StripBuildMetadata` as the oracle, so the test isn't pinned to a specific version literal.
- [x] Warning ratchet: 254 (well under the 261 CI limit).
- [ ] Manual smoke test: hit `/api/Health/Version` on a `-pre.n` build and confirm `InformationalVersion` carries the SemVer tag while `Version` keeps the numeric 4-part value.