### PR TITLE
feat: content startup warm-up (bulk load + per-language cache counts)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@ on:
     branches: [master]
 
 env:
-  MAJOR_MINOR: '0.8'
+  MAJOR_MINOR: '0.9'
 
 permissions:
   contents: write

--- a/Quilt4Net.Toolkit.Blazor.Tests/ContentWarmupTests.cs
+++ b/Quilt4Net.Toolkit.Blazor.Tests/ContentWarmupTests.cs
@@ -1,0 +1,111 @@
+using System.Collections.Concurrent;
+using Blazored.LocalStorage;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Quilt4Net.Toolkit;
+using Quilt4Net.Toolkit.Blazor;
+using Quilt4Net.Toolkit.Features.Content;
+using Quilt4Net.Toolkit.Features.FeatureToggle;
+using Xunit;
+
+namespace Quilt4Net.Toolkit.Blazor.Tests;
+
+public class ContentWarmupTests
+{
+    [Fact]
+    public async Task HostedService_warms_the_default_language_on_start_when_enabled()
+    {
+        var call = new RecordingRemoteCallService();
+        var sut = new ContentWarmupHostedService(call, Options.Create(new ContentOptions { WarmUpEnabled = true }),
+            NullLogger<ContentWarmupHostedService>.Instance);
+
+        await sut.StartAsync(CancellationToken.None);
+
+        (await WaitUntil(() => call.Calls.Any(c => c == Guid.Empty))).Should().BeTrue();
+        call.Calls.Should().ContainSingle().Which.Should().Be(Guid.Empty);
+    }
+
+    [Fact]
+    public async Task HostedService_does_not_warm_when_disabled()
+    {
+        var call = new RecordingRemoteCallService();
+        var sut = new ContentWarmupHostedService(call, Options.Create(new ContentOptions { WarmUpEnabled = false }),
+            NullLogger<ContentWarmupHostedService>.Instance);
+
+        await sut.StartAsync(CancellationToken.None);
+
+        await Task.Delay(150);
+        call.Calls.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task LanguageStateService_warms_a_newly_selected_non_default_language()
+    {
+        var call = new RecordingRemoteCallService();
+        var other = new Language { Key = Guid.NewGuid(), Name = "Swedish" };
+        var languages = new[] { new Language { Key = Guid.Empty, Name = "Default" }, other };
+        var sut = new LanguageStateService(new FakeLanguageService(languages), new NoopLocalStorage(), call);
+
+        sut.Selected = other;
+
+        (await WaitUntil(() => call.Calls.Contains(other.Key))).Should().BeTrue("selecting a non-default language warms its content");
+        call.Calls.Should().NotContain(Guid.Empty, "the default language is warmed at startup, not by the selector");
+    }
+
+    private static async Task<bool> WaitUntil(Func<bool> condition, int timeoutMs = 2000)
+    {
+        var deadline = Environment.TickCount64 + timeoutMs;
+        while (Environment.TickCount64 < deadline)
+        {
+            if (condition()) return true;
+            await Task.Delay(20);
+        }
+        return condition();
+    }
+
+    private sealed class RecordingRemoteCallService : IRemoteContentCallService
+    {
+        public ConcurrentBag<Guid> Calls { get; } = [];
+
+        public Task WarmCacheAsync(Guid languageKey, string application = null)
+        {
+            Calls.Add(languageKey);
+            return Task.CompletedTask;
+        }
+
+        public Task<(string Value, bool Success)> GetContentAsync(string key, string defaultValue, Guid languageKey, ContentFormat? contentType, string application = null)
+            => Task.FromResult((defaultValue, true));
+        public Task SetContentAsync(string key, string defaultValue, Guid languageKey, ContentFormat contentType, string application = null) => Task.CompletedTask;
+        public Task<Language[]> GetLanguagesAsync(bool forceReload) => Task.FromResult(Array.Empty<Language>());
+        public Task ClearContentCacheAsync() => Task.CompletedTask;
+        public IReadOnlyDictionary<Guid, int> GetCacheCountsByLanguage() => new Dictionary<Guid, int>();
+    }
+
+    private sealed class FakeLanguageService(Language[] languages) : ILanguageService
+    {
+        public Task<Language[]> GetLanguagesAsync(bool forceReload) => Task.FromResult(languages);
+    }
+
+    // Only the two members LanguageStateService touches are implemented; the rest are unused here.
+    private sealed class NoopLocalStorage : ILocalStorageService
+    {
+        public ValueTask<T> GetItemAsync<T>(string key, CancellationToken cancellationToken = default) => new(default(T));
+        public ValueTask SetItemAsync<T>(string key, T data, CancellationToken cancellationToken = default) => ValueTask.CompletedTask;
+
+        public ValueTask ClearAsync(CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public ValueTask<bool> ContainKeyAsync(string key, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public ValueTask<string> GetItemAsStringAsync(string key, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public ValueTask<string> KeyAsync(int index, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public ValueTask<IEnumerable<string>> KeysAsync(CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public ValueTask<int> LengthAsync(CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public ValueTask RemoveItemAsync(string key, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public ValueTask RemoveItemsAsync(IEnumerable<string> keys, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public ValueTask SetItemAsStringAsync(string key, string data, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+
+#pragma warning disable CS0067
+        public event EventHandler<ChangingEventArgs> Changing;
+        public event EventHandler<ChangedEventArgs> Changed;
+#pragma warning restore CS0067
+    }
+}

--- a/Quilt4Net.Toolkit.Blazor/ContentWarmupHostedService.cs
+++ b/Quilt4Net.Toolkit.Blazor/ContentWarmupHostedService.cs
@@ -1,0 +1,49 @@
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Quilt4Net.Toolkit.Features.Content;
+
+namespace Quilt4Net.Toolkit.Blazor;
+
+/// <summary>
+/// Pre-fills the content cache with the default language at application startup via one bulk call,
+/// so the first page render serves from a warm cache instead of fanning out a request per key.
+/// Runs in the background (does not block startup) and is best-effort — any failure is swallowed by
+/// the warm-up call, leaving the normal per-key path intact. Disabled via <see cref="ContentOptions.WarmUpEnabled"/>.
+/// The selected (non-default) language is warmed per-circuit by <see cref="LanguageStateService"/>.
+/// </summary>
+internal sealed class ContentWarmupHostedService : IHostedService
+{
+    private readonly IRemoteContentCallService _callService;
+    private readonly ContentOptions _options;
+    private readonly ILogger<ContentWarmupHostedService> _logger;
+
+    public ContentWarmupHostedService(IRemoteContentCallService callService, IOptions<ContentOptions> options, ILogger<ContentWarmupHostedService> logger)
+    {
+        _callService = callService;
+        _options = options.Value;
+        _logger = logger;
+    }
+
+    public Task StartAsync(CancellationToken cancellationToken)
+    {
+        if (!_options.WarmUpEnabled) return Task.CompletedTask;
+
+        // Background so app startup isn't blocked by the bulk fetch. Guid.Empty = default language.
+        _ = Task.Run(async () =>
+        {
+            try
+            {
+                await _callService.WarmCacheAsync(Guid.Empty);
+            }
+            catch (Exception e)
+            {
+                _logger.LogError(e, "Content startup warm-up failed: {Message}", e.Message);
+            }
+        }, CancellationToken.None);
+
+        return Task.CompletedTask;
+    }
+
+    public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+}

--- a/Quilt4Net.Toolkit.Blazor/Features/Language/ContentAdmin.razor
+++ b/Quilt4Net.Toolkit.Blazor/Features/Language/ContentAdmin.razor
@@ -5,6 +5,7 @@
 @inject IContentService ContentService
 @inject IEditContentService EditContentService
 @inject IContentAdminService ContentAdminService
+@inject IRemoteContentCallService RemoteContentCallService
 @inject NavigationManager NavigationManager
 
 <ConnectionWrapper Service="Service.Content">
@@ -27,15 +28,59 @@
                 <StandardButton Text="Reload Content" Icon="bolt" Click="ReloadContent"/>
             </RadzenColumn>
         </RadzenRow>
+        @if (_isAdmin)
+        {
+            <RadzenRow>
+                <RadzenColumn>
+                    <RadzenStack Orientation="Orientation.Horizontal" AlignItems="AlignItems.Center" Gap="0.5rem">
+                        <RadzenText Text="Loaded content per language" TextStyle="TextStyle.Caption"/>
+                        <StandardButton Text="Refresh" Icon="refresh" Click="RefreshCounts"/>
+                    </RadzenStack>
+                    @if (_loaded.Count == 0)
+                    {
+                        <RadzenText Text="Nothing cached yet." TextStyle="TextStyle.Body2"/>
+                    }
+                    else
+                    {
+                        @foreach (var row in _loaded)
+                        {
+                            <RadzenText Text="@($"{row.Name}: {row.Count}")" TextStyle="TextStyle.Body2"/>
+                        }
+                    }
+                </RadzenColumn>
+            </RadzenRow>
+        }
     </RadzenStack>
 </ConnectionWrapper>
 
 @code {
     private bool _isAdmin;
+    private List<(string Name, int Count)> _loaded = [];
 
     protected override async Task OnInitializedAsync()
     {
         _isAdmin = await ContentAdminService.IsContentAdminAsync();
+        await RefreshCounts();
+    }
+
+    private Task RefreshCounts()
+    {
+        var counts = RemoteContentCallService.GetCacheCountsByLanguage();
+        var languages = LanguageStateService.Languages ?? [];
+
+        string NameOf(Guid key)
+        {
+            var name = languages.FirstOrDefault(l => l.Key == key)?.Name;
+            if (!string.IsNullOrEmpty(name)) return name;
+            return key == Guid.Empty ? "Default" : key.ToString();
+        }
+
+        _loaded = counts
+            .Select(c => (Name: NameOf(c.Key), Count: c.Value))
+            .OrderByDescending(x => x.Count)
+            .ToList();
+
+        return Task.CompletedTask;
     }
 
     private async Task ReloadContent()

--- a/Quilt4Net.Toolkit.Blazor/LanguageStateService.cs
+++ b/Quilt4Net.Toolkit.Blazor/LanguageStateService.cs
@@ -8,14 +8,16 @@ internal class LanguageStateService : ILanguageStateService
 {
     private readonly ILanguageService _languageService;
     private readonly ILocalStorageService _localStorageService;
+    private readonly IRemoteContentCallService _remoteContentCallService;
     private Language _selected;
     private bool _developerMode;
     private readonly Language _defaultLanguage;
 
-    public LanguageStateService(ILanguageService languageService, ILocalStorageService localStorageService)
+    public LanguageStateService(ILanguageService languageService, ILocalStorageService localStorageService, IRemoteContentCallService remoteContentCallService)
     {
         _languageService = languageService;
         _localStorageService = localStorageService;
+        _remoteContentCallService = remoteContentCallService;
         _defaultLanguage = new Language { Name = null };
 
         Task.Run(async () =>
@@ -118,9 +120,34 @@ internal class LanguageStateService : ILanguageStateService
                     catch (InvalidOperationException) { /* JS interop unavailable — selection persists for the lifetime of this session only. */ }
                     catch (JSDisconnectedException) { /* Circuit disposed mid-call — nowhere to persist. */ }
                 });
+                WarmSelected(value);
                 LanguageChangedEvent?.Invoke(this, new LanguageChangedEventArgs());
             }
         }
+    }
+
+    /// <summary>
+    /// Best-effort bulk warm-up of a newly-selected non-default language so subsequent renders in
+    /// that language hit cache instead of fanning out per key. Fire-and-forget — the per-key path
+    /// still serves the current switch if the warm-up hasn't completed yet. The default language is
+    /// warmed at startup by <see cref="ContentWarmupHostedService"/>, so it's skipped here.
+    /// </summary>
+    private void WarmSelected(Language language)
+    {
+        var key = language?.Key ?? Guid.Empty;
+        if (key == Guid.Empty || key == Language.DeveloperLanguageKey || key == Language.NoApiKeyLanguageKey) return;
+
+        _ = Task.Run(async () =>
+        {
+            try
+            {
+                await _remoteContentCallService.WarmCacheAsync(key);
+            }
+            catch
+            {
+                // Best-effort; the per-key path remains as the fallback.
+            }
+        });
     }
 
     public Language[] Languages { get; set; }

--- a/Quilt4Net.Toolkit.Blazor/Quilt4ContentRegistration.cs
+++ b/Quilt4Net.Toolkit.Blazor/Quilt4ContentRegistration.cs
@@ -45,6 +45,11 @@ public static class Quilt4ContentRegistration
         services.AddBlazoredLocalStorage();
         services.AddQuilt4NetContent(configuration, options);
 
+        // Startup warm-up: bulk-load the default language into the (singleton) content cache so the
+        // first render avoids per-key fan-out. Honors ContentOptions.WarmUpEnabled; selected-language
+        // warming is handled per-circuit by LanguageStateService.
+        services.AddHostedService<ContentWarmupHostedService>();
+
         return services;
     }
 }

--- a/Quilt4Net.Toolkit.Tests/ContentWarmUpTests.cs
+++ b/Quilt4Net.Toolkit.Tests/ContentWarmUpTests.cs
@@ -1,0 +1,162 @@
+using System.Net;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Quilt4Net.Toolkit.Features.Content;
+using Quilt4Net.Toolkit.Features.FeatureToggle;
+using Xunit;
+
+namespace Quilt4Net.Toolkit.Tests;
+
+public class ContentWarmUpTests
+{
+    private const string App = "App1";
+
+    [Fact]
+    public async Task WarmCacheAsync_then_GetContentAsync_serves_from_cache_without_a_per_key_call()
+    {
+        using var listener = StartListener(out var prefix, out var state,
+            bulkItems: [("k1", "v1"), ("k2", "v2")]);
+
+        var (warm, content) = Build(prefix);
+
+        await warm.WarmCacheAsync(Guid.Empty, App);
+        state.SingleKeyCalls = 0; // ignore anything before the warm; measure reads after it
+
+        var r1 = await content.GetContentAsync("k1", "def", Guid.Empty, ContentFormat.String, App);
+        var r2 = await content.GetContentAsync("k2", "def", Guid.Empty, ContentFormat.String, App);
+
+        r1.Should().Be(("v1", true));
+        r2.Should().Be(("v2", true));
+        state.SingleKeyCalls.Should().Be(0, "warmed keys must be served from cache without a server round-trip");
+        state.BulkCalls.Should().Be(1, "warm-up is a single bulk call for the whole application");
+    }
+
+    [Fact]
+    public async Task WarmCacheAsync_falls_back_to_per_key_when_bulk_endpoint_returns_404()
+    {
+        using var listener = StartListener(out var prefix, out var state, bulkItems: null, bulkStatus: 404);
+
+        var (warm, content) = Build(prefix);
+
+        await warm.WarmCacheAsync(Guid.Empty, App); // must not throw
+        state.SingleKeyCalls = 0;
+
+        var r = await content.GetContentAsync("k1", "def", Guid.Empty, ContentFormat.String, App);
+
+        r.Success.Should().BeTrue();
+        r.Value.Should().Be("single-value");
+        state.SingleKeyCalls.Should().Be(1, "an old server without the bulk endpoint must leave the per-key path working");
+    }
+
+    [Fact]
+    public async Task GetCacheCountsByLanguage_reports_loaded_count_per_language()
+    {
+        using var listener = StartListener(out var prefix, out _, bulkItems: [("k1", "v1"), ("k2", "v2")]);
+
+        var (warm, _) = Build(prefix);
+        await warm.WarmCacheAsync(Guid.Empty, App);
+
+        var counts = warm.GetCacheCountsByLanguage();
+
+        counts.Should().ContainKey(Guid.Empty);
+        counts[Guid.Empty].Should().Be(2);
+    }
+
+    [Fact]
+    public async Task WarmCacheAsync_does_nothing_when_no_api_key_configured()
+    {
+        using var listener = StartListener(out var prefix, out var state, bulkItems: [("k1", "v1")]);
+
+        var (warm, _) = Build(prefix, apiKey: "");
+
+        await warm.WarmCacheAsync(Guid.Empty, App);
+
+        state.BulkCalls.Should().Be(0, "no API key means no calls are made at all");
+    }
+
+    private static (IRemoteContentCallService warm, IContentService content) Build(string baseAddress, string apiKey = "test-key")
+    {
+        var host = Host.CreateDefaultBuilder()
+            .ConfigureServices(services =>
+            {
+                services.AddQuilt4NetContent(null, o =>
+                {
+                    o.Quilt4NetAddress = baseAddress;
+                    o.ApiKey = apiKey;
+                });
+            })
+            .Build();
+
+        return (host.Services.GetRequiredService<IRemoteContentCallService>(),
+                host.Services.GetRequiredService<IContentService>());
+    }
+
+    private sealed class ListenerState
+    {
+        public int BulkCalls;
+        public int SingleKeyCalls;
+    }
+
+    private static HttpListener StartListener(out string prefix, out ListenerState state,
+        (string Key, string Value)[] bulkItems, int bulkStatus = 200)
+    {
+        var port = GetFreePort();
+        prefix = $"http://127.0.0.1:{port}/";
+        var listener = new HttpListener();
+        listener.Prefixes.Add(prefix);
+        listener.Start();
+
+        var s = new ListenerState();
+        state = s;
+        var sync = new object();
+
+        _ = Task.Run(async () =>
+        {
+            while (listener.IsListening)
+            {
+                HttpListenerContext ctx;
+                try { ctx = await listener.GetContextAsync(); }
+                catch { return; }
+
+                var segments = ctx.Request.Url!.AbsolutePath.Split('/', StringSplitOptions.RemoveEmptyEntries);
+                var isBulk = segments.Length >= 3
+                    && segments[0].Equals("Api", StringComparison.OrdinalIgnoreCase)
+                    && segments[1].Equals("Content", StringComparison.OrdinalIgnoreCase)
+                    && segments[2].Equals("all", StringComparison.OrdinalIgnoreCase);
+
+                string body;
+                if (isBulk)
+                {
+                    lock (sync) s.BulkCalls++;
+                    ctx.Response.StatusCode = bulkStatus;
+                    var items = string.Join(",", (bulkItems ?? []).Select(i =>
+                        $$"""{"key":"{{i.Key}}","value":"{{i.Value}}"}"""));
+                    body = $$"""{"items":[{{items}}],"validTo":"{{DateTime.UtcNow.AddHours(1):o}}"}""";
+                }
+                else
+                {
+                    lock (sync) s.SingleKeyCalls++;
+                    ctx.Response.StatusCode = 200;
+                    body = $$"""{"value":"single-value","validTo":"{{DateTime.UtcNow.AddHours(1):o}}"}""";
+                }
+
+                ctx.Response.ContentType = "application/json";
+                var buf = System.Text.Encoding.UTF8.GetBytes(body);
+                await ctx.Response.OutputStream.WriteAsync(buf);
+                ctx.Response.Close();
+            }
+        });
+
+        return listener;
+    }
+
+    private static int GetFreePort()
+    {
+        using var l = new System.Net.Sockets.TcpListener(IPAddress.Loopback, 0);
+        l.Start();
+        var port = ((IPEndPoint)l.LocalEndpoint).Port;
+        l.Stop();
+        return port;
+    }
+}

--- a/Quilt4Net.Toolkit/ContentOptions.cs
+++ b/Quilt4Net.Toolkit/ContentOptions.cs
@@ -52,6 +52,14 @@ public record ContentOptions
     public bool StaleWhileRevalidate { get; set; } = true;
 
     /// <summary>
+    /// When true (default), the Blazor content registration runs a startup warm-up that pre-fills
+    /// the cache with the default language in one bulk call (so pages render without a request per
+    /// key). The user's selected language is warmed per-circuit when it differs from the default.
+    /// Set false to disable warm-up and rely solely on lazy per-key fetching.
+    /// </summary>
+    public bool WarmUpEnabled { get; set; } = true;
+
+    /// <summary>
     /// Roles that grant content admin access (edit, debug, reload).
     /// Checked against the authenticated user's claim roles (e.g. Entra ID).
     /// Default is ["ContentAdmin", "Developer"].

--- a/Quilt4Net.Toolkit/Features/Content/IRemoteContentCallService.cs
+++ b/Quilt4Net.Toolkit/Features/Content/IRemoteContentCallService.cs
@@ -8,4 +8,18 @@ public interface IRemoteContentCallService
     Task SetContentAsync(string key, string defaultValue, Guid languageKey, ContentFormat contentType, string application = null);
     Task<Language[]> GetLanguagesAsync(bool forceReload);
     Task ClearContentCacheAsync();
+
+    /// <summary>
+    /// Pre-fill the local cache for an entire application + language in one bulk call (the startup
+    /// warm-up). Eliminates the per-key fan-out on cold load. Best-effort: a missing endpoint (old
+    /// server, 404), failure, or timeout is swallowed so the normal per-key path still serves
+    /// content. <paramref name="application"/> follows the usual convention (null → resolve).
+    /// </summary>
+    Task WarmCacheAsync(Guid languageKey, string application = null);
+
+    /// <summary>
+    /// Number of currently-cached content entries grouped by language key — i.e. how much content
+    /// has been loaded so far per language (warm-up + lazy loads). For diagnostics/admin display.
+    /// </summary>
+    IReadOnlyDictionary<Guid, int> GetCacheCountsByLanguage();
 }

--- a/Quilt4Net.Toolkit/Features/Content/RemoteContentCallService.cs
+++ b/Quilt4Net.Toolkit/Features/Content/RemoteContentCallService.cs
@@ -174,6 +174,61 @@ internal class RemoteContentCallService : IRemoteContentCallService
         _localCache.Clear();
     }
 
+    public async Task WarmCacheAsync(Guid languageKey, string application = null)
+    {
+        if (string.IsNullOrEmpty(_contentOptions.ApiKey)) return;
+        if (languageKey == Language.DeveloperLanguageKey || languageKey == Language.NoApiKeyLanguageKey) return;
+
+        var effectiveApplication = ResolveApplication(application);
+        if (string.IsNullOrEmpty(effectiveApplication)) return;
+
+        var sw = Stopwatch.StartNew();
+        try
+        {
+            using var cts = new CancellationTokenSource(_contentOptions.HttpTimeout);
+            using var client = GetHttpClient();
+            var address = $"Api/Content/all/{Uri.EscapeDataString(effectiveApplication)}/{Uri.EscapeDataString(_environmentName.Name ?? "")}/{languageKey}";
+            var response = await client.GetAsync(address, cts.Token);
+
+            if (response.StatusCode == HttpStatusCode.NotFound)
+            {
+                _logger.LogInformation("Content warm-up endpoint unavailable (404). Server predates bulk content; falling back to per-key fetching.");
+                return;
+            }
+
+            if (!response.IsSuccessStatusCode)
+            {
+                _logger.LogWarning("Content warm-up failed. Response was {StatusCode} {ReasonPhrase}. Falling back to per-key fetching.",
+                    response.StatusCode, response.ReasonPhrase);
+                return;
+            }
+
+            var result = await response.Content.ReadFromJsonAsync<GetAllContentResponse>(cancellationToken: cts.Token);
+            if (result?.Items == null) return;
+
+            var ttl = result.ValidTo - DateTime.UtcNow;
+            foreach (var item in result.Items)
+            {
+                var cacheKey = BuildCacheKey(item.Key, languageKey, effectiveApplication);
+                var cached = new GetContentResponse { Value = item.Value, ValidTo = result.ValidTo };
+                _localCache.AddOrUpdate(cacheKey, cached, (_, _) => cached);
+                if (ttl > TimeSpan.Zero) _lastKnownTtl[cacheKey] = ttl;
+            }
+
+            _logger.LogInformation("Content warm-up loaded {Count} item(s) in {Elapsed}ms for application '{Application}', language '{LanguageKey}'. ValidTo: {ValidTo}.",
+                result.Items.Length, sw.ElapsedMilliseconds, effectiveApplication, languageKey, result.ValidTo);
+        }
+        catch (OperationCanceledException)
+        {
+            _logger.LogWarning("Content warm-up timed out after {Timeout}ms. Falling back to per-key fetching.",
+                _contentOptions.HttpTimeout.TotalMilliseconds);
+        }
+        catch (Exception e)
+        {
+            _logger.LogError(e, "Content warm-up failed: {Message} Falling back to per-key fetching.", e.Message);
+        }
+    }
+
     private async Task<(string Value, bool Success)> FetchContentWithTimeout(string key, string cacheKey, string defaultValue, Guid languageKey, ContentFormat? contentType, Stopwatch sw, string effectiveApplication)
     {
         try
@@ -323,6 +378,28 @@ internal class RemoteContentCallService : IRemoteContentCallService
     {
         // "" and null both mean "shared" so they collapse to the same cache slot.
         return $"{key}_{languageKey}|{effectiveApplication ?? ""}";
+    }
+
+    public IReadOnlyDictionary<Guid, int> GetCacheCountsByLanguage()
+    {
+        var counts = new Dictionary<Guid, int>();
+        foreach (var cacheKey in _localCache.Keys)
+        {
+            if (!TryParseLanguageFromCacheKey(cacheKey, out var languageKey)) continue;
+            counts[languageKey] = counts.GetValueOrDefault(languageKey) + 1;
+        }
+        return counts;
+    }
+
+    // Reverse of BuildCacheKey: the language key is the 36-char GUID immediately before the '|'
+    // application delimiter (application names never contain '|'). Kept beside BuildCacheKey so the
+    // two stay in sync if the format ever changes.
+    private static bool TryParseLanguageFromCacheKey(string cacheKey, out Guid languageKey)
+    {
+        languageKey = Guid.Empty;
+        var pipe = cacheKey.LastIndexOf('|');
+        if (pipe < 36) return false;
+        return Guid.TryParse(cacheKey.Substring(pipe - 36, 36), out languageKey);
     }
 
     private static string BuildKey(GetContentRequest request)

--- a/Quilt4Net.Toolkit/Features/FeatureToggle/ContentItem.cs
+++ b/Quilt4Net.Toolkit/Features/FeatureToggle/ContentItem.cs
@@ -1,0 +1,11 @@
+namespace Quilt4Net.Toolkit.Features.FeatureToggle;
+
+/// <summary>A single resolved content entry (key and rendered value) within a <see cref="GetAllContentResponse"/>.</summary>
+public record ContentItem
+{
+    /// <summary>Content key.</summary>
+    public required string Key { get; init; }
+
+    /// <summary>Rendered content value for the requested language (server-rendered, same as the single-key path).</summary>
+    public required string Value { get; init; }
+}

--- a/Quilt4Net.Toolkit/Features/FeatureToggle/GetAllContentResponse.cs
+++ b/Quilt4Net.Toolkit/Features/FeatureToggle/GetAllContentResponse.cs
@@ -1,0 +1,15 @@
+namespace Quilt4Net.Toolkit.Features.FeatureToggle;
+
+/// <summary>
+/// Bulk content response used by the startup warm-up. Carries every resolved content value for a
+/// single application + environment + language in one round-trip, sharing one <see cref="ValidTo"/>
+/// so the client can seed its cache without a call per key.
+/// </summary>
+public record GetAllContentResponse
+{
+    /// <summary>The resolved content entries (already rendered server-side, same as the single-key path).</summary>
+    public required ContentItem[] Items { get; init; }
+
+    /// <summary>Cache expiry shared by every entry in <see cref="Items"/>.</summary>
+    public required DateTime ValidTo { get; init; }
+}

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ All packages read from `appsettings.json` under the `Quilt4Net` section. The sha
 | `Quilt4Net:HealthApi` | Health | Health endpoint options (pattern, controller name, heartbeat, certificate). |
 | `Quilt4Net:ApiLogging` | Api | API logging options (log mode, paths, body size, correlation ID). |
 | `Quilt4Net:RemoteConfiguration` | Toolkit | Remote configuration and feature toggle options (TTL). |
-| `Quilt4Net:Content` | Toolkit / Blazor | Content management options (application name, server address). |
+| `Quilt4Net:Content` | Toolkit / Blazor | Content management options (application name, server address, `WarmUpEnabled` startup cache warm-up). |
 | `Quilt4Net:ApplicationInsights` | Toolkit | Application Insights client options (tenant, workspace, credentials). |
 | `Quilt4Net:HealthClient` | Toolkit | Health client options (remote health API address). |
 

--- a/docs/articles/content-components.md
+++ b/docs/articles/content-components.md
@@ -252,6 +252,39 @@ Notifications whose summary and (optional) detail come from content keys.
 | `detailKey` / `defaultDetail` | Optional detail pair. Both null → no detail line. |
 | `duration` | Display duration in ms (default 3000). |
 
+## Startup warm-up
+
+On a cold cache every content component issues its own HTTP lookup, so a content-heavy page (a menu,
+a dashboard) fans out into dozens of requests that trickle in as they complete. To avoid that,
+`AddQuilt4NetBlazorContent` registers a startup warm-up that pre-fills the cache in a **single bulk
+call per language**:
+
+- The **default language** is warmed in the background at application start (non-blocking — startup
+  is not delayed).
+- The user's **selected language** is warmed per circuit as soon as it's known, and again whenever
+  they switch language. The cache is process-wide, so the first user on a language pays the one bulk
+  call and everyone after hits the warm cache.
+- Warming is **best-effort and backward-compatible**: against a server that doesn't expose the bulk
+  endpoint (404), or on any failure/timeout, it silently falls back to the existing per-key fetching.
+
+Disable it to rely purely on lazy per-key loading:
+
+```json
+{
+  "Quilt4Net": {
+    "Content": {
+      "WarmUpEnabled": false
+    }
+  }
+}
+```
+
+### Inspecting what's loaded
+
+The content admin panel (`<ContentAdmin>`) shows content admins a **Loaded content per language**
+list — the number of cached content entries per language, with a Refresh button — so you can confirm
+the warm-up populated the cache as expected.
+
 ## Where next
 
 - **[Log views](log-views.md)** — content-aware host of the AI log surface.


### PR DESCRIPTION
## What
Replace the cold-load per-key content fan-out with a single **bulk warm-up** that pre-fills the cache, so content-heavy pages (menus, dashboards) render from a warm cache instead of trickling in one request per key.

## Why
On a cold cache every content component issues its own HTTP lookup. A page with ~50 content keys fans out into ~50 round-trips; against a remote/slow server these cascade into 5 s timeouts and visible pop-in.

## Changes
- **`IRemoteContentCallService.WarmCacheAsync(languageKey, application?)`** — bulk-loads all content for an application + language in one call and seeds the cache. **Best-effort & backward compatible**: a 404 (server without the bulk endpoint), failure, or timeout silently falls back to the existing per-key path.
- **`ContentWarmupHostedService`** — warms the **default** language in the background at startup (non-blocking).
- **`LanguageStateService`** — warms the **selected** language per circuit and on switch (the cache is process-wide, so the first user on a language pays the one bulk call).
- **`ContentOptions.WarmUpEnabled`** (default `true`) toggles it.
- **`GetCacheCountsByLanguage()`** + a *Loaded content per language* panel in `ContentAdmin` for visibility into what's cached.
- New shared DTOs **`GetAllContentResponse`** / **`ContentItem`** for the bulk endpoint.
- Minor version bump **0.8 → 0.9** (`MAJOR_MINOR` in `build.yml`).

## Server dependency
Consumes a new `GET Api/Content/all/{application}/{environment}/{languageKey}` endpoint on Quilt4Net.Server (separate repo). **This PR is safe to merge/release first** — the 404 fallback keeps older servers working.

## Tests
- Core: **169 passing** (incl. `WarmCacheAsync` populate / 404 fallback / cache-count).
- Blazor: **114 passing** (incl. hosted-service warm + selected-language warm).

## Docs
- `docs/articles/content-components.md` — startup warm-up section.
- `README.md` — config note.
