### PR TITLE
Content-aware Radzen wrappers + docs sweep (closes #112)

### DIFF
--- a/Quilt4Net.Toolkit.Blazor.Tests/Quilt4NotificationServiceTests.cs
+++ b/Quilt4Net.Toolkit.Blazor.Tests/Quilt4NotificationServiceTests.cs
@@ -1,0 +1,96 @@
+using FluentAssertions;
+using Quilt4Net.Toolkit.Features.Content;
+using Quilt4Net.Toolkit.Features.FeatureToggle;
+using Radzen;
+using Xunit;
+
+namespace Quilt4Net.Toolkit.Blazor.Tests;
+
+public class Quilt4NotificationServiceTests
+{
+    [Fact]
+    public async Task NotifyAsync_resolves_summary_and_detail_keys()
+    {
+        var content = new FakeContentService();
+        content.Map["save.success.summary"] = "Saved";
+        content.Map["save.success.detail"] = "Your changes have been saved.";
+        var languageState = new FakeLanguageStateService { Selected = new Language { Key = Guid.NewGuid() } };
+        var notificationService = new NotificationService();
+
+        var sut = new Quilt4NotificationService(notificationService, content, languageState);
+
+        await sut.NotifyAsync(NotificationSeverity.Success,
+            summaryKey: "save.success.summary", defaultSummary: "Saved (default)",
+            detailKey: "save.success.detail", defaultDetail: "Default detail.");
+
+        // Radzen's NotificationService exposes a `Messages` observable collection rather than
+        // an OnNotify event; the NotificationContainer subscribes to it. Asserting on that
+        // collection captures the same data the UI would render.
+        notificationService.Messages.Should().HaveCount(1);
+        var msg = notificationService.Messages[0];
+        msg.Severity.Should().Be(NotificationSeverity.Success);
+        msg.Summary.Should().Be("Saved");
+        msg.Detail.Should().Be("Your changes have been saved.");
+    }
+
+    [Fact]
+    public async Task NotifyAsync_falls_back_to_default_summary_when_key_missing()
+    {
+        var content = new FakeContentService();
+        var languageState = new FakeLanguageStateService { Selected = new Language { Key = Guid.NewGuid() } };
+        var notificationService = new NotificationService();
+
+        var sut = new Quilt4NotificationService(notificationService, content, languageState);
+
+        await sut.NotifyAsync(NotificationSeverity.Warning,
+            summaryKey: "missing.key", defaultSummary: "Fallback summary");
+
+        notificationService.Messages.Should().HaveCount(1);
+        var msg = notificationService.Messages[0];
+        msg.Summary.Should().Be("Fallback summary");
+        msg.Detail.Should().BeNull("when neither detail key nor default is supplied, leave Detail null");
+    }
+
+    [Fact]
+    public async Task NotifyAsync_forwards_duration()
+    {
+        var content = new FakeContentService();
+        var languageState = new FakeLanguageStateService { Selected = new Language { Key = Guid.NewGuid() } };
+        var notificationService = new NotificationService();
+
+        var sut = new Quilt4NotificationService(notificationService, content, languageState);
+
+        await sut.NotifyAsync(NotificationSeverity.Info,
+            summaryKey: null, defaultSummary: "Heads up",
+            duration: 5000);
+
+        notificationService.Messages.Should().HaveCount(1);
+        notificationService.Messages[0].Duration.Should().Be(5000);
+    }
+
+    private class FakeContentService : IContentService
+    {
+        public Dictionary<string, string> Map { get; } = new();
+
+        public Task<(string Value, bool Success)> GetContentAsync(string key, string defaultValue, Guid languageKey, ContentFormat? contentType, string application = null)
+        {
+            if (Map.TryGetValue(key ?? "", out var v) && !string.IsNullOrEmpty(v)) return Task.FromResult((v, true));
+            return Task.FromResult((defaultValue ?? "", false));
+        }
+
+        public Task SetContentAsync(string key, string value, Guid languageKey, ContentFormat contentType, string application = null) => Task.CompletedTask;
+        public Task ClearCacheAsync() => Task.CompletedTask;
+    }
+
+    private class FakeLanguageStateService : ILanguageStateService
+    {
+        public event EventHandler<LanguageLoadedEventArgs> LanguageLoadedEvent;
+        public event EventHandler<LanguageChangedEventArgs> LanguageChangedEvent;
+        public event EventHandler<DeveloperModeEventArgs> DeveloperModeEvent;
+        public Language Selected { get; set; }
+        public Language[] Languages { get; set; } = [];
+        public bool DeveloperMode { get; set; }
+        public Task<Language[]> ReloadAsync() => Task.FromResult(Languages);
+        private void Unused() { LanguageLoadedEvent?.Invoke(this, null); LanguageChangedEvent?.Invoke(this, null); DeveloperModeEvent?.Invoke(this, null); }
+    }
+}

--- a/Quilt4Net.Toolkit.Blazor.Tests/Quilt4RadzenAlertTests.cs
+++ b/Quilt4Net.Toolkit.Blazor.Tests/Quilt4RadzenAlertTests.cs
@@ -1,0 +1,128 @@
+using Bunit;
+using FluentAssertions;
+using Quilt4Net.Toolkit.Features.Content;
+using Quilt4Net.Toolkit.Features.FeatureToggle;
+using Xunit;
+
+namespace Quilt4Net.Toolkit.Blazor.Tests;
+
+public class Quilt4RadzenAlertTests : BunitContext
+{
+    private readonly FakeContentService _contentService = new();
+    private readonly FakeLanguageStateService _languageStateService = new();
+
+    public Quilt4RadzenAlertTests()
+    {
+        Services.AddSingleton<IContentService>(_contentService);
+        Services.AddSingleton<ILanguageStateService>(_languageStateService);
+        _languageStateService.Selected = new Language { Key = Guid.NewGuid(), Name = "English" };
+    }
+
+    [Fact]
+    public void Loads_Text_From_Content_Service()
+    {
+        _contentService.Map["alert.permission"] = "You don't have permission to do that.";
+
+        var cut = Render<Quilt4RadzenAlert>(parameters => parameters
+            .Add(p => p.TextKey, "alert.permission")
+            .Add(p => p.DefaultText, "Permission denied."));
+
+        cut.Instance.LoadedText.Should().Be("You don't have permission to do that.");
+    }
+
+    [Fact]
+    public void Falls_Back_To_DefaultText_When_Content_Missing()
+    {
+        // Same fallback semantics as the other Quilt4Radzen* wrappers — if the service has no
+        // value for the key, the static default carries the user-facing message.
+        var cut = Render<Quilt4RadzenAlert>(parameters => parameters
+            .Add(p => p.TextKey, "alert.missing")
+            .Add(p => p.DefaultText, "Something went wrong."));
+
+        cut.Instance.LoadedText.Should().Be("Something went wrong.");
+    }
+
+    [Fact]
+    public void Loads_Title_From_Content_Service_When_TitleKey_Set()
+    {
+        // Title is optional — a separate key/default pair, resolved with the same precedence.
+        // A title-less alert leaves both TitleKey and DefaultTitle null and gets null on Loaded.
+        _contentService.Map["alert.title.error"] = "Error";
+
+        var cut = Render<Quilt4RadzenAlert>(parameters => parameters
+            .Add(p => p.TextKey, "alert.body")
+            .Add(p => p.DefaultText, "body")
+            .Add(p => p.TitleKey, "alert.title.error")
+            .Add(p => p.DefaultTitle, "Default Error"));
+
+        cut.Instance.LoadedTitle.Should().Be("Error");
+    }
+
+    [Fact]
+    public void Title_Is_Null_When_No_TitleKey_Or_DefaultTitle_Supplied()
+    {
+        var cut = Render<Quilt4RadzenAlert>(parameters => parameters
+            .Add(p => p.TextKey, "alert.body")
+            .Add(p => p.DefaultText, "body"));
+
+        cut.Instance.LoadedTitle.Should().BeNull("a title-less alert must not render an empty title bar");
+    }
+
+    [Fact]
+    public void Updates_On_Language_Change()
+    {
+        _contentService.Map["alert.permission"] = "Permission denied";
+
+        var cut = Render<Quilt4RadzenAlert>(parameters => parameters
+            .Add(p => p.TextKey, "alert.permission")
+            .Add(p => p.DefaultText, "Permission denied."));
+
+        cut.Instance.LoadedText.Should().Be("Permission denied");
+
+        _contentService.Map["alert.permission"] = "Åtkomst nekad";
+        _languageStateService.RaiseLanguageChanged();
+
+        cut.WaitForState(() => cut.Instance.LoadedText == "Åtkomst nekad");
+        cut.Instance.LoadedText.Should().Be("Åtkomst nekad");
+    }
+
+    [Fact]
+    public void DefaultText_Used_When_TextKey_Null()
+    {
+        // Pure-default usage — a host that wants a Quilt4 alert without a content lookup
+        // can still mount this component and get its DefaultText rendered.
+        var cut = Render<Quilt4RadzenAlert>(parameters => parameters
+            .Add(p => p.DefaultText, "Static message"));
+
+        cut.Instance.LoadedText.Should().Be("Static message");
+    }
+
+    private class FakeContentService : IContentService
+    {
+        public Dictionary<string, string> Map { get; } = new();
+
+        public Task<(string Value, bool Success)> GetContentAsync(string key, string defaultValue, Guid languageKey, ContentFormat? contentType, string application = null)
+        {
+            if (Map.TryGetValue(key ?? "", out var value) && !string.IsNullOrEmpty(value))
+                return Task.FromResult((value, true));
+            return Task.FromResult((defaultValue ?? "", false));
+        }
+
+        public Task SetContentAsync(string key, string value, Guid languageKey, ContentFormat contentType, string application = null) => Task.CompletedTask;
+        public Task ClearCacheAsync() => Task.CompletedTask;
+    }
+
+    private class FakeLanguageStateService : ILanguageStateService
+    {
+        public event EventHandler<LanguageLoadedEventArgs> LanguageLoadedEvent;
+        public event EventHandler<LanguageChangedEventArgs> LanguageChangedEvent;
+        public event EventHandler<DeveloperModeEventArgs> DeveloperModeEvent;
+        public Language Selected { get; set; }
+        public Language[] Languages { get; set; } = [];
+        public bool DeveloperMode { get; set; }
+        public Task<Language[]> ReloadAsync() => Task.FromResult(Languages);
+
+        public void RaiseLanguageChanged() => LanguageChangedEvent?.Invoke(this, new LanguageChangedEventArgs());
+        private void Unused() { LanguageLoadedEvent?.Invoke(this, null); DeveloperModeEvent?.Invoke(this, null); }
+    }
+}

--- a/Quilt4Net.Toolkit.Blazor.Tests/Quilt4RadzenDataGridTests.cs
+++ b/Quilt4Net.Toolkit.Blazor.Tests/Quilt4RadzenDataGridTests.cs
@@ -1,0 +1,88 @@
+using Bunit;
+using FluentAssertions;
+using Quilt4Net.Toolkit.Features.Content;
+using Quilt4Net.Toolkit.Features.FeatureToggle;
+using Xunit;
+
+namespace Quilt4Net.Toolkit.Blazor.Tests;
+
+public class Quilt4RadzenDataGridTests : BunitContext
+{
+    private readonly FakeContentService _contentService = new();
+    private readonly FakeLanguageStateService _languageStateService = new();
+
+    public Quilt4RadzenDataGridTests()
+    {
+        JSInterop.Mode = JSRuntimeMode.Loose;
+        Services.AddSingleton<IContentService>(_contentService);
+        Services.AddSingleton<ILanguageStateService>(_languageStateService);
+        _languageStateService.Selected = new Language { Key = Guid.NewGuid(), Name = "English" };
+    }
+
+    [Fact]
+    public void Loads_EmptyText_From_Content_Service()
+    {
+        _contentService.Map["grid.empty"] = "No customers yet.";
+
+        var cut = Render<Quilt4RadzenDataGrid<string>>(p => p
+            .Add(c => c.EmptyTextKey, "grid.empty")
+            .Add(c => c.DefaultEmptyText, "No data."));
+
+        cut.Instance.LoadedEmptyText.Should().Be("No customers yet.");
+    }
+
+    [Fact]
+    public void Falls_Back_To_DefaultEmptyText()
+    {
+        var cut = Render<Quilt4RadzenDataGrid<string>>(p => p
+            .Add(c => c.EmptyTextKey, "grid.missing")
+            .Add(c => c.DefaultEmptyText, "No data."));
+
+        cut.Instance.LoadedEmptyText.Should().Be("No data.");
+    }
+
+    [Fact]
+    public void Updates_EmptyText_On_Language_Change()
+    {
+        _contentService.Map["grid.empty"] = "No customers yet.";
+
+        var cut = Render<Quilt4RadzenDataGrid<string>>(p => p
+            .Add(c => c.EmptyTextKey, "grid.empty")
+            .Add(c => c.DefaultEmptyText, "No data."));
+
+        cut.Instance.LoadedEmptyText.Should().Be("No customers yet.");
+
+        _contentService.Map["grid.empty"] = "Inga kunder ännu.";
+        _languageStateService.RaiseLanguageChanged();
+
+        cut.WaitForState(() => cut.Instance.LoadedEmptyText == "Inga kunder ännu.");
+        cut.Instance.LoadedEmptyText.Should().Be("Inga kunder ännu.");
+    }
+
+    private class FakeContentService : IContentService
+    {
+        public Dictionary<string, string> Map { get; } = new();
+
+        public Task<(string Value, bool Success)> GetContentAsync(string key, string defaultValue, Guid languageKey, ContentFormat? contentType, string application = null)
+        {
+            if (Map.TryGetValue(key ?? "", out var v) && !string.IsNullOrEmpty(v)) return Task.FromResult((v, true));
+            return Task.FromResult((defaultValue ?? "", false));
+        }
+
+        public Task SetContentAsync(string key, string value, Guid languageKey, ContentFormat contentType, string application = null) => Task.CompletedTask;
+        public Task ClearCacheAsync() => Task.CompletedTask;
+    }
+
+    private class FakeLanguageStateService : ILanguageStateService
+    {
+        public event EventHandler<LanguageLoadedEventArgs> LanguageLoadedEvent;
+        public event EventHandler<LanguageChangedEventArgs> LanguageChangedEvent;
+        public event EventHandler<DeveloperModeEventArgs> DeveloperModeEvent;
+        public Language Selected { get; set; }
+        public Language[] Languages { get; set; } = [];
+        public bool DeveloperMode { get; set; }
+        public Task<Language[]> ReloadAsync() => Task.FromResult(Languages);
+        public void RaiseLanguageChanged() => LanguageChangedEvent?.Invoke(this, new LanguageChangedEventArgs());
+        private void Unused() { LanguageLoadedEvent?.Invoke(this, null); DeveloperModeEvent?.Invoke(this, null); }
+    }
+}

--- a/Quilt4Net.Toolkit.Blazor.Tests/Quilt4RadzenPlaceholderTests.cs
+++ b/Quilt4Net.Toolkit.Blazor.Tests/Quilt4RadzenPlaceholderTests.cs
@@ -1,0 +1,143 @@
+using Bunit;
+using FluentAssertions;
+using Quilt4Net.Toolkit.Features.Content;
+using Quilt4Net.Toolkit.Features.FeatureToggle;
+using Xunit;
+
+namespace Quilt4Net.Toolkit.Blazor.Tests;
+
+// The four Quilt4Radzen* input wrappers (TextBox / TextArea / DropDown / Numeric) all share the
+// same placeholder-resolution code via PlaceholderResolver. We test each component's wiring
+// once to assert that wiring is correct, but exhaustive precedence tests live with the resolver
+// implementation by virtue of the existing Quilt4RadzenDataGridColumnTests / AlertTests style.
+public class Quilt4RadzenPlaceholderTests : BunitContext
+{
+    private readonly FakeContentService _contentService = new();
+    private readonly FakeLanguageStateService _languageStateService = new();
+
+    public Quilt4RadzenPlaceholderTests()
+    {
+        // RadzenDropDown / Numeric call JS interop in OnAfterRenderAsync; loose mode keeps the
+        // unset calls from blowing up the test without requiring per-call mock setup.
+        JSInterop.Mode = JSRuntimeMode.Loose;
+
+        Services.AddSingleton<IContentService>(_contentService);
+        Services.AddSingleton<ILanguageStateService>(_languageStateService);
+        _languageStateService.Selected = new Language { Key = Guid.NewGuid(), Name = "English" };
+    }
+
+    [Fact]
+    public void TextBox_loads_placeholder_from_content_service()
+    {
+        _contentService.Map["input.name"] = "Enter your name";
+
+        var cut = Render<Quilt4RadzenTextBox>(p => p
+            .Add(c => c.PlaceholderKey, "input.name")
+            .Add(c => c.DefaultPlaceholder, "Name"));
+
+        cut.Instance.LoadedPlaceholder.Should().Be("Enter your name");
+    }
+
+    [Fact]
+    public void TextBox_falls_back_to_default_placeholder()
+    {
+        var cut = Render<Quilt4RadzenTextBox>(p => p
+            .Add(c => c.PlaceholderKey, "input.missing")
+            .Add(c => c.DefaultPlaceholder, "Type something..."));
+
+        cut.Instance.LoadedPlaceholder.Should().Be("Type something...");
+    }
+
+    [Fact]
+    public void TextArea_loads_placeholder_from_content_service()
+    {
+        _contentService.Map["input.notes"] = "Notes (optional)";
+
+        var cut = Render<Quilt4RadzenTextArea>(p => p
+            .Add(c => c.PlaceholderKey, "input.notes")
+            .Add(c => c.DefaultPlaceholder, "Notes"));
+
+        cut.Instance.LoadedPlaceholder.Should().Be("Notes (optional)");
+    }
+
+    [Fact]
+    public void TextArea_falls_back_to_default_placeholder()
+    {
+        var cut = Render<Quilt4RadzenTextArea>(p => p
+            .Add(c => c.PlaceholderKey, "input.missing")
+            .Add(c => c.DefaultPlaceholder, "Type your message..."));
+
+        cut.Instance.LoadedPlaceholder.Should().Be("Type your message...");
+    }
+
+    [Fact]
+    public void DropDown_loads_placeholder_from_content_service()
+    {
+        _contentService.Map["input.country"] = "Choose country";
+
+        var cut = Render<Quilt4RadzenDropDown<string>>(p => p
+            .Add(c => c.PlaceholderKey, "input.country")
+            .Add(c => c.DefaultPlaceholder, "Country"));
+
+        cut.Instance.LoadedPlaceholder.Should().Be("Choose country");
+    }
+
+    [Fact]
+    public void Numeric_loads_placeholder_from_content_service()
+    {
+        _contentService.Map["input.quantity"] = "How many?";
+
+        var cut = Render<Quilt4RadzenNumeric<int>>(p => p
+            .Add(c => c.PlaceholderKey, "input.quantity")
+            .Add(c => c.DefaultPlaceholder, "Quantity"));
+
+        cut.Instance.LoadedPlaceholder.Should().Be("How many?");
+    }
+
+    [Fact]
+    public void TextBox_updates_placeholder_on_language_change()
+    {
+        // One language-change test is enough to validate the shared subscription pattern
+        // — all four wrappers use the same OnInitializedAsync handler shape.
+        _contentService.Map["input.name"] = "Enter your name";
+
+        var cut = Render<Quilt4RadzenTextBox>(p => p
+            .Add(c => c.PlaceholderKey, "input.name")
+            .Add(c => c.DefaultPlaceholder, "Name"));
+
+        cut.Instance.LoadedPlaceholder.Should().Be("Enter your name");
+
+        _contentService.Map["input.name"] = "Ange ditt namn";
+        _languageStateService.RaiseLanguageChanged();
+
+        cut.WaitForState(() => cut.Instance.LoadedPlaceholder == "Ange ditt namn");
+        cut.Instance.LoadedPlaceholder.Should().Be("Ange ditt namn");
+    }
+
+    private class FakeContentService : IContentService
+    {
+        public Dictionary<string, string> Map { get; } = new();
+
+        public Task<(string Value, bool Success)> GetContentAsync(string key, string defaultValue, Guid languageKey, ContentFormat? contentType, string application = null)
+        {
+            if (Map.TryGetValue(key ?? "", out var v) && !string.IsNullOrEmpty(v)) return Task.FromResult((v, true));
+            return Task.FromResult((defaultValue ?? "", false));
+        }
+
+        public Task SetContentAsync(string key, string value, Guid languageKey, ContentFormat contentType, string application = null) => Task.CompletedTask;
+        public Task ClearCacheAsync() => Task.CompletedTask;
+    }
+
+    private class FakeLanguageStateService : ILanguageStateService
+    {
+        public event EventHandler<LanguageLoadedEventArgs> LanguageLoadedEvent;
+        public event EventHandler<LanguageChangedEventArgs> LanguageChangedEvent;
+        public event EventHandler<DeveloperModeEventArgs> DeveloperModeEvent;
+        public Language Selected { get; set; }
+        public Language[] Languages { get; set; } = [];
+        public bool DeveloperMode { get; set; }
+        public Task<Language[]> ReloadAsync() => Task.FromResult(Languages);
+        public void RaiseLanguageChanged() => LanguageChangedEvent?.Invoke(this, new LanguageChangedEventArgs());
+        private void Unused() { LanguageLoadedEvent?.Invoke(this, null); DeveloperModeEvent?.Invoke(this, null); }
+    }
+}

--- a/Quilt4Net.Toolkit.Blazor.Tests/Quilt4RadzenTabsItemAndLabelTests.cs
+++ b/Quilt4Net.Toolkit.Blazor.Tests/Quilt4RadzenTabsItemAndLabelTests.cs
@@ -1,0 +1,112 @@
+using Bunit;
+using FluentAssertions;
+using Quilt4Net.Toolkit.Features.Content;
+using Quilt4Net.Toolkit.Features.FeatureToggle;
+using Xunit;
+
+namespace Quilt4Net.Toolkit.Blazor.Tests;
+
+// Bundle the TabsItem + Label tests since they share the identical content-resolution
+// pattern (same Quilt4RadzenPanelMenuItem-style TextKey/DefaultText pair, same resolver).
+public class Quilt4RadzenTabsItemAndLabelTests : BunitContext
+{
+    private readonly FakeContentService _contentService = new();
+    private readonly FakeLanguageStateService _languageStateService = new();
+
+    public Quilt4RadzenTabsItemAndLabelTests()
+    {
+        JSInterop.Mode = JSRuntimeMode.Loose;
+        Services.AddSingleton<IContentService>(_contentService);
+        Services.AddSingleton<ILanguageStateService>(_languageStateService);
+        _languageStateService.Selected = new Language { Key = Guid.NewGuid(), Name = "English" };
+    }
+
+    [Fact]
+    public void TabsItem_loads_text_from_content_service()
+    {
+        _contentService.Map["tab.overview"] = "Overview";
+
+        var cut = Render<Quilt4RadzenTabsItem>(p => p
+            .Add(c => c.TextKey, "tab.overview")
+            .Add(c => c.DefaultText, "Default Overview"));
+
+        cut.Instance.LoadedText.Should().Be("Overview");
+    }
+
+    [Fact]
+    public void TabsItem_falls_back_to_default()
+    {
+        var cut = Render<Quilt4RadzenTabsItem>(p => p
+            .Add(c => c.TextKey, "tab.missing")
+            .Add(c => c.DefaultText, "Fallback Tab"));
+
+        cut.Instance.LoadedText.Should().Be("Fallback Tab");
+    }
+
+    [Fact]
+    public void Label_loads_text_from_content_service()
+    {
+        _contentService.Map["form.name.label"] = "Full name";
+
+        var cut = Render<Quilt4RadzenLabel>(p => p
+            .Add(c => c.TextKey, "form.name.label")
+            .Add(c => c.DefaultText, "Name"));
+
+        cut.Instance.LoadedText.Should().Be("Full name");
+    }
+
+    [Fact]
+    public void Label_falls_back_to_default()
+    {
+        var cut = Render<Quilt4RadzenLabel>(p => p
+            .Add(c => c.TextKey, "form.missing")
+            .Add(c => c.DefaultText, "Default Label"));
+
+        cut.Instance.LoadedText.Should().Be("Default Label");
+    }
+
+    [Fact]
+    public void Label_updates_on_language_change()
+    {
+        _contentService.Map["form.name.label"] = "Full name";
+
+        var cut = Render<Quilt4RadzenLabel>(p => p
+            .Add(c => c.TextKey, "form.name.label")
+            .Add(c => c.DefaultText, "Name"));
+
+        cut.Instance.LoadedText.Should().Be("Full name");
+
+        _contentService.Map["form.name.label"] = "Fullständigt namn";
+        _languageStateService.RaiseLanguageChanged();
+
+        cut.WaitForState(() => cut.Instance.LoadedText == "Fullständigt namn");
+        cut.Instance.LoadedText.Should().Be("Fullständigt namn");
+    }
+
+    private class FakeContentService : IContentService
+    {
+        public Dictionary<string, string> Map { get; } = new();
+
+        public Task<(string Value, bool Success)> GetContentAsync(string key, string defaultValue, Guid languageKey, ContentFormat? contentType, string application = null)
+        {
+            if (Map.TryGetValue(key ?? "", out var v) && !string.IsNullOrEmpty(v)) return Task.FromResult((v, true));
+            return Task.FromResult((defaultValue ?? "", false));
+        }
+
+        public Task SetContentAsync(string key, string value, Guid languageKey, ContentFormat contentType, string application = null) => Task.CompletedTask;
+        public Task ClearCacheAsync() => Task.CompletedTask;
+    }
+
+    private class FakeLanguageStateService : ILanguageStateService
+    {
+        public event EventHandler<LanguageLoadedEventArgs> LanguageLoadedEvent;
+        public event EventHandler<LanguageChangedEventArgs> LanguageChangedEvent;
+        public event EventHandler<DeveloperModeEventArgs> DeveloperModeEvent;
+        public Language Selected { get; set; }
+        public Language[] Languages { get; set; } = [];
+        public bool DeveloperMode { get; set; }
+        public Task<Language[]> ReloadAsync() => Task.FromResult(Languages);
+        public void RaiseLanguageChanged() => LanguageChangedEvent?.Invoke(this, new LanguageChangedEventArgs());
+        private void Unused() { LanguageLoadedEvent?.Invoke(this, null); DeveloperModeEvent?.Invoke(this, null); }
+    }
+}

--- a/Quilt4Net.Toolkit.Blazor.Tests/Quilt4TooltipTests.cs
+++ b/Quilt4Net.Toolkit.Blazor.Tests/Quilt4TooltipTests.cs
@@ -1,0 +1,86 @@
+using Bunit;
+using FluentAssertions;
+using Quilt4Net.Toolkit.Features.Content;
+using Quilt4Net.Toolkit.Features.FeatureToggle;
+using Xunit;
+
+namespace Quilt4Net.Toolkit.Blazor.Tests;
+
+public class Quilt4TooltipTests : BunitContext
+{
+    private readonly FakeContentService _contentService = new();
+    private readonly FakeLanguageStateService _languageStateService = new();
+
+    public Quilt4TooltipTests()
+    {
+        Services.AddSingleton<IContentService>(_contentService);
+        Services.AddSingleton<ILanguageStateService>(_languageStateService);
+        _languageStateService.Selected = new Language { Key = Guid.NewGuid(), Name = "English" };
+    }
+
+    [Fact]
+    public void Loads_tooltip_from_content_service()
+    {
+        _contentService.Map["btn.delete.tooltip"] = "Delete this customer";
+
+        var cut = Render<Quilt4Tooltip>(p => p
+            .Add(c => c.TooltipKey, "btn.delete.tooltip")
+            .Add(c => c.DefaultTooltip, "Delete"));
+
+        cut.Instance.LoadedTooltip.Should().Be("Delete this customer");
+        // Verify the title attribute is on the wrapping span — that's how browsers surface
+        // the native hover-tooltip.
+        cut.Markup.Should().Contain("title=\"Delete this customer\"");
+    }
+
+    [Fact]
+    public void Falls_back_to_default_tooltip()
+    {
+        var cut = Render<Quilt4Tooltip>(p => p
+            .Add(c => c.TooltipKey, "missing.key")
+            .Add(c => c.DefaultTooltip, "Fallback hover text"));
+
+        cut.Instance.LoadedTooltip.Should().Be("Fallback hover text");
+    }
+
+    [Fact]
+    public void Wraps_child_content()
+    {
+        _contentService.Map["btn.help.tooltip"] = "Open help";
+
+        var cut = Render<Quilt4Tooltip>(p => p
+            .Add(c => c.TooltipKey, "btn.help.tooltip")
+            .Add(c => c.DefaultTooltip, "Help")
+            .AddChildContent("<button>?</button>"));
+
+        cut.Markup.Should().Contain("<button>?</button>", "tooltip wrapper must render its child content unchanged");
+        cut.Markup.Should().Contain("title=\"Open help\"");
+    }
+
+    private class FakeContentService : IContentService
+    {
+        public Dictionary<string, string> Map { get; } = new();
+
+        public Task<(string Value, bool Success)> GetContentAsync(string key, string defaultValue, Guid languageKey, ContentFormat? contentType, string application = null)
+        {
+            if (Map.TryGetValue(key ?? "", out var v) && !string.IsNullOrEmpty(v)) return Task.FromResult((v, true));
+            return Task.FromResult((defaultValue ?? "", false));
+        }
+
+        public Task SetContentAsync(string key, string value, Guid languageKey, ContentFormat contentType, string application = null) => Task.CompletedTask;
+        public Task ClearCacheAsync() => Task.CompletedTask;
+    }
+
+    private class FakeLanguageStateService : ILanguageStateService
+    {
+        public event EventHandler<LanguageLoadedEventArgs> LanguageLoadedEvent;
+        public event EventHandler<LanguageChangedEventArgs> LanguageChangedEvent;
+        public event EventHandler<DeveloperModeEventArgs> DeveloperModeEvent;
+        public Language Selected { get; set; }
+        public Language[] Languages { get; set; } = [];
+        public bool DeveloperMode { get; set; }
+        public Task<Language[]> ReloadAsync() => Task.FromResult(Languages);
+        public void RaiseLanguageChanged() => LanguageChangedEvent?.Invoke(this, new LanguageChangedEventArgs());
+        private void Unused() { LanguageLoadedEvent?.Invoke(this, null); DeveloperModeEvent?.Invoke(this, null); }
+    }
+}

--- a/Quilt4Net.Toolkit.Blazor/IQuilt4DialogService.cs
+++ b/Quilt4Net.Toolkit.Blazor/IQuilt4DialogService.cs
@@ -1,0 +1,26 @@
+using Radzen;
+
+namespace Quilt4Net.Toolkit.Blazor;
+
+/// <summary>
+/// Content-aware Confirm / Alert helpers for Radzen's <see cref="DialogService"/>. Resolves
+/// message and title strings through the content service in the currently-selected language,
+/// so a code-behind call can carry content keys instead of hard-coded strings or per-callsite
+/// <c>GetAsync</c> plumbing.
+/// </summary>
+public interface IQuilt4DialogService
+{
+    /// <summary>
+    /// Shows a confirmation dialog. <paramref name="messageKey"/> is resolved through the
+    /// content service; on miss / empty / lookup failure <paramref name="defaultMessage"/>
+    /// is shown. The same applies to the title (omit both to leave it blank).
+    /// </summary>
+    /// <returns><c>true</c> if the user confirmed, <c>false</c> if cancelled,
+    /// <c>null</c> if the dialog was closed without an explicit choice.</returns>
+    Task<bool?> ConfirmAsync(string messageKey, string defaultMessage, string titleKey = null, string defaultTitle = null);
+
+    /// <summary>
+    /// Shows an informational alert. Same key/default precedence as <see cref="ConfirmAsync"/>.
+    /// </summary>
+    Task AlertAsync(string messageKey, string defaultMessage, string titleKey = null, string defaultTitle = null);
+}

--- a/Quilt4Net.Toolkit.Blazor/IQuilt4NotificationService.cs
+++ b/Quilt4Net.Toolkit.Blazor/IQuilt4NotificationService.cs
@@ -1,0 +1,31 @@
+using Radzen;
+
+namespace Quilt4Net.Toolkit.Blazor;
+
+/// <summary>
+/// Content-aware wrapper around Radzen's <see cref="NotificationService"/>. Resolves
+/// summary and detail strings through the content service in the currently-selected
+/// language, so notification calls in C# don't need per-callsite <c>GetAsync</c> wiring.
+/// </summary>
+public interface IQuilt4NotificationService
+{
+    /// <summary>
+    /// Posts a notification. <paramref name="summaryKey"/> and (optionally)
+    /// <paramref name="detailKey"/> are resolved through the content service; on miss /
+    /// empty / lookup failure the corresponding default is shown.
+    /// </summary>
+    /// <param name="severity">Radzen severity (Info / Success / Warning / Error).</param>
+    /// <param name="summaryKey">Content key for the notification's summary line.</param>
+    /// <param name="defaultSummary">Fallback summary used when the key isn't set or the
+    /// lookup yields nothing.</param>
+    /// <param name="detailKey">Optional content key for the notification's detail line.</param>
+    /// <param name="defaultDetail">Optional fallback detail.</param>
+    /// <param name="duration">Display duration in milliseconds (Radzen default: 3000).</param>
+    Task NotifyAsync(
+        NotificationSeverity severity,
+        string summaryKey,
+        string defaultSummary,
+        string detailKey = null,
+        string defaultDetail = null,
+        double duration = 3000);
+}

--- a/Quilt4Net.Toolkit.Blazor/PlaceholderResolver.cs
+++ b/Quilt4Net.Toolkit.Blazor/PlaceholderResolver.cs
@@ -1,0 +1,32 @@
+using Quilt4Net.Toolkit.Features.Content;
+using Quilt4Net.Toolkit.Features.FeatureToggle;
+
+namespace Quilt4Net.Toolkit.Blazor;
+
+/// <summary>
+/// Shared content-lookup helper for the placeholder-wrapping Quilt4Radzen* components
+/// (<see cref="Quilt4RadzenTextBox"/>, <see cref="Quilt4RadzenTextArea"/>,
+/// <see cref="Quilt4RadzenDropDown{TValue}"/>, <see cref="Quilt4RadzenNumeric{TValue}"/>).
+/// Each component has its own pass-through param surface but the placeholder resolution
+/// is identical, so this lives in one place.
+/// </summary>
+internal static class PlaceholderResolver
+{
+    /// <summary>
+    /// Resolves <paramref name="key"/> via the content service in the currently-selected
+    /// language. Falls through to <paramref name="default"/> when the key is null/empty,
+    /// the service returns an empty value, or the lookup fails. Matches the precedence the
+    /// other Quilt4Radzen* wrappers (DataGridColumn / PanelMenuItem) already use.
+    /// </summary>
+    public static async Task<string> ResolveAsync(
+        IContentService contentService,
+        ILanguageStateService languageState,
+        string key,
+        string @default)
+    {
+        if (string.IsNullOrEmpty(key)) return @default;
+        var response = await contentService.GetContentAsync(
+            key, @default, languageState.Selected?.Key ?? Guid.Empty, ContentFormat.String);
+        return !string.IsNullOrEmpty(response.Value) ? response.Value : @default;
+    }
+}

--- a/Quilt4Net.Toolkit.Blazor/Quilt4Button.razor
+++ b/Quilt4Net.Toolkit.Blazor/Quilt4Button.razor
@@ -4,10 +4,19 @@
 @inject IContentService ContentService
 
 @* <Tharga.Blazor.StandardButton Text="@_text" Icon="@Icon" Click="@Click" /> *@
-<RadzenButton Text="@_text" Icon="@Icon" Click="@Click" Style="@Style" />
+<RadzenButton Text="@_text"
+              Icon="@Icon"
+              Click="@Click"
+              Style="@Style"
+              Attributes="@_attributes" />
 
 @code {
     private string _text;
+    // RadzenButton renders unknown DOM attributes from its `Attributes` dictionary. We use
+    // it to set the native HTML `title` for tooltips so icon-only buttons can carry a
+    // localised hover-text without TooltipService plumbing. Null/empty title attribute is
+    // dropped so we don't render `title=""` on buttons that never set a tooltip.
+    private IReadOnlyDictionary<string, object> _attributes;
 
     [Parameter]
     public string TextKey { get; set; }
@@ -23,6 +32,19 @@
 
     [Parameter]
     public string Style{ get; set; }
+
+    /// <summary>Optional content key resolved for the button's hover tooltip (HTML
+    /// <c>title</c> attribute). Falls back to <see cref="DefaultTooltip"/> on miss / empty /
+    /// lookup failure. Most useful on icon-only buttons; leave unset for buttons whose
+    /// label already speaks for itself.</summary>
+    [Parameter]
+    public string TooltipKey { get; set; }
+
+    /// <summary>Fallback tooltip used when <see cref="TooltipKey"/> isn't set or the lookup
+    /// yields nothing. Set this alone (without TooltipKey) for a static, non-localised
+    /// tooltip; set both for localised content with a sane fallback.</summary>
+    [Parameter]
+    public string DefaultTooltip { get; set; }
 
     protected override async Task OnInitializedAsync()
     {
@@ -40,6 +62,10 @@
     private async Task LoadContentAsync()
     {
         _text = (await ContentService.GetContentAsync(TextKey, DefaultText, LanguageStateService.Selected.Key, ContentFormat.String)).Value;
+        var tooltip = await PlaceholderResolver.ResolveAsync(ContentService, LanguageStateService, TooltipKey, DefaultTooltip);
+        _attributes = string.IsNullOrEmpty(tooltip)
+            ? null
+            : new Dictionary<string, object> { ["title"] = tooltip };
     }
 
 }

--- a/Quilt4Net.Toolkit.Blazor/Quilt4ContentRegistration.cs
+++ b/Quilt4Net.Toolkit.Blazor/Quilt4ContentRegistration.cs
@@ -32,6 +32,11 @@ public static class Quilt4ContentRegistration
         services.AddScoped<ILanguageStateService, LanguageStateService>();
         services.AddScoped<IQuilt4ContentService, Quilt4ContentService>();
         services.AddScoped<IContentAdminService, ContentAdminService>();
+        // Content-aware Radzen DialogService / NotificationService wrappers. Both depend on
+        // the already-registered Radzen services (host registers Radzen via AddRadzen* or
+        // AddScoped<DialogService>() / AddScoped<NotificationService>()).
+        services.AddScoped<IQuilt4DialogService, Quilt4DialogService>();
+        services.AddScoped<IQuilt4NotificationService, Quilt4NotificationService>();
         // Default adapter forwards to Tharga.Blazor's BreadCrumbService when registered, silently
         // no-ops otherwise. TryAdd so a host can swap in their own adapter ahead of this call.
         services.TryAddScoped<Features.Content.Pages.IPageBreadcrumbAdapter, Features.Content.Pages.TharBlazorBreadcrumbAdapter>();

--- a/Quilt4Net.Toolkit.Blazor/Quilt4DialogService.cs
+++ b/Quilt4Net.Toolkit.Blazor/Quilt4DialogService.cs
@@ -1,0 +1,37 @@
+using Quilt4Net.Toolkit.Features.Content;
+using Radzen;
+
+namespace Quilt4Net.Toolkit.Blazor;
+
+internal sealed class Quilt4DialogService : IQuilt4DialogService
+{
+    private readonly DialogService _dialogService;
+    private readonly IContentService _contentService;
+    private readonly ILanguageStateService _languageStateService;
+
+    public Quilt4DialogService(DialogService dialogService, IContentService contentService, ILanguageStateService languageStateService)
+    {
+        _dialogService = dialogService;
+        _contentService = contentService;
+        _languageStateService = languageStateService;
+    }
+
+    public async Task<bool?> ConfirmAsync(string messageKey, string defaultMessage, string titleKey = null, string defaultTitle = null)
+    {
+        var (message, title) = await ResolveAsync(messageKey, defaultMessage, titleKey, defaultTitle);
+        return await _dialogService.Confirm(message, title);
+    }
+
+    public async Task AlertAsync(string messageKey, string defaultMessage, string titleKey = null, string defaultTitle = null)
+    {
+        var (message, title) = await ResolveAsync(messageKey, defaultMessage, titleKey, defaultTitle);
+        await _dialogService.Alert(message, title);
+    }
+
+    private async Task<(string Message, string Title)> ResolveAsync(string messageKey, string defaultMessage, string titleKey, string defaultTitle)
+    {
+        var message = await PlaceholderResolver.ResolveAsync(_contentService, _languageStateService, messageKey, defaultMessage);
+        var title = await PlaceholderResolver.ResolveAsync(_contentService, _languageStateService, titleKey, defaultTitle);
+        return (message, title);
+    }
+}

--- a/Quilt4Net.Toolkit.Blazor/Quilt4NotificationService.cs
+++ b/Quilt4Net.Toolkit.Blazor/Quilt4NotificationService.cs
@@ -1,0 +1,39 @@
+using Quilt4Net.Toolkit.Features.Content;
+using Radzen;
+
+namespace Quilt4Net.Toolkit.Blazor;
+
+internal sealed class Quilt4NotificationService : IQuilt4NotificationService
+{
+    private readonly NotificationService _notificationService;
+    private readonly IContentService _contentService;
+    private readonly ILanguageStateService _languageStateService;
+
+    public Quilt4NotificationService(NotificationService notificationService, IContentService contentService, ILanguageStateService languageStateService)
+    {
+        _notificationService = notificationService;
+        _contentService = contentService;
+        _languageStateService = languageStateService;
+    }
+
+    public async Task NotifyAsync(
+        NotificationSeverity severity,
+        string summaryKey,
+        string defaultSummary,
+        string detailKey = null,
+        string defaultDetail = null,
+        double duration = 3000)
+    {
+        var summary = await PlaceholderResolver.ResolveAsync(_contentService, _languageStateService, summaryKey, defaultSummary);
+        var detail = string.IsNullOrEmpty(detailKey) && string.IsNullOrEmpty(defaultDetail)
+            ? null
+            : await PlaceholderResolver.ResolveAsync(_contentService, _languageStateService, detailKey, defaultDetail);
+        _notificationService.Notify(new NotificationMessage
+        {
+            Severity = severity,
+            Summary = summary,
+            Detail = detail,
+            Duration = duration,
+        });
+    }
+}

--- a/Quilt4Net.Toolkit.Blazor/Quilt4RadzenAlert.razor
+++ b/Quilt4Net.Toolkit.Blazor/Quilt4RadzenAlert.razor
@@ -1,0 +1,91 @@
+@using Quilt4Net.Toolkit.Features.Content
+@using Quilt4Net.Toolkit.Features.FeatureToggle
+@inject IContentService ContentService
+@inject ILanguageStateService LanguageStateService
+
+@*
+    Content-aware wrapper around <RadzenAlert>. Resolves Text and (optionally) Title from
+    the content service so an alert can carry a content key directly in markup, instead of
+    every host wiring up a code-behind GetAsync. Matches the existing Quilt4Radzen* shape:
+    {Property}Key + Default{Property}, with all other RadzenAlert parameters pass-through.
+    Subscribes to LanguageChangedEvent so the text updates live on language switch.
+*@
+<RadzenAlert Text="@LoadedText"
+             Title="@LoadedTitle"
+             AlertStyle="@AlertStyle"
+             Shade="@Shade"
+             ShowIcon="@ShowIcon"
+             Icon="@Icon"
+             Variant="@Variant"
+             Size="@Size"
+             AllowClose="@AllowClose"
+             Visible="@Visible"
+             Style="@Style"
+             Close="@Close">
+    @ChildContent
+</RadzenAlert>
+
+@code {
+    /// <summary>Content key resolved for the alert's Text. When the key is missing or the
+    /// resolved value is empty, <see cref="DefaultText"/> is shown.</summary>
+    [Parameter]
+    public string TextKey { get; set; }
+
+    /// <summary>Fallback text used when <see cref="TextKey"/> isn't set, the content service
+    /// returns an empty value, or the lookup fails.</summary>
+    [Parameter]
+    public string DefaultText { get; set; }
+
+    /// <summary>Optional content key for the alert's Title. Resolved the same way as
+    /// <see cref="TextKey"/>. Leave both this and <see cref="DefaultTitle"/> null for a
+    /// title-less alert.</summary>
+    [Parameter]
+    public string TitleKey { get; set; }
+
+    /// <summary>Fallback title used when <see cref="TitleKey"/> isn't set, the content service
+    /// returns an empty value, or the lookup fails.</summary>
+    [Parameter]
+    public string DefaultTitle { get; set; }
+
+    [Parameter] public AlertStyle AlertStyle { get; set; } = AlertStyle.Primary;
+    [Parameter] public Shade Shade { get; set; } = Shade.Default;
+    [Parameter] public bool ShowIcon { get; set; } = true;
+    [Parameter] public string Icon { get; set; }
+    [Parameter] public Variant Variant { get; set; } = Variant.Filled;
+    [Parameter] public AlertSize Size { get; set; } = AlertSize.Medium;
+    [Parameter] public bool AllowClose { get; set; } = true;
+    [Parameter] public bool Visible { get; set; } = true;
+    [Parameter] public string Style { get; set; }
+    [Parameter] public EventCallback Close { get; set; }
+    [Parameter] public RenderFragment ChildContent { get; set; }
+
+    internal string LoadedText { get; private set; }
+    internal string LoadedTitle { get; private set; }
+
+    protected override async Task OnInitializedAsync()
+    {
+        LanguageStateService.LanguageChangedEvent += async (_, _) =>
+        {
+            await LoadContentAsync();
+            await InvokeAsync(StateHasChanged);
+        };
+
+        await LoadContentAsync();
+    }
+
+    private async Task LoadContentAsync()
+    {
+        LoadedText = await ResolveAsync(TextKey, DefaultText);
+        LoadedTitle = await ResolveAsync(TitleKey, DefaultTitle);
+    }
+
+    // Same precedence as Quilt4RadzenDataGridColumn / Quilt4RadzenPanelMenuItem: take the
+    // service's value when present and non-empty, else fall back to the supplied default.
+    // Null/empty key is fine — GetContentAsync handles it (returns the default).
+    private async Task<string> ResolveAsync(string key, string @default)
+    {
+        if (string.IsNullOrEmpty(key)) return @default;
+        var response = await ContentService.GetContentAsync(key, @default, LanguageStateService.Selected?.Key ?? Guid.Empty, ContentFormat.String);
+        return !string.IsNullOrEmpty(response.Value) ? response.Value : @default;
+    }
+}

--- a/Quilt4Net.Toolkit.Blazor/Quilt4RadzenDataGrid.razor
+++ b/Quilt4Net.Toolkit.Blazor/Quilt4RadzenDataGrid.razor
@@ -1,0 +1,89 @@
+@using Quilt4Net.Toolkit.Features.Content
+@using Quilt4Net.Toolkit.Features.FeatureToggle
+@inject IContentService ContentService
+@inject ILanguageStateService LanguageStateService
+@typeparam TItem
+
+@*
+    Content-aware wrapper around <RadzenDataGrid>. The most common ask from #112: the
+    empty-state text. Existing `EmptyTemplate` + `<Quilt4Text>` works today, but a single
+    EmptyTextKey + DefaultEmptyText pair is tidier when the empty state is a plain string.
+
+    Note on scope. RadzenDataGrid has dozens of parameters; this wrapper deliberately
+    forwards only the most-used ones (sorting / filtering / paging / data binding +
+    the Columns / EmptyTemplate render fragments). Callers that need more granular
+    Radzen options should drop back to <RadzenDataGrid> directly with a
+    <Quilt4Text> inside their EmptyTemplate. The narrow surface is intentional —
+    wider mirroring drifts every Radzen release.
+*@
+<RadzenDataGrid TItem="TItem"
+                Data="@Data"
+                EmptyText="@LoadedEmptyText"
+                AllowSorting="@AllowSorting"
+                AllowFiltering="@AllowFiltering"
+                FilterMode="@FilterMode"
+                FilterCaseSensitivity="@FilterCaseSensitivity"
+                AllowPaging="@AllowPaging"
+                PageSize="@PageSize"
+                PageSizeOptions="@PageSizeOptions"
+                ShowPagingSummary="@ShowPagingSummary"
+                PagingSummaryFormat="@PagingSummaryFormat"
+                Visible="@Visible"
+                Style="@Style">
+    <Columns>
+        @Columns
+    </Columns>
+    <EmptyTemplate>
+        @EmptyTemplate
+    </EmptyTemplate>
+</RadzenDataGrid>
+
+@code {
+    /// <summary>Content key resolved for the grid's empty-state text. When the key is missing
+    /// or the resolved value is empty, <see cref="DefaultEmptyText"/> is shown. Ignored if the
+    /// host supplies an <see cref="EmptyTemplate"/> (Radzen falls back to its template-vs-text
+    /// precedence in that case).</summary>
+    [Parameter]
+    public string EmptyTextKey { get; set; }
+
+    /// <summary>Fallback empty-state text used when <see cref="EmptyTextKey"/> isn't set or
+    /// the lookup yields nothing.</summary>
+    [Parameter]
+    public string DefaultEmptyText { get; set; }
+
+    [Parameter] public System.Collections.Generic.IEnumerable<TItem> Data { get; set; }
+    [Parameter] public bool AllowSorting { get; set; } = true;
+    [Parameter] public bool AllowFiltering { get; set; }
+    [Parameter] public FilterMode FilterMode { get; set; } = FilterMode.Simple;
+    [Parameter] public FilterCaseSensitivity FilterCaseSensitivity { get; set; } = FilterCaseSensitivity.CaseInsensitive;
+    [Parameter] public bool AllowPaging { get; set; }
+    [Parameter] public int PageSize { get; set; } = 10;
+    [Parameter] public IEnumerable<int> PageSizeOptions { get; set; }
+    [Parameter] public bool ShowPagingSummary { get; set; }
+    [Parameter] public string PagingSummaryFormat { get; set; }
+    [Parameter] public bool Visible { get; set; } = true;
+    [Parameter] public string Style { get; set; }
+
+    /// <summary>Forwarded to RadzenDataGrid.Columns. Place the same RadzenDataGridColumn /
+    /// Quilt4RadzenDataGridColumn entries you'd put inside a plain RadzenDataGrid.</summary>
+    [Parameter] public RenderFragment Columns { get; set; }
+
+    /// <summary>Forwarded to RadzenDataGrid.EmptyTemplate. When set, Radzen prefers the
+    /// template over EmptyText regardless of how this wrapper resolved it.</summary>
+    [Parameter] public RenderFragment EmptyTemplate { get; set; }
+
+    internal string LoadedEmptyText { get; private set; }
+
+    protected override async Task OnInitializedAsync()
+    {
+        LanguageStateService.LanguageChangedEvent += async (_, _) =>
+        {
+            await LoadContentAsync();
+            await InvokeAsync(StateHasChanged);
+        };
+        await LoadContentAsync();
+    }
+
+    private async Task LoadContentAsync()
+        => LoadedEmptyText = await PlaceholderResolver.ResolveAsync(ContentService, LanguageStateService, EmptyTextKey, DefaultEmptyText);
+}

--- a/Quilt4Net.Toolkit.Blazor/Quilt4RadzenDropDown.razor
+++ b/Quilt4Net.Toolkit.Blazor/Quilt4RadzenDropDown.razor
@@ -1,0 +1,62 @@
+@using Quilt4Net.Toolkit.Features.Content
+@using Quilt4Net.Toolkit.Features.FeatureToggle
+@inject IContentService ContentService
+@inject ILanguageStateService LanguageStateService
+@typeparam TValue
+
+@* Content-aware wrapper around <RadzenDropDown>. See Quilt4RadzenTextBox for the rationale —
+   only Placeholder is resolved through the content service; everything else is pass-through.
+   Generic on TValue to mirror RadzenDropDown's signature. *@
+<RadzenDropDown TValue="TValue"
+                Value="@Value"
+                ValueChanged="@ValueChanged"
+                Data="@Data"
+                TextProperty="@TextProperty"
+                ValueProperty="@ValueProperty"
+                Placeholder="@LoadedPlaceholder"
+                AllowClear="@AllowClear"
+                AllowFiltering="@AllowFiltering"
+                Multiple="@Multiple"
+                Name="@Name"
+                Disabled="@Disabled"
+                Visible="@Visible"
+                Style="@Style"
+                Change="@Change" />
+
+@code {
+    /// <summary>Content key resolved for the dropdown's placeholder. Falls back to
+    /// <see cref="DefaultPlaceholder"/> on miss / empty / lookup failure.</summary>
+    [Parameter] public string PlaceholderKey { get; set; }
+
+    /// <summary>Fallback placeholder used when the key isn't set or the lookup yields nothing.</summary>
+    [Parameter] public string DefaultPlaceholder { get; set; }
+
+    [Parameter] public TValue Value { get; set; }
+    [Parameter] public EventCallback<TValue> ValueChanged { get; set; }
+    [Parameter] public System.Collections.IEnumerable Data { get; set; }
+    [Parameter] public string TextProperty { get; set; }
+    [Parameter] public string ValueProperty { get; set; }
+    [Parameter] public bool AllowClear { get; set; }
+    [Parameter] public bool AllowFiltering { get; set; }
+    [Parameter] public bool Multiple { get; set; }
+    [Parameter] public string Name { get; set; }
+    [Parameter] public bool Disabled { get; set; }
+    [Parameter] public bool Visible { get; set; } = true;
+    [Parameter] public string Style { get; set; }
+    [Parameter] public EventCallback<object> Change { get; set; }
+
+    internal string LoadedPlaceholder { get; private set; }
+
+    protected override async Task OnInitializedAsync()
+    {
+        LanguageStateService.LanguageChangedEvent += async (_, _) =>
+        {
+            await LoadContentAsync();
+            await InvokeAsync(StateHasChanged);
+        };
+        await LoadContentAsync();
+    }
+
+    private async Task LoadContentAsync()
+        => LoadedPlaceholder = await PlaceholderResolver.ResolveAsync(ContentService, LanguageStateService, PlaceholderKey, DefaultPlaceholder);
+}

--- a/Quilt4Net.Toolkit.Blazor/Quilt4RadzenLabel.razor
+++ b/Quilt4Net.Toolkit.Blazor/Quilt4RadzenLabel.razor
@@ -1,0 +1,44 @@
+@using Quilt4Net.Toolkit.Features.Content
+@using Quilt4Net.Toolkit.Features.FeatureToggle
+@inject IContentService ContentService
+@inject ILanguageStateService LanguageStateService
+
+@*
+    Content-aware wrapper around <RadzenLabel>. The Text param is resolved through the
+    content service; Component (the associated input's Name) and the rest of the Radzen
+    label params are pass-through.
+*@
+<RadzenLabel Text="@LoadedText"
+             Component="@Component"
+             Visible="@Visible"
+             Style="@Style" />
+
+@code {
+    /// <summary>Content key resolved for the label's Text. Falls back to <see cref="DefaultText"/>
+    /// on miss / empty / lookup failure.</summary>
+    [Parameter] public string TextKey { get; set; }
+
+    /// <summary>Fallback label text used when the key isn't set or the lookup yields nothing.</summary>
+    [Parameter] public string DefaultText { get; set; }
+
+    /// <summary>Name of the associated input — same semantics as <c>RadzenLabel.Component</c>.</summary>
+    [Parameter] public string Component { get; set; }
+
+    [Parameter] public bool Visible { get; set; } = true;
+    [Parameter] public string Style { get; set; }
+
+    internal string LoadedText { get; private set; }
+
+    protected override async Task OnInitializedAsync()
+    {
+        LanguageStateService.LanguageChangedEvent += async (_, _) =>
+        {
+            await LoadContentAsync();
+            await InvokeAsync(StateHasChanged);
+        };
+        await LoadContentAsync();
+    }
+
+    private async Task LoadContentAsync()
+        => LoadedText = await PlaceholderResolver.ResolveAsync(ContentService, LanguageStateService, TextKey, DefaultText);
+}

--- a/Quilt4Net.Toolkit.Blazor/Quilt4RadzenNumeric.razor
+++ b/Quilt4Net.Toolkit.Blazor/Quilt4RadzenNumeric.razor
@@ -1,0 +1,64 @@
+@using Quilt4Net.Toolkit.Features.Content
+@using Quilt4Net.Toolkit.Features.FeatureToggle
+@inject IContentService ContentService
+@inject ILanguageStateService LanguageStateService
+@typeparam TValue
+
+@* Content-aware wrapper around <RadzenNumeric>. See Quilt4RadzenTextBox for the rationale —
+   only Placeholder is resolved through the content service; everything else is pass-through.
+   Generic on TValue to mirror RadzenNumeric's signature (int, decimal, double, ...). *@
+<RadzenNumeric TValue="TValue"
+               Value="@Value"
+               ValueChanged="@ValueChanged"
+               Placeholder="@LoadedPlaceholder"
+               Min="@Min"
+               Max="@Max"
+               Step="@Step"
+               Format="@Format"
+               ShowUpDown="@ShowUpDown"
+               Name="@Name"
+               Disabled="@Disabled"
+               ReadOnly="@ReadOnly"
+               Visible="@Visible"
+               Style="@Style"
+               Change="@Change" />
+
+@code {
+    /// <summary>Content key resolved for the numeric input's placeholder. Falls back to
+    /// <see cref="DefaultPlaceholder"/> on miss / empty / lookup failure.</summary>
+    [Parameter] public string PlaceholderKey { get; set; }
+
+    /// <summary>Fallback placeholder used when the key isn't set or the lookup yields nothing.</summary>
+    [Parameter] public string DefaultPlaceholder { get; set; }
+
+    [Parameter] public TValue Value { get; set; }
+    [Parameter] public EventCallback<TValue> ValueChanged { get; set; }
+    // Min/Max/Step are 'dynamic' here to mirror RadzenNumeric's loosely-typed surface — pinning
+    // to decimal? gave CS1503 because Radzen accepts the value as object and coerces against TValue.
+    [Parameter] public dynamic Min { get; set; }
+    [Parameter] public dynamic Max { get; set; }
+    [Parameter] public dynamic Step { get; set; }
+    [Parameter] public string Format { get; set; }
+    [Parameter] public bool ShowUpDown { get; set; } = true;
+    [Parameter] public string Name { get; set; }
+    [Parameter] public bool Disabled { get; set; }
+    [Parameter] public bool ReadOnly { get; set; }
+    [Parameter] public bool Visible { get; set; } = true;
+    [Parameter] public string Style { get; set; }
+    [Parameter] public EventCallback<TValue> Change { get; set; }
+
+    internal string LoadedPlaceholder { get; private set; }
+
+    protected override async Task OnInitializedAsync()
+    {
+        LanguageStateService.LanguageChangedEvent += async (_, _) =>
+        {
+            await LoadContentAsync();
+            await InvokeAsync(StateHasChanged);
+        };
+        await LoadContentAsync();
+    }
+
+    private async Task LoadContentAsync()
+        => LoadedPlaceholder = await PlaceholderResolver.ResolveAsync(ContentService, LanguageStateService, PlaceholderKey, DefaultPlaceholder);
+}

--- a/Quilt4Net.Toolkit.Blazor/Quilt4RadzenTabsItem.razor
+++ b/Quilt4Net.Toolkit.Blazor/Quilt4RadzenTabsItem.razor
@@ -1,0 +1,45 @@
+@using Quilt4Net.Toolkit.Features.Content
+@using Quilt4Net.Toolkit.Features.FeatureToggle
+@inject IContentService ContentService
+@inject ILanguageStateService LanguageStateService
+
+@*
+    Content-aware wrapper around <RadzenTabsItem>. Use inside the Tabs collection of a
+    <RadzenTabs> the same way a regular RadzenTabsItem would be used; the Text param is
+    resolved through the content service.
+*@
+<RadzenTabsItem Text="@LoadedText"
+                Icon="@Icon"
+                Disabled="@Disabled"
+                Visible="@Visible">
+    @ChildContent
+</RadzenTabsItem>
+
+@code {
+    /// <summary>Content key resolved for the tab's Text. Falls back to <see cref="DefaultText"/>
+    /// on miss / empty / lookup failure.</summary>
+    [Parameter] public string TextKey { get; set; }
+
+    /// <summary>Fallback tab label used when the key isn't set or the lookup yields nothing.</summary>
+    [Parameter] public string DefaultText { get; set; }
+
+    [Parameter] public string Icon { get; set; }
+    [Parameter] public bool Disabled { get; set; }
+    [Parameter] public bool Visible { get; set; } = true;
+    [Parameter] public RenderFragment ChildContent { get; set; }
+
+    internal string LoadedText { get; private set; }
+
+    protected override async Task OnInitializedAsync()
+    {
+        LanguageStateService.LanguageChangedEvent += async (_, _) =>
+        {
+            await LoadContentAsync();
+            await InvokeAsync(StateHasChanged);
+        };
+        await LoadContentAsync();
+    }
+
+    private async Task LoadContentAsync()
+        => LoadedText = await PlaceholderResolver.ResolveAsync(ContentService, LanguageStateService, TextKey, DefaultText);
+}

--- a/Quilt4Net.Toolkit.Blazor/Quilt4RadzenTextArea.razor
+++ b/Quilt4Net.Toolkit.Blazor/Quilt4RadzenTextArea.razor
@@ -1,0 +1,55 @@
+@using Quilt4Net.Toolkit.Features.Content
+@using Quilt4Net.Toolkit.Features.FeatureToggle
+@inject IContentService ContentService
+@inject ILanguageStateService LanguageStateService
+
+@* Content-aware wrapper around <RadzenTextArea>. See Quilt4RadzenTextBox for the rationale —
+   only Placeholder is resolved through the content service; everything else is pass-through. *@
+<RadzenTextArea Value="@Value"
+                ValueChanged="@ValueChanged"
+                Placeholder="@LoadedPlaceholder"
+                Name="@Name"
+                Disabled="@Disabled"
+                ReadOnly="@ReadOnly"
+                Rows="@Rows"
+                Cols="@Cols"
+                MaxLength="@MaxLength"
+                Visible="@Visible"
+                Style="@Style"
+                Change="@Change" />
+
+@code {
+    /// <summary>Content key resolved for the textarea's placeholder. Falls back to
+    /// <see cref="DefaultPlaceholder"/> on miss / empty / lookup failure.</summary>
+    [Parameter] public string PlaceholderKey { get; set; }
+
+    /// <summary>Fallback placeholder used when the key isn't set or the lookup yields nothing.</summary>
+    [Parameter] public string DefaultPlaceholder { get; set; }
+
+    [Parameter] public string Value { get; set; }
+    [Parameter] public EventCallback<string> ValueChanged { get; set; }
+    [Parameter] public string Name { get; set; }
+    [Parameter] public bool Disabled { get; set; }
+    [Parameter] public bool ReadOnly { get; set; }
+    [Parameter] public int Rows { get; set; } = 3;
+    [Parameter] public int Cols { get; set; }
+    [Parameter] public long MaxLength { get; set; }
+    [Parameter] public bool Visible { get; set; } = true;
+    [Parameter] public string Style { get; set; }
+    [Parameter] public EventCallback<string> Change { get; set; }
+
+    internal string LoadedPlaceholder { get; private set; }
+
+    protected override async Task OnInitializedAsync()
+    {
+        LanguageStateService.LanguageChangedEvent += async (_, _) =>
+        {
+            await LoadContentAsync();
+            await InvokeAsync(StateHasChanged);
+        };
+        await LoadContentAsync();
+    }
+
+    private async Task LoadContentAsync()
+        => LoadedPlaceholder = await PlaceholderResolver.ResolveAsync(ContentService, LanguageStateService, PlaceholderKey, DefaultPlaceholder);
+}

--- a/Quilt4Net.Toolkit.Blazor/Quilt4RadzenTextBox.razor
+++ b/Quilt4Net.Toolkit.Blazor/Quilt4RadzenTextBox.razor
@@ -1,0 +1,57 @@
+@using Quilt4Net.Toolkit.Features.Content
+@using Quilt4Net.Toolkit.Features.FeatureToggle
+@inject IContentService ContentService
+@inject ILanguageStateService LanguageStateService
+
+@*
+    Content-aware wrapper around <RadzenTextBox>. Only Placeholder is resolved through the
+    content service; everything else is pass-through. Use this anywhere a code-behind
+    GetAsync was previously needed only to localise the placeholder attribute.
+*@
+<RadzenTextBox Value="@Value"
+               ValueChanged="@ValueChanged"
+               Placeholder="@LoadedPlaceholder"
+               Name="@Name"
+               Disabled="@Disabled"
+               ReadOnly="@ReadOnly"
+               MaxLength="@MaxLength"
+               Visible="@Visible"
+               Style="@Style"
+               Change="@Change" />
+
+@code {
+    /// <summary>Content key resolved for the input's placeholder. When the key is missing or
+    /// the resolved value is empty, <see cref="DefaultPlaceholder"/> is shown.</summary>
+    [Parameter]
+    public string PlaceholderKey { get; set; }
+
+    /// <summary>Fallback placeholder used when <see cref="PlaceholderKey"/> isn't set, the
+    /// content service returns an empty value, or the lookup fails.</summary>
+    [Parameter]
+    public string DefaultPlaceholder { get; set; }
+
+    [Parameter] public string Value { get; set; }
+    [Parameter] public EventCallback<string> ValueChanged { get; set; }
+    [Parameter] public string Name { get; set; }
+    [Parameter] public bool Disabled { get; set; }
+    [Parameter] public bool ReadOnly { get; set; }
+    [Parameter] public long MaxLength { get; set; }
+    [Parameter] public bool Visible { get; set; } = true;
+    [Parameter] public string Style { get; set; }
+    [Parameter] public EventCallback<string> Change { get; set; }
+
+    internal string LoadedPlaceholder { get; private set; }
+
+    protected override async Task OnInitializedAsync()
+    {
+        LanguageStateService.LanguageChangedEvent += async (_, _) =>
+        {
+            await LoadContentAsync();
+            await InvokeAsync(StateHasChanged);
+        };
+        await LoadContentAsync();
+    }
+
+    private async Task LoadContentAsync()
+        => LoadedPlaceholder = await PlaceholderResolver.ResolveAsync(ContentService, LanguageStateService, PlaceholderKey, DefaultPlaceholder);
+}

--- a/Quilt4Net.Toolkit.Blazor/Quilt4Tooltip.razor
+++ b/Quilt4Net.Toolkit.Blazor/Quilt4Tooltip.razor
@@ -1,0 +1,51 @@
+@using Quilt4Net.Toolkit.Features.Content
+@using Quilt4Net.Toolkit.Features.FeatureToggle
+@inject IContentService ContentService
+@inject ILanguageStateService LanguageStateService
+
+@*
+    Content-aware tooltip wrapper. Wraps arbitrary child content in a span that carries a
+    standard HTML `title="..."` attribute resolved through the content service. The
+    title="..." native tooltip is intentional — it's the most universal hover-tooltip
+    surface (no JS, works on icon-only buttons, links, plain text, etc.) and Radzen's
+    own components honour it.
+
+    For the Radzen popover-style RadzenTooltip + TooltipService imperative API, a host
+    that needs that surface can keep using TooltipService directly with a content-aware
+    string resolved via IQuilt4DialogService-style helpers — but the native title
+    attribute covers ~90% of real tooltip use today, and Quilt4Tooltip lands that without
+    new infrastructure.
+*@
+<span title="@LoadedTooltip" style="@Style">
+    @ChildContent
+</span>
+
+@code {
+    /// <summary>Content key resolved for the tooltip text. Falls back to <see cref="DefaultTooltip"/>
+    /// on miss / empty / lookup failure.</summary>
+    [Parameter] public string TooltipKey { get; set; }
+
+    /// <summary>Fallback tooltip text used when the key isn't set or the lookup yields nothing.</summary>
+    [Parameter] public string DefaultTooltip { get; set; }
+
+    /// <summary>The element(s) the tooltip is attached to.</summary>
+    [Parameter] public RenderFragment ChildContent { get; set; }
+
+    /// <summary>Optional inline style on the wrapping span (display: inline-block / flex / etc.).</summary>
+    [Parameter] public string Style { get; set; }
+
+    internal string LoadedTooltip { get; private set; }
+
+    protected override async Task OnInitializedAsync()
+    {
+        LanguageStateService.LanguageChangedEvent += async (_, _) =>
+        {
+            await LoadContentAsync();
+            await InvokeAsync(StateHasChanged);
+        };
+        await LoadContentAsync();
+    }
+
+    private async Task LoadContentAsync()
+        => LoadedTooltip = await PlaceholderResolver.ResolveAsync(ContentService, LanguageStateService, TooltipKey, DefaultTooltip);
+}

--- a/Quilt4Net.Toolkit.Blazor/README.md
+++ b/Quilt4Net.Toolkit.Blazor/README.md
@@ -34,9 +34,20 @@ builder.AddQuilt4NetBlazorContent(o =>
 
 ## Content components
 
-Render managed content using built-in Blazor components. Each component takes a `Key` to identify the content and a default value used when no content exists on the server.
+Two shapes ship in this package, with the same purpose — render text managed via Quilt4Net.Server in a Blazor app and have it switch language live without per-component plumbing.
 
-### Quilt4Text
+- **Standalone components** (`Quilt4Text`, `Quilt4Content`, `Quilt4Span`, `Quilt4Raw`, `Quilt4Button`, `Quilt4PageTitle`) — content-aware controls. Drop them in where you'd otherwise hard-code a string.
+- **Content-aware Radzen wrappers** (`Quilt4Radzen*`) — thin wrappers around Radzen components that resolve a specific `string` attribute (Text / Title / Placeholder / EmptyText / Tooltip) through the content service. Drop them in where the only thing you need to localise on a Radzen control is one or two text attributes.
+
+Every component below:
+
+- Subscribes to `ILanguageStateService.LanguageChangedEvent` so the resolved text re-renders live on language switch.
+- Falls back to the supplied default on miss / empty value / lookup failure — never throws.
+- Uses the same convention: `{Property}Key` for the content key and `Default{Property}` for the fallback.
+
+### Standalone components
+
+#### Quilt4Text
 
 Renders plain text using a Radzen `TextStyle`.
 
@@ -46,13 +57,13 @@ Renders plain text using a Radzen `TextStyle`.
 
 | Parameter | Default | Description |
 |-----------|---------|-------------|
-| `Key` | | Content key. |
-| `Default` | | Fallback text when no content exists. |
+| `Key` | — | Content key. |
+| `Default` | — | Fallback text when no content exists. |
 | `TextStyle` | `Body1` | Radzen `TextStyle` (H1, H2, Body1, etc.). |
 | `Visible` | `true` | Show or hide the component. |
 | `Style` | `null` | Custom CSS styles. |
 
-### Quilt4Content
+#### Quilt4Content
 
 Renders HTML content. The default value is provided as child content.
 
@@ -67,7 +78,7 @@ Renders HTML content. The default value is provided as child content.
 | `Key` | Content key. |
 | `ChildContent` | Default HTML content used when no content exists. |
 
-### Quilt4Span
+#### Quilt4Span
 
 Renders plain text in a `<span>` tag.
 
@@ -75,7 +86,7 @@ Renders plain text in a `<span>` tag.
 <Quilt4Span Key="MyLabel" Default="Status:" />
 ```
 
-### Quilt4Raw
+#### Quilt4Raw
 
 Renders plain text directly without any HTML wrapper.
 
@@ -83,12 +94,16 @@ Renders plain text directly without any HTML wrapper.
 <Quilt4Raw Key="MyValue" Default="OK" />
 ```
 
-### Quilt4Button
+#### Quilt4Button
 
-Renders a Radzen button with managed text.
+Renders a Radzen button with managed text — and, optionally, a managed hover tooltip (HTML `title` attribute). Particularly useful for icon-only buttons whose label is the icon alone.
 
 ```razor
 <Quilt4Button TextKey="SubmitBtn" DefaultText="Submit" Icon="send" Click="@OnSubmitClick" />
+
+<Quilt4Button Icon="delete"
+              TooltipKey="btn.delete.tooltip" DefaultTooltip="Delete this row"
+              Click="@OnDelete" />
 ```
 
 | Parameter | Description |
@@ -96,8 +111,233 @@ Renders a Radzen button with managed text.
 | `TextKey` | Content key for the button text. |
 | `DefaultText` | Fallback text. |
 | `Icon` | Radzen icon name. |
+| `TooltipKey` | Optional content key resolved into the button's `title` attribute. |
+| `DefaultTooltip` | Optional fallback tooltip text. Set without `TooltipKey` for a static, non-localised tooltip. |
 | `Click` | Async click handler (`Func<Task>`). |
 | `Style` | Custom CSS styles. |
+
+#### Quilt4PageTitle
+
+Wraps Blazor's `<PageTitle>` with a content-aware text.
+
+```razor
+<Quilt4PageTitle Key="page.about.title" Default="About us" />
+```
+
+| Parameter | Description |
+|-----------|-------------|
+| `Key` | Content key for the page title. |
+| `Default` | Fallback used when the key isn't set or the lookup yields nothing. |
+
+#### Quilt4Tooltip
+
+Wraps arbitrary child content with a `<span title="...">` that pulls the tooltip text from the content service. Use it on any element that doesn't already have a `TooltipKey` parameter (custom controls, links, plain `<div>` elements, etc.).
+
+```razor
+<Quilt4Tooltip TooltipKey="status.idle.tooltip" DefaultTooltip="Service is idle">
+    <i class="rzi rz-icon-check" />
+</Quilt4Tooltip>
+```
+
+| Parameter | Description |
+|-----------|-------------|
+| `TooltipKey` | Content key resolved into the HTML `title` attribute on the wrapping span. |
+| `DefaultTooltip` | Fallback tooltip text. |
+| `ChildContent` | The element(s) the tooltip is attached to. |
+| `Style` | Optional inline style on the wrapping span. |
+
+### Content-aware Radzen wrappers
+
+Drop-in wrappers around Radzen components. Pass the same parameters you would pass to the underlying Radzen control; the wrapper resolves one or two text attributes through the content service and forwards the rest unchanged.
+
+#### Quilt4RadzenAlert
+
+Wraps `<RadzenAlert>`. Resolves `Text` (required) and `Title` (optional) — keep the title slot null for a title-less alert.
+
+```razor
+<Quilt4RadzenAlert AlertStyle="AlertStyle.Info"
+                   TextKey="alert.permission.body"
+                   DefaultText="You don't have permission to do that."
+                   TitleKey="alert.permission.title"
+                   DefaultTitle="Permission denied" />
+```
+
+| Parameter | Description |
+|-----------|-------------|
+| `TextKey` / `DefaultText` | Content key + fallback for the alert body. |
+| `TitleKey` / `DefaultTitle` | Optional title pair. Omit both for a title-less alert. |
+| `AlertStyle`, `Shade`, `ShowIcon`, `Icon`, `Variant`, `Size`, `AllowClose`, `Visible`, `Style`, `Close`, `ChildContent` | Pass-through to `<RadzenAlert>`. |
+
+#### Quilt4RadzenDataGridColumn&lt;TItem&gt;
+
+Wraps `<RadzenDataGridColumn>`. Resolves the `Title` attribute. Drop in inline inside a `<RadzenDataGrid>` (or `Quilt4RadzenDataGrid`).
+
+```razor
+<RadzenDataGrid TItem="Customer" Data="@_customers">
+    <Columns>
+        <Quilt4RadzenDataGridColumn TItem="Customer" Property="@nameof(Customer.Name)"
+                                    TitleKey="col.customer.name" DefaultTitle="Name" />
+    </Columns>
+</RadzenDataGrid>
+```
+
+| Parameter | Description |
+|-----------|-------------|
+| `TitleKey` / `DefaultTitle` | Content key + fallback for the column header. |
+| `Property`, `Width`, `Sortable`, `Filterable`, `Visible`, `SortOrder`, `TextAlign`, `FormatString`, `Template` | Pass-through to `<RadzenDataGridColumn>`. |
+
+#### Quilt4RadzenDataGrid&lt;TItem&gt;
+
+Wraps `<RadzenDataGrid>`. Resolves the `EmptyText` attribute. Use for plain string empty-states; for richer empty content (icons, buttons), pass an `EmptyTemplate` instead and Radzen picks the template over the resolved text.
+
+```razor
+<Quilt4RadzenDataGrid TItem="Customer" Data="@_customers"
+                      EmptyTextKey="grid.customers.empty" DefaultEmptyText="No customers yet.">
+    <Columns>
+        <RadzenDataGridColumn TItem="Customer" Property="@nameof(Customer.Name)" Title="Name" />
+    </Columns>
+</Quilt4RadzenDataGrid>
+```
+
+| Parameter | Description |
+|-----------|-------------|
+| `EmptyTextKey` / `DefaultEmptyText` | Content key + fallback for the empty-state text. |
+| `Data`, `AllowSorting`, `AllowFiltering`, `FilterMode`, `FilterCaseSensitivity`, `AllowPaging`, `PageSize`, `PageSizeOptions`, `ShowPagingSummary`, `PagingSummaryFormat`, `Visible`, `Style`, `Columns`, `EmptyTemplate` | Pass-through to `<RadzenDataGrid>`. |
+
+> Note: this wrapper deliberately forwards only the most-used `RadzenDataGrid` parameters — wider mirroring drifts every Radzen release. If you need finer control, use `<RadzenDataGrid>` directly and place a `<Quilt4Text>` inside its `EmptyTemplate`.
+
+#### Quilt4RadzenPanelMenuItem
+
+Wraps `<RadzenPanelMenuItem>`. Resolves `Text`. Use inside a `<RadzenPanelMenu>`.
+
+```razor
+<RadzenPanelMenu>
+    <Quilt4RadzenPanelMenuItem TextKey="menu.home" DefaultText="Home" Icon="home" Path="/" />
+    <Quilt4RadzenPanelMenuItem TextKey="menu.customers" DefaultText="Customers" Icon="people" Path="/customers" />
+</RadzenPanelMenu>
+```
+
+| Parameter | Description |
+|-----------|-------------|
+| `TextKey` / `DefaultText` | Content key + fallback for the menu-item label. |
+| `Icon`, `Path`, `Target`, `Expanded`, `ExpandedChanged`, `Selected`, `Disabled`, `IconColor`, `Image`, `ImageAlternateText`, `Click`, `ChildContent` | Pass-through to `<RadzenPanelMenuItem>`. |
+
+#### Quilt4RadzenTabsItem
+
+Wraps `<RadzenTabsItem>`. Resolves `Text`. Use inside `<RadzenTabs>`'s `Tabs` slot.
+
+```razor
+<RadzenTabs>
+    <Tabs>
+        <Quilt4RadzenTabsItem TextKey="tab.overview" DefaultText="Overview">
+            ...
+        </Quilt4RadzenTabsItem>
+    </Tabs>
+</RadzenTabs>
+```
+
+| Parameter | Description |
+|-----------|-------------|
+| `TextKey` / `DefaultText` | Content key + fallback for the tab label. |
+| `Icon`, `Disabled`, `Visible`, `ChildContent` | Pass-through. |
+
+#### Quilt4RadzenLabel
+
+Wraps `<RadzenLabel>`. Resolves `Text`.
+
+```razor
+<Quilt4RadzenLabel TextKey="form.name.label" DefaultText="Name" Component="Name" />
+<Quilt4RadzenTextBox Name="Name" @bind-Value="@_name" />
+```
+
+| Parameter | Description |
+|-----------|-------------|
+| `TextKey` / `DefaultText` | Content key + fallback for the label text. |
+| `Component` | Name of the associated input — same as `RadzenLabel.Component`. |
+| `Visible`, `Style` | Pass-through. |
+
+#### Quilt4RadzenTextBox / Quilt4RadzenTextArea / Quilt4RadzenDropDown&lt;TValue&gt; / Quilt4RadzenNumeric&lt;TValue&gt;
+
+Wrap the four input controls. All resolve `Placeholder` only; the rest is pass-through. Use these whenever the only content-bound attribute is the placeholder — for any richer localisation, drop back to the underlying Radzen control with `<Quilt4Text>` inside as a label.
+
+```razor
+<Quilt4RadzenTextBox @bind-Value="@_name"
+                     PlaceholderKey="input.name" DefaultPlaceholder="Type your name..." />
+
+<Quilt4RadzenTextArea @bind-Value="@_notes"
+                      PlaceholderKey="input.notes" DefaultPlaceholder="Notes..." Rows="4" />
+
+<Quilt4RadzenDropDown TValue="string" Data="@_countries"
+                      @bind-Value="@_country"
+                      PlaceholderKey="input.country" DefaultPlaceholder="Choose country" />
+
+<Quilt4RadzenNumeric TValue="int" @bind-Value="@_quantity"
+                     PlaceholderKey="input.quantity" DefaultPlaceholder="Quantity"
+                     Min="1" Max="100" />
+```
+
+All four share these content-aware parameters:
+
+| Parameter | Description |
+|-----------|-------------|
+| `PlaceholderKey` | Content key for the input's placeholder. |
+| `DefaultPlaceholder` | Fallback placeholder. |
+
+Plus the type-specific pass-through (`Value`, `ValueChanged`, `Name`, `Disabled`, `ReadOnly`, plus the control-specific ones — `Rows` / `Cols` on TextArea, `Data` / `TextProperty` / `ValueProperty` / `Multiple` / `AllowFiltering` / `AllowClear` on DropDown, `Min` / `Max` / `Step` / `Format` / `ShowUpDown` on Numeric).
+
+### Content-aware Radzen services
+
+For the two Radzen services that take text as a method argument rather than as a component attribute, this package ships content-aware wrappers registered alongside `AddQuilt4NetBlazorContent`:
+
+#### IQuilt4DialogService
+
+Confirm / Alert dialogs whose message and (optional) title come from content keys.
+
+```razor
+@inject IQuilt4DialogService Q4Dialogs
+
+@code {
+    private async Task DeleteAsync()
+    {
+        var ok = await Q4Dialogs.ConfirmAsync(
+            messageKey: "delete.customer.confirm",
+            defaultMessage: "Are you sure you want to delete this customer?",
+            titleKey: "delete.confirm.title",
+            defaultTitle: "Confirm delete");
+        if (ok == true) { ... }
+    }
+}
+```
+
+| Method | Description |
+|--------|-------------|
+| `ConfirmAsync(messageKey, defaultMessage, titleKey?, defaultTitle?)` | Resolves the keys then calls Radzen's `DialogService.Confirm`. Returns the same `bool?`. |
+| `AlertAsync(messageKey, defaultMessage, titleKey?, defaultTitle?)` | Resolves the keys then calls `DialogService.Alert`. |
+
+#### IQuilt4NotificationService
+
+Notifications whose summary and (optional) detail come from content keys.
+
+```razor
+@inject IQuilt4NotificationService Q4Notifications
+
+@code {
+    private async Task SaveAsync()
+    {
+        ...
+        await Q4Notifications.NotifyAsync(
+            NotificationSeverity.Success,
+            summaryKey: "save.success.summary",
+            defaultSummary: "Saved",
+            detailKey: "save.success.detail",
+            defaultDetail: "Your changes have been saved.");
+    }
+}
+```
+
+| Method | Description |
+|--------|-------------|
+| `NotifyAsync(severity, summaryKey, defaultSummary, detailKey?, defaultDetail?, duration = 3000)` | Resolves the keys then posts via `NotificationService.Notify`. |
 
 ## Hierarchical pages
 

--- a/docs/articles/content-components.md
+++ b/docs/articles/content-components.md
@@ -1,0 +1,258 @@
+# Content components
+
+Blazor components in `Quilt4Net.Toolkit.Blazor` for rendering content managed at [Quilt4Net Web](https://quilt4net.com). Two shapes:
+
+- **Standalone components** drop a content-aware control directly into markup.
+- **Content-aware Radzen wrappers** wrap an existing Radzen component and resolve one or two of its text attributes through the content service so the rest of the API stays exactly the same.
+
+Every component below:
+
+- Subscribes to `ILanguageStateService.LanguageChangedEvent` so the resolved text re-renders live on language switch.
+- Falls back to the supplied default on miss / empty value / lookup failure — never throws.
+- Follows the same naming: `{Property}Key` for the content key, `Default{Property}` for the fallback.
+
+## Standalone components
+
+### `<Quilt4Text>`
+
+Plain text inside a Radzen `<RadzenText>` with a `TextStyle`.
+
+```razor
+<Quilt4Text Key="welcome.title" Default="Welcome" TextStyle="TextStyle.H1" />
+```
+
+| Parameter | Default | Description |
+|---|---|---|
+| `Key` | — | Content key. |
+| `Default` | — | Fallback text. |
+| `TextStyle` | `Body1` | Radzen text style. |
+| `Visible` | `true` | Show or hide. |
+| `Style` | `null` | Inline CSS. |
+
+### `<Quilt4Content>`
+
+HTML content. The default is provided as child content (rendered as `MarkupString` when no remote value exists).
+
+```razor
+<Quilt4Content Key="footer.copy">
+    &copy; 2026 ACME Co. <a href="/privacy">Privacy</a>
+</Quilt4Content>
+```
+
+### `<Quilt4Span>` / `<Quilt4Raw>`
+
+Plain-string variants of `Quilt4Text`. `Quilt4Span` wraps in `<span>`; `Quilt4Raw` writes the resolved string directly with no wrapper.
+
+```razor
+<Quilt4Span Key="label.status" Default="Status:" />
+<Quilt4Raw Key="value.ok" Default="OK" />
+```
+
+### `<Quilt4Button>`
+
+A Radzen button with managed Text **and** an optional managed hover tooltip (HTML `title`). Especially useful for icon-only buttons.
+
+```razor
+<Quilt4Button TextKey="btn.submit" DefaultText="Submit" Icon="send" Click="@OnSubmit" />
+
+<Quilt4Button Icon="delete"
+              TooltipKey="btn.delete.tooltip" DefaultTooltip="Delete this row"
+              Click="@OnDelete" />
+```
+
+| Parameter | Description |
+|---|---|
+| `TextKey` / `DefaultText` | Label content key + fallback. |
+| `TooltipKey` / `DefaultTooltip` | Optional hover-tooltip content key + fallback. Set just the default for a static (non-localised) tooltip. |
+| `Icon` | Radzen icon name. |
+| `Click` | `Func<Task>` click handler. |
+| `Style` | Inline CSS. |
+
+### `<Quilt4PageTitle>`
+
+Wraps Blazor's `<PageTitle>` with a content-aware title.
+
+```razor
+<Quilt4PageTitle Key="page.about.title" Default="About us" />
+```
+
+### `<Quilt4Tooltip>`
+
+A `<span title="...">` wrapper that pulls its tooltip text from the content service. Use on any element that doesn't already have a `TooltipKey` parameter (custom controls, links, icons, plain `<div>` etc.).
+
+```razor
+<Quilt4Tooltip TooltipKey="status.idle.tooltip" DefaultTooltip="Service is idle">
+    <i class="rzi rz-icon-check" />
+</Quilt4Tooltip>
+```
+
+| Parameter | Description |
+|---|---|
+| `TooltipKey` / `DefaultTooltip` | Tooltip content key + fallback. |
+| `ChildContent` | The element(s) the tooltip is attached to. |
+| `Style` | Inline CSS on the wrapping span. |
+
+## Content-aware Radzen wrappers
+
+Same parameter shape you'd pass to the underlying Radzen control, **plus** a content-aware pair for one or two text attributes. Everything else is pass-through unchanged.
+
+### `<Quilt4RadzenAlert>`
+
+Wraps `<RadzenAlert>`. Resolves `Text` (required) and `Title` (optional).
+
+```razor
+<Quilt4RadzenAlert AlertStyle="AlertStyle.Info"
+                   TextKey="alert.permission.body"
+                   DefaultText="You don't have permission to do that."
+                   TitleKey="alert.permission.title"
+                   DefaultTitle="Permission denied" />
+```
+
+Title is omitted entirely (no empty title bar) when neither `TitleKey` nor `DefaultTitle` is set.
+
+### `<Quilt4RadzenDataGridColumn TItem="...">`
+
+Wraps `<RadzenDataGridColumn>`. Resolves `Title`. Drop in inline inside a `<RadzenDataGrid>` (or `Quilt4RadzenDataGrid`).
+
+```razor
+<RadzenDataGrid TItem="Customer" Data="@_customers">
+    <Columns>
+        <Quilt4RadzenDataGridColumn TItem="Customer"
+                                    Property="@nameof(Customer.Name)"
+                                    TitleKey="col.customer.name"
+                                    DefaultTitle="Name" />
+    </Columns>
+</RadzenDataGrid>
+```
+
+Pass-through: `Property`, `Width`, `Sortable`, `Filterable`, `Visible`, `SortOrder`, `TextAlign`, `FormatString`, `Template`.
+
+### `<Quilt4RadzenDataGrid TItem="...">`
+
+Wraps `<RadzenDataGrid>`. Resolves `EmptyText`. Use it when the empty state is plain text; for richer empty content, pass an `EmptyTemplate` and Radzen prefers the template over the resolved text.
+
+```razor
+<Quilt4RadzenDataGrid TItem="Customer" Data="@_customers"
+                      EmptyTextKey="grid.customers.empty"
+                      DefaultEmptyText="No customers yet.">
+    <Columns>
+        <RadzenDataGridColumn TItem="Customer" Property="@nameof(Customer.Name)" Title="Name" />
+    </Columns>
+</Quilt4RadzenDataGrid>
+```
+
+> **Surface scope.** This wrapper forwards only the most-used `RadzenDataGrid` parameters (sorting / filtering / paging / `Data` / `Columns` / `EmptyTemplate`). For finer control, use `<RadzenDataGrid>` directly with `<Quilt4Text>` inside its `EmptyTemplate`.
+
+### `<Quilt4RadzenPanelMenuItem>`
+
+Wraps `<RadzenPanelMenuItem>`. Resolves `Text`.
+
+```razor
+<RadzenPanelMenu>
+    <Quilt4RadzenPanelMenuItem TextKey="menu.home" DefaultText="Home" Icon="home" Path="/" />
+    <Quilt4RadzenPanelMenuItem TextKey="menu.customers" DefaultText="Customers" Icon="people" Path="/customers" />
+</RadzenPanelMenu>
+```
+
+### `<Quilt4RadzenTabsItem>` and `<Quilt4RadzenLabel>`
+
+Wrap `<RadzenTabsItem>` and `<RadzenLabel>` respectively. Both resolve `Text`.
+
+```razor
+<RadzenTabs>
+    <Tabs>
+        <Quilt4RadzenTabsItem TextKey="tab.overview" DefaultText="Overview">...</Quilt4RadzenTabsItem>
+        <Quilt4RadzenTabsItem TextKey="tab.activity" DefaultText="Activity">...</Quilt4RadzenTabsItem>
+    </Tabs>
+</RadzenTabs>
+
+<Quilt4RadzenLabel TextKey="form.name.label" DefaultText="Name" Component="Name" />
+<Quilt4RadzenTextBox Name="Name" @bind-Value="@_name" />
+```
+
+### Input placeholders: `<Quilt4RadzenTextBox>` / `<Quilt4RadzenTextArea>` / `<Quilt4RadzenDropDown TValue="...">` / `<Quilt4RadzenNumeric TValue="...">`
+
+The four input wrappers each resolve a single `Placeholder` attribute. Everything else — value binding, validation, change events, type-specific controls — is straight pass-through.
+
+```razor
+<Quilt4RadzenTextBox @bind-Value="@_name"
+                     PlaceholderKey="input.name" DefaultPlaceholder="Type your name..." />
+
+<Quilt4RadzenTextArea @bind-Value="@_notes"
+                      PlaceholderKey="input.notes" DefaultPlaceholder="Notes..."
+                      Rows="4" />
+
+<Quilt4RadzenDropDown TValue="string" Data="@_countries"
+                      @bind-Value="@_country"
+                      PlaceholderKey="input.country" DefaultPlaceholder="Choose country" />
+
+<Quilt4RadzenNumeric TValue="int" @bind-Value="@_quantity"
+                     PlaceholderKey="input.quantity" DefaultPlaceholder="Quantity"
+                     Min="1" Max="100" />
+```
+
+Common content-aware parameters across all four:
+
+| Parameter | Description |
+|---|---|
+| `PlaceholderKey` | Content key for the input's placeholder. |
+| `DefaultPlaceholder` | Fallback placeholder. |
+
+Plus per-control pass-through: `Value` / `ValueChanged` / `Name` / `Disabled` / `ReadOnly` / `Change` on all; `Rows` / `Cols` on TextArea; `Data` / `TextProperty` / `ValueProperty` / `Multiple` / `AllowFiltering` / `AllowClear` on DropDown; `Min` / `Max` / `Step` / `Format` / `ShowUpDown` on Numeric.
+
+## Content-aware Radzen services
+
+For the two Radzen services that take user-facing text as method arguments rather than as component attributes, `AddQuilt4NetBlazorContent` also registers content-aware wrappers.
+
+### `IQuilt4DialogService`
+
+Confirm / Alert dialogs whose message and (optional) title come from content keys.
+
+```razor
+@inject IQuilt4DialogService Q4Dialogs
+
+@code {
+    private async Task DeleteAsync()
+    {
+        var ok = await Q4Dialogs.ConfirmAsync(
+            messageKey: "delete.customer.confirm",
+            defaultMessage: "Are you sure you want to delete this customer?",
+            titleKey: "delete.confirm.title",
+            defaultTitle: "Confirm delete");
+        if (ok != true) return;
+        await DoDelete();
+    }
+}
+```
+
+Both `ConfirmAsync` and `AlertAsync` resolve the keys via the content service, then call Radzen's `DialogService.Confirm` / `Alert`. The return contract (`bool?` / `void`) is unchanged.
+
+### `IQuilt4NotificationService`
+
+Notifications whose summary and (optional) detail come from content keys.
+
+```razor
+@inject IQuilt4NotificationService Q4Notifications
+
+@code {
+    private async Task OnSaved()
+    {
+        await Q4Notifications.NotifyAsync(
+            NotificationSeverity.Success,
+            summaryKey: "save.success.summary", defaultSummary: "Saved",
+            detailKey: "save.success.detail", defaultDetail: "Your changes have been saved.");
+    }
+}
+```
+
+| Parameter | Description |
+|---|---|
+| `severity` | Radzen `NotificationSeverity` (Info / Success / Warning / Error). |
+| `summaryKey` / `defaultSummary` | Required summary content key + fallback. |
+| `detailKey` / `defaultDetail` | Optional detail pair. Both null → no detail line. |
+| `duration` | Display duration in ms (default 3000). |
+
+## Where next
+
+- **[Log views](log-views.md)** — content-aware host of the AI log surface.
+- **[Version matrix](version-matrix.md)** — app × env grid sourced from the same workspace.

--- a/docs/articles/toc.yml
+++ b/docs/articles/toc.yml
@@ -4,6 +4,8 @@
   href: getting-started.md
 - name: Telemetry identity & correlation
   href: telemetry-identity.md
+- name: Content components
+  href: content-components.md
 - name: Log views
   href: log-views.md
 - name: Metrics


### PR DESCRIPTION
## Summary

Implements the six requests in #112 — content-aware wrappers around the Radzen surfaces where consumers were previously dropping back to code-behind `GetAsync` just to localise a single string attribute. Plus a documentation sweep that brings every existing and new `Quilt4*` content component into the README and a new docfx article.

### New components

| Component | What it resolves through the content service |
|---|---|
| `Quilt4RadzenAlert` | `Text` (required) + `Title` (optional) |
| `Quilt4RadzenTextBox` / `Quilt4RadzenTextArea` / `Quilt4RadzenDropDown<TValue>` / `Quilt4RadzenNumeric<TValue>` | `Placeholder` |
| `Quilt4RadzenDataGrid<TItem>` | `EmptyText` |
| `Quilt4RadzenTabsItem` | `Text` |
| `Quilt4RadzenLabel` | `Text` |
| `Quilt4Tooltip` | Native HTML `title` attribute on any wrapped element |
| `Quilt4Button` *(updated)* | adds `TooltipKey` / `DefaultTooltip` for the button's hover tooltip |
| `IQuilt4DialogService` | `Confirm` / `Alert` message + (optional) title |
| `IQuilt4NotificationService` | `Notify` summary + (optional) detail |

All follow the existing `Quilt4RadzenDataGridColumn` / `Quilt4RadzenPanelMenuItem` shape:
- `{Property}Key` for the content key, `Default{Property}` for the fallback.
- Subscribed to `ILanguageStateService.LanguageChangedEvent` so the text re-renders live on language switch.
- Service-resolved value when present and non-empty, else the supplied default. Never throws.
- An internal `PlaceholderResolver` helper centralises the lookup so the wrappers don't each carry a copy.

### Documentation

`Quilt4Net.Toolkit.Blazor/README.md` "Content components" section is now authoritative:
- **Splits** into Standalone / Radzen wrappers / Radzen services.
- **Documents every existing `Quilt4*` component**, including ones that were previously undocumented or barely mentioned (`Quilt4RadzenDataGridColumn`, `Quilt4RadzenPanelMenuItem`, `Quilt4PageTitle`).
- **Documents every new wrapper** from this PR with a copy-paste snippet and full parameter list.

New `docs/articles/content-components.md` mirrors the README in docfx format, linked from `toc.yml` between *Telemetry identity & correlation* and *Log views*.

## Test plan

- [x] `dotnet test Toolkit/Quilt4Net.Toolkit.sln` — **362/362 green** (Blazor 84 → 111, +27 new).
- [x] `docfx build` clean — 0 errors, 0 warnings.
- [x] Build clean across the solution.
- [ ] Smoke-test in a downstream consumer (Eplicta FortDocs filed the issue).

## Commit-by-commit

The branch implements each piece in its own commit so a reviewer can pull individual asks if needed:
- `3ae5b0c` Quilt4RadzenAlert + tests (6)
- `0c1cba0` Placeholders × 4 + tests (7)
- `bbd78f8` Quilt4RadzenDataGrid + tests (3)
- `e13b190` Quilt4RadzenTabsItem + Quilt4RadzenLabel + tests (5)
- `73fbfed` IQuilt4DialogService + IQuilt4NotificationService + tests (3)
- `c9ecb73` Quilt4Tooltip + TooltipKey on Quilt4Button + tests (3)
- `668bb60` README + docs/articles content-components sweep