### PR TITLE
feat: cluster metrics + logging cost/volume dashboard

### DIFF
--- a/Quilt4Net.Toolkit.Blazor.Tests/LogEnvironmentSelectorIncidentTests.cs
+++ b/Quilt4Net.Toolkit.Blazor.Tests/LogEnvironmentSelectorIncidentTests.cs
@@ -35,6 +35,7 @@ public class LogEnvironmentSelectorIncidentTests : BunitContext
 
         public Task<bool> CanConnectAsync(IApplicationInsightsContext context) => Task.FromResult(false);
 
+        public IAsyncEnumerable<VolumeBySource> GetVolumeBySourceAsync(IApplicationInsightsContext context, TimeSpan timeSpan, CancellationToken cancellationToken = default) => Throw<VolumeBySource>();
         public IAsyncEnumerable<EnvironmentOption> GetEnvironments(IApplicationInsightsContext context) => Throw<EnvironmentOption>();
         public IAsyncEnumerable<LogItem> SearchAsync(IApplicationInsightsContext context, string environment, string text, TimeSpan timeSpan, SeverityLevel minSeverityLevel = SeverityLevel.Verbose, CancellationToken cancellationToken = default) => Throw<LogItem>();
         public IAsyncEnumerable<MeasureData> GetMeasureAsync(IApplicationInsightsContext context, string environment, TimeSpan timeSpan, CancellationToken cancellationToken = default) => Throw<MeasureData>();

--- a/Quilt4Net.Toolkit.Blazor.Tests/LogEnvironmentSelectorIncidentTests.cs
+++ b/Quilt4Net.Toolkit.Blazor.Tests/LogEnvironmentSelectorIncidentTests.cs
@@ -55,6 +55,9 @@ public class LogEnvironmentSelectorIncidentTests : BunitContext
         public IAsyncEnumerable<MetricSample> GetClusterPodCpuAsync(IApplicationInsightsContext context, string node, TimeSpan timeSpan, CancellationToken cancellationToken = default) => Throw<MetricSample>();
         public IAsyncEnumerable<MetricSample> GetClusterPodMemoryAsync(IApplicationInsightsContext context, string node, TimeSpan timeSpan, CancellationToken cancellationToken = default) => Throw<MetricSample>();
         public IAsyncEnumerable<MetricSample> GetClusterNodeFilesystemAsync(IApplicationInsightsContext context, TimeSpan timeSpan, CancellationToken cancellationToken = default) => Throw<MetricSample>();
+        public IAsyncEnumerable<MetricSample> GetClusterTotalCpuAsync(IApplicationInsightsContext context, TimeSpan timeSpan, CancellationToken cancellationToken = default) => Throw<MetricSample>();
+        public IAsyncEnumerable<MetricSample> GetClusterTotalMemoryAsync(IApplicationInsightsContext context, TimeSpan timeSpan, CancellationToken cancellationToken = default) => Throw<MetricSample>();
+        public IAsyncEnumerable<MetricSample> GetClusterTotalFilesystemAsync(IApplicationInsightsContext context, TimeSpan timeSpan, CancellationToken cancellationToken = default) => Throw<MetricSample>();
         public IAsyncEnumerable<LogCountByServiceCell> GetLogCountByServiceAsync(IApplicationInsightsContext context, TimeSpan timeSpan, CancellationToken cancellationToken = default) => Throw<LogCountByServiceCell>();
 
 #pragma warning disable CS1998

--- a/Quilt4Net.Toolkit.Blazor.Tests/LogEnvironmentSelectorIncidentTests.cs
+++ b/Quilt4Net.Toolkit.Blazor.Tests/LogEnvironmentSelectorIncidentTests.cs
@@ -36,6 +36,7 @@ public class LogEnvironmentSelectorIncidentTests : BunitContext
         public Task<bool> CanConnectAsync(IApplicationInsightsContext context) => Task.FromResult(false);
 
         public IAsyncEnumerable<VolumeBySource> GetVolumeBySourceAsync(IApplicationInsightsContext context, TimeSpan timeSpan, CancellationToken cancellationToken = default) => Throw<VolumeBySource>();
+        public Task<CapTimeline> GetCapTimelineAsync(IApplicationInsightsContext context, int days, CancellationToken cancellationToken = default) => Task.FromException<CapTimeline>(_ex);
         public IAsyncEnumerable<EnvironmentOption> GetEnvironments(IApplicationInsightsContext context) => Throw<EnvironmentOption>();
         public IAsyncEnumerable<LogItem> SearchAsync(IApplicationInsightsContext context, string environment, string text, TimeSpan timeSpan, SeverityLevel minSeverityLevel = SeverityLevel.Verbose, CancellationToken cancellationToken = default) => Throw<LogItem>();
         public IAsyncEnumerable<MeasureData> GetMeasureAsync(IApplicationInsightsContext context, string environment, TimeSpan timeSpan, CancellationToken cancellationToken = default) => Throw<MeasureData>();

--- a/Quilt4Net.Toolkit.Blazor.Tests/LogEnvironmentSelectorIncidentTests.cs
+++ b/Quilt4Net.Toolkit.Blazor.Tests/LogEnvironmentSelectorIncidentTests.cs
@@ -50,6 +50,11 @@ public class LogEnvironmentSelectorIncidentTests : BunitContext
         public IAsyncEnumerable<MetricSample> GetDiskFreeAsync(IApplicationInsightsContext context, TimeSpan timeSpan, CancellationToken cancellationToken = default) => Throw<MetricSample>();
         public IAsyncEnumerable<DiskCapacity> GetDiskCapacityAsync(IApplicationInsightsContext context, TimeSpan timeSpan, CancellationToken cancellationToken = default) => Throw<DiskCapacity>();
         public IAsyncEnumerable<MetricSample> GetNetworkThroughputAsync(IApplicationInsightsContext context, TimeSpan timeSpan, CancellationToken cancellationToken = default) => Throw<MetricSample>();
+        public IAsyncEnumerable<MetricSample> GetClusterNodeCpuAsync(IApplicationInsightsContext context, TimeSpan timeSpan, CancellationToken cancellationToken = default) => Throw<MetricSample>();
+        public IAsyncEnumerable<MetricSample> GetClusterNodeMemoryAsync(IApplicationInsightsContext context, TimeSpan timeSpan, CancellationToken cancellationToken = default) => Throw<MetricSample>();
+        public IAsyncEnumerable<MetricSample> GetClusterPodCpuAsync(IApplicationInsightsContext context, string node, TimeSpan timeSpan, CancellationToken cancellationToken = default) => Throw<MetricSample>();
+        public IAsyncEnumerable<MetricSample> GetClusterPodMemoryAsync(IApplicationInsightsContext context, string node, TimeSpan timeSpan, CancellationToken cancellationToken = default) => Throw<MetricSample>();
+        public IAsyncEnumerable<MetricSample> GetClusterNodeFilesystemAsync(IApplicationInsightsContext context, TimeSpan timeSpan, CancellationToken cancellationToken = default) => Throw<MetricSample>();
         public IAsyncEnumerable<LogCountByServiceCell> GetLogCountByServiceAsync(IApplicationInsightsContext context, TimeSpan timeSpan, CancellationToken cancellationToken = default) => Throw<LogCountByServiceCell>();
 
 #pragma warning disable CS1998

--- a/Quilt4Net.Toolkit.Blazor.Tests/LogViewConfigTests.cs
+++ b/Quilt4Net.Toolkit.Blazor.Tests/LogViewConfigTests.cs
@@ -74,6 +74,9 @@ public class LogViewConfigTests : BunitContext
         public IAsyncEnumerable<MetricSample> GetClusterPodCpuAsync(IApplicationInsightsContext context, string node, TimeSpan timeSpan, CancellationToken cancellationToken = default) => Empty<MetricSample>();
         public IAsyncEnumerable<MetricSample> GetClusterPodMemoryAsync(IApplicationInsightsContext context, string node, TimeSpan timeSpan, CancellationToken cancellationToken = default) => Empty<MetricSample>();
         public IAsyncEnumerable<MetricSample> GetClusterNodeFilesystemAsync(IApplicationInsightsContext context, TimeSpan timeSpan, CancellationToken cancellationToken = default) => Empty<MetricSample>();
+        public IAsyncEnumerable<MetricSample> GetClusterTotalCpuAsync(IApplicationInsightsContext context, TimeSpan timeSpan, CancellationToken cancellationToken = default) => Empty<MetricSample>();
+        public IAsyncEnumerable<MetricSample> GetClusterTotalMemoryAsync(IApplicationInsightsContext context, TimeSpan timeSpan, CancellationToken cancellationToken = default) => Empty<MetricSample>();
+        public IAsyncEnumerable<MetricSample> GetClusterTotalFilesystemAsync(IApplicationInsightsContext context, TimeSpan timeSpan, CancellationToken cancellationToken = default) => Empty<MetricSample>();
         public IAsyncEnumerable<LogCountByServiceCell> GetLogCountByServiceAsync(IApplicationInsightsContext context, TimeSpan timeSpan, CancellationToken cancellationToken = default) => Empty<LogCountByServiceCell>();
 
         private static async IAsyncEnumerable<T> Empty<T>()

--- a/Quilt4Net.Toolkit.Blazor.Tests/LogViewConfigTests.cs
+++ b/Quilt4Net.Toolkit.Blazor.Tests/LogViewConfigTests.cs
@@ -55,6 +55,7 @@ public class LogViewConfigTests : BunitContext
     {
         public Task<bool> CanConnectAsync(IApplicationInsightsContext context) => Task.FromResult(false);
         public IAsyncEnumerable<VolumeBySource> GetVolumeBySourceAsync(IApplicationInsightsContext context, TimeSpan timeSpan, CancellationToken cancellationToken = default) => Empty<VolumeBySource>();
+        public Task<CapTimeline> GetCapTimelineAsync(IApplicationInsightsContext context, int days, CancellationToken cancellationToken = default) => Task.FromResult(new CapTimeline { Days = [] });
         public IAsyncEnumerable<EnvironmentOption> GetEnvironments(IApplicationInsightsContext context) => Empty<EnvironmentOption>();
         public IAsyncEnumerable<LogItem> SearchAsync(IApplicationInsightsContext context, string environment, string text, TimeSpan timeSpan, SeverityLevel minSeverityLevel = SeverityLevel.Verbose, CancellationToken cancellationToken = default) => Empty<LogItem>();
         public IAsyncEnumerable<MeasureData> GetMeasureAsync(IApplicationInsightsContext context, string environment, TimeSpan timeSpan, CancellationToken cancellationToken = default) => Empty<MeasureData>();

--- a/Quilt4Net.Toolkit.Blazor.Tests/LogViewConfigTests.cs
+++ b/Quilt4Net.Toolkit.Blazor.Tests/LogViewConfigTests.cs
@@ -69,6 +69,11 @@ public class LogViewConfigTests : BunitContext
         public IAsyncEnumerable<MetricSample> GetDiskFreeAsync(IApplicationInsightsContext context, TimeSpan timeSpan, CancellationToken cancellationToken = default) => Empty<MetricSample>();
         public IAsyncEnumerable<DiskCapacity> GetDiskCapacityAsync(IApplicationInsightsContext context, TimeSpan timeSpan, CancellationToken cancellationToken = default) => Empty<DiskCapacity>();
         public IAsyncEnumerable<MetricSample> GetNetworkThroughputAsync(IApplicationInsightsContext context, TimeSpan timeSpan, CancellationToken cancellationToken = default) => Empty<MetricSample>();
+        public IAsyncEnumerable<MetricSample> GetClusterNodeCpuAsync(IApplicationInsightsContext context, TimeSpan timeSpan, CancellationToken cancellationToken = default) => Empty<MetricSample>();
+        public IAsyncEnumerable<MetricSample> GetClusterNodeMemoryAsync(IApplicationInsightsContext context, TimeSpan timeSpan, CancellationToken cancellationToken = default) => Empty<MetricSample>();
+        public IAsyncEnumerable<MetricSample> GetClusterPodCpuAsync(IApplicationInsightsContext context, string node, TimeSpan timeSpan, CancellationToken cancellationToken = default) => Empty<MetricSample>();
+        public IAsyncEnumerable<MetricSample> GetClusterPodMemoryAsync(IApplicationInsightsContext context, string node, TimeSpan timeSpan, CancellationToken cancellationToken = default) => Empty<MetricSample>();
+        public IAsyncEnumerable<MetricSample> GetClusterNodeFilesystemAsync(IApplicationInsightsContext context, TimeSpan timeSpan, CancellationToken cancellationToken = default) => Empty<MetricSample>();
         public IAsyncEnumerable<LogCountByServiceCell> GetLogCountByServiceAsync(IApplicationInsightsContext context, TimeSpan timeSpan, CancellationToken cancellationToken = default) => Empty<LogCountByServiceCell>();
 
         private static async IAsyncEnumerable<T> Empty<T>()

--- a/Quilt4Net.Toolkit.Blazor.Tests/LogViewConfigTests.cs
+++ b/Quilt4Net.Toolkit.Blazor.Tests/LogViewConfigTests.cs
@@ -54,6 +54,7 @@ public class LogViewConfigTests : BunitContext
     private sealed class StubApplicationInsightsService : IApplicationInsightsService
     {
         public Task<bool> CanConnectAsync(IApplicationInsightsContext context) => Task.FromResult(false);
+        public IAsyncEnumerable<VolumeBySource> GetVolumeBySourceAsync(IApplicationInsightsContext context, TimeSpan timeSpan, CancellationToken cancellationToken = default) => Empty<VolumeBySource>();
         public IAsyncEnumerable<EnvironmentOption> GetEnvironments(IApplicationInsightsContext context) => Empty<EnvironmentOption>();
         public IAsyncEnumerable<LogItem> SearchAsync(IApplicationInsightsContext context, string environment, string text, TimeSpan timeSpan, SeverityLevel minSeverityLevel = SeverityLevel.Verbose, CancellationToken cancellationToken = default) => Empty<LogItem>();
         public IAsyncEnumerable<MeasureData> GetMeasureAsync(IApplicationInsightsContext context, string environment, TimeSpan timeSpan, CancellationToken cancellationToken = default) => Empty<MeasureData>();

--- a/Quilt4Net.Toolkit.Blazor.Tests/MetricsSeriesCacheTests.cs
+++ b/Quilt4Net.Toolkit.Blazor.Tests/MetricsSeriesCacheTests.cs
@@ -1,0 +1,62 @@
+using System;
+using FluentAssertions;
+using Quilt4Net.Toolkit.Blazor.Features.Metrics;
+using Quilt4Net.Toolkit.Features.ApplicationInsights;
+using Xunit;
+
+namespace Quilt4Net.Toolkit.Blazor.Tests;
+
+public class MetricsSeriesCacheTests
+{
+    private static MetricSample[] One(string series, double value)
+        => [new MetricSample(series, new DateTime(2026, 6, 14, 10, 0, 0, DateTimeKind.Utc), value)];
+
+    [Fact]
+    public void Round_trips_host_and_cluster_node_series()
+    {
+        var cache = new MetricsSeriesCache();
+        var range = TimeSpan.FromHours(1);
+        var loaded = DateTime.UtcNow;
+
+        cache.Set("ctx:a", range,
+            cpu: One("Eplicta1", 12),
+            memory: One("Eplicta1", 34),
+            disk: One("Eplicta1 C:", 50),
+            diskCapacity: [new DiskCapacity("Eplicta1 C:", 50, 50, 0, 100)],
+            nodeCpu: One("cog-audry", 0.5),
+            nodeMemory: One("cog-audry", 29),
+            nodeFilesystem: One("cog-audry", 1.7),
+            loadedUtc: loaded);
+
+        cache.TryGet("ctx:a", range, TimeSpan.FromMinutes(10), out var entry).Should().BeTrue();
+        entry.NodeCpu.Should().ContainSingle().Which.Series.Should().Be("cog-audry");
+        entry.NodeMemory[0].Value.Should().Be(29);
+        entry.NodeFilesystem[0].Value.Should().Be(1.7);
+        entry.Cpu[0].Series.Should().Be("Eplicta1");
+        entry.LoadedUtc.Should().Be(loaded);
+    }
+
+    [Fact]
+    public void Expired_entry_is_evicted()
+    {
+        var cache = new MetricsSeriesCache();
+        var range = TimeSpan.FromHours(1);
+
+        cache.Set("ctx:a", range, [], [], [], [], One("cog-audry", 0.5), [], [],
+            loadedUtc: DateTime.UtcNow - TimeSpan.FromMinutes(30));
+
+        cache.TryGet("ctx:a", range, TimeSpan.FromMinutes(10), out _).Should().BeFalse();
+    }
+
+    [Fact]
+    public void Invalidate_removes_the_entry()
+    {
+        var cache = new MetricsSeriesCache();
+        var range = TimeSpan.FromHours(1);
+        cache.Set("ctx:a", range, [], [], [], [], One("cog-audry", 0.5), [], [], DateTime.UtcNow);
+
+        cache.Invalidate("ctx:a", range);
+
+        cache.TryGet("ctx:a", range, TimeSpan.FromMinutes(10), out _).Should().BeFalse();
+    }
+}

--- a/Quilt4Net.Toolkit.Blazor.Tests/MetricsViewClusterTests.cs
+++ b/Quilt4Net.Toolkit.Blazor.Tests/MetricsViewClusterTests.cs
@@ -110,6 +110,7 @@ public class MetricsViewClusterTests : BunitContext
 
         // Everything else returns empty — the view only needs the metric methods to render.
         public Task<bool> CanConnectAsync(IApplicationInsightsContext context) => Task.FromResult(true);
+        public IAsyncEnumerable<VolumeBySource> GetVolumeBySourceAsync(IApplicationInsightsContext context, TimeSpan timeSpan, CancellationToken cancellationToken = default) => Empty<VolumeBySource>();
         public IAsyncEnumerable<EnvironmentOption> GetEnvironments(IApplicationInsightsContext context) => Empty<EnvironmentOption>();
         public IAsyncEnumerable<LogItem> SearchAsync(IApplicationInsightsContext context, string environment, string text, TimeSpan timeSpan, SeverityLevel minSeverityLevel = SeverityLevel.Verbose, CancellationToken cancellationToken = default) => Empty<LogItem>();
         public IAsyncEnumerable<MeasureData> GetMeasureAsync(IApplicationInsightsContext context, string environment, TimeSpan timeSpan, CancellationToken cancellationToken = default) => Empty<MeasureData>();

--- a/Quilt4Net.Toolkit.Blazor.Tests/MetricsViewClusterTests.cs
+++ b/Quilt4Net.Toolkit.Blazor.Tests/MetricsViewClusterTests.cs
@@ -111,6 +111,7 @@ public class MetricsViewClusterTests : BunitContext
         // Everything else returns empty — the view only needs the metric methods to render.
         public Task<bool> CanConnectAsync(IApplicationInsightsContext context) => Task.FromResult(true);
         public IAsyncEnumerable<VolumeBySource> GetVolumeBySourceAsync(IApplicationInsightsContext context, TimeSpan timeSpan, CancellationToken cancellationToken = default) => Empty<VolumeBySource>();
+        public Task<CapTimeline> GetCapTimelineAsync(IApplicationInsightsContext context, int days, CancellationToken cancellationToken = default) => Task.FromResult(new CapTimeline { Days = [] });
         public IAsyncEnumerable<EnvironmentOption> GetEnvironments(IApplicationInsightsContext context) => Empty<EnvironmentOption>();
         public IAsyncEnumerable<LogItem> SearchAsync(IApplicationInsightsContext context, string environment, string text, TimeSpan timeSpan, SeverityLevel minSeverityLevel = SeverityLevel.Verbose, CancellationToken cancellationToken = default) => Empty<LogItem>();
         public IAsyncEnumerable<MeasureData> GetMeasureAsync(IApplicationInsightsContext context, string environment, TimeSpan timeSpan, CancellationToken cancellationToken = default) => Empty<MeasureData>();

--- a/Quilt4Net.Toolkit.Blazor.Tests/MetricsViewClusterTests.cs
+++ b/Quilt4Net.Toolkit.Blazor.Tests/MetricsViewClusterTests.cs
@@ -41,7 +41,23 @@ public class MetricsViewClusterTests : BunitContext
 
     [Fact]
     public void NodeNames_of_empty_series_is_empty()
-        => MetricsViewLogic.NodeNames([]).Should().BeEmpty();
+        => MetricsViewLogic.NodeNames(System.Array.Empty<MetricSample>()).Should().BeEmpty();
+
+    [Fact]
+    public void NodeNames_unions_across_series_so_tab_survives_empty_cpu()
+    {
+        // Regression: the node list (and thus the Cluster tab) must be the union across series.
+        // CPU% can be empty when allocatable_cpu doesn't overlap the window, but memory/filesystem
+        // are always present — the tab must still show every node.
+        MetricSample S(string series) => new(series, new DateTime(2026, 6, 14, 10, 0, 0, DateTimeKind.Utc), 1);
+        var emptyCpu = System.Array.Empty<MetricSample>();
+        var memory = new[] { S("cog-audry"), S("cog-exshaw") };
+        var filesystem = new[] { S("cog-audry"), S("vm-ygg-cp-1") };
+
+        var nodes = MetricsViewLogic.NodeNames(emptyCpu, memory, filesystem);
+
+        nodes.Should().Equal("cog-audry", "cog-exshaw", "vm-ygg-cp-1");
+    }
 
     [Fact]
     public void Hides_cluster_section_when_no_node_metrics()

--- a/Quilt4Net.Toolkit.Blazor.Tests/MetricsViewClusterTests.cs
+++ b/Quilt4Net.Toolkit.Blazor.Tests/MetricsViewClusterTests.cs
@@ -1,0 +1,120 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Bunit;
+using Radzen;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Quilt4Net.Toolkit.Blazor.Features.Metrics;
+using Quilt4Net.Toolkit.Features.ApplicationInsights;
+using Xunit;
+
+namespace Quilt4Net.Toolkit.Blazor.Tests;
+
+public class MetricsViewClusterTests : BunitContext
+{
+    public MetricsViewClusterTests()
+    {
+        // RadzenChart / RadzenDropDown make JS-interop calls during render; loose mode returns
+        // defaults so the component renders its markup without a strict-mode throw.
+        JSInterop.Mode = JSRuntimeMode.Loose;
+        // RadzenChart property-injects TooltipService (and siblings) — register the Radzen
+        // services so the chart can instantiate when a series has data.
+        Services.AddRadzenComponents();
+    }
+
+    [Fact]
+    public void NodeNames_dedupes_sorts_and_drops_empty()
+    {
+        // The drill-down dropdown is populated from the node CPU series — one entry per node,
+        // sorted, with blank (no k8s.node.name) samples excluded. Rendering the populated
+        // RadzenCharts isn't viable under bUnit (RadzenChart.OnAfterRenderAsync needs real browser
+        // layout), so the node-derivation logic is asserted directly via the extracted helper.
+        MetricSample S(string series) => new(series, new DateTime(2026, 6, 14, 10, 0, 0, DateTimeKind.Utc), 1);
+        var samples = new[] { S("cog-courvoisier"), S("cog-audry"), S("cog-audry"), S(""), S("vm-ygg-cp-1") };
+
+        var nodes = MetricsViewLogic.NodeNames(samples);
+
+        nodes.Should().Equal("cog-audry", "cog-courvoisier", "vm-ygg-cp-1");
+    }
+
+    [Fact]
+    public void NodeNames_of_empty_series_is_empty()
+        => MetricsViewLogic.NodeNames([]).Should().BeEmpty();
+
+    [Fact]
+    public void Hides_cluster_section_when_no_node_metrics()
+    {
+        Services.AddSingleton<IApplicationInsightsService>(new StubApplicationInsightsService(hasNodes: false));
+
+        var cut = Render<MetricsView>(p => p.Add(c => c.Context, new TestContext()));
+
+        // The Hosts section always renders; the Cluster section must collapse once loading
+        // completes and no node series came back.
+        cut.WaitForAssertion(() =>
+        {
+            cut.Markup.Should().Contain("Hosts");
+            cut.Markup.Should().NotContain("Cluster nodes");
+        });
+    }
+
+    private sealed class TestContext : IApplicationInsightsContext
+    {
+        public string TenantId => "t";
+        public string WorkspaceId => "w";
+        public string ClientId => "c";
+        public string ClientSecret => "s";
+    }
+
+    private sealed class StubApplicationInsightsService : IApplicationInsightsService
+    {
+        private readonly bool _hasNodes;
+        public StubApplicationInsightsService(bool hasNodes) => _hasNodes = hasNodes;
+
+        private static MetricSample Sample(string series, double value)
+            => new(series, new DateTime(2026, 6, 14, 10, 0, 0, DateTimeKind.Utc), value);
+
+        public IAsyncEnumerable<MetricSample> GetClusterNodeCpuAsync(IApplicationInsightsContext context, TimeSpan timeSpan, CancellationToken cancellationToken = default)
+            => _hasNodes ? Of(Sample("cog-audry", 0.5), Sample("cog-braastad", 0.6)) : Empty<MetricSample>();
+        public IAsyncEnumerable<MetricSample> GetClusterNodeMemoryAsync(IApplicationInsightsContext context, TimeSpan timeSpan, CancellationToken cancellationToken = default)
+            => _hasNodes ? Of(Sample("cog-audry", 29), Sample("cog-braastad", 35)) : Empty<MetricSample>();
+        public IAsyncEnumerable<MetricSample> GetClusterNodeFilesystemAsync(IApplicationInsightsContext context, TimeSpan timeSpan, CancellationToken cancellationToken = default)
+            => _hasNodes ? Of(Sample("cog-audry", 1.7)) : Empty<MetricSample>();
+        public IAsyncEnumerable<MetricSample> GetClusterPodCpuAsync(IApplicationInsightsContext context, string node, TimeSpan timeSpan, CancellationToken cancellationToken = default)
+            => Of(Sample("agents/web-1", 0.1));
+        public IAsyncEnumerable<MetricSample> GetClusterPodMemoryAsync(IApplicationInsightsContext context, string node, TimeSpan timeSpan, CancellationToken cancellationToken = default)
+            => Of(Sample("agents/web-1", 200));
+
+        // Everything else returns empty — the view only needs the metric methods to render.
+        public Task<bool> CanConnectAsync(IApplicationInsightsContext context) => Task.FromResult(true);
+        public IAsyncEnumerable<EnvironmentOption> GetEnvironments(IApplicationInsightsContext context) => Empty<EnvironmentOption>();
+        public IAsyncEnumerable<LogItem> SearchAsync(IApplicationInsightsContext context, string environment, string text, TimeSpan timeSpan, SeverityLevel minSeverityLevel = SeverityLevel.Verbose, CancellationToken cancellationToken = default) => Empty<LogItem>();
+        public IAsyncEnumerable<MeasureData> GetMeasureAsync(IApplicationInsightsContext context, string environment, TimeSpan timeSpan, CancellationToken cancellationToken = default) => Empty<MeasureData>();
+        public IAsyncEnumerable<CountData> GetCountAsync(IApplicationInsightsContext context, string environment, TimeSpan timeSpan, CancellationToken cancellationToken = default) => Empty<CountData>();
+        public Task<LogDetails> GetDetail(IApplicationInsightsContext context, string id, LogSource source, string environment, TimeSpan timeSpan) => Task.FromResult<LogDetails>(null);
+        public Task<SummaryData> GetSummary(IApplicationInsightsContext context, string fingerprint, LogSource source, string environment, TimeSpan timeSpan, int maxItems = 100) => Task.FromResult<SummaryData>(null);
+        public IAsyncEnumerable<SummarySubset> GetSummaries(IApplicationInsightsContext context, string environment, TimeSpan timeSpan, CancellationToken cancellationToken = default) => Empty<SummarySubset>();
+        public IAsyncEnumerable<VersionMatrixCell> GetVersionMatrixAsync(IApplicationInsightsContext context, TimeSpan? lookback = null, bool forceRefresh = false) => Empty<VersionMatrixCell>();
+        public IAsyncEnumerable<LogItem> SearchByIncidentIdAsync(IApplicationInsightsContext context, string incidentId, TimeSpan timeSpan) => Empty<LogItem>();
+        public IAsyncEnumerable<LogItem> SearchByCorrelationIdAsync(IApplicationInsightsContext context, string correlationId, TimeSpan timeSpan) => Empty<LogItem>();
+        public IAsyncEnumerable<MetricSample> GetCpuUtilizationAsync(IApplicationInsightsContext context, TimeSpan timeSpan, CancellationToken cancellationToken = default) => Empty<MetricSample>();
+        public IAsyncEnumerable<MetricSample> GetMemoryUtilizationAsync(IApplicationInsightsContext context, TimeSpan timeSpan, CancellationToken cancellationToken = default) => Empty<MetricSample>();
+        public IAsyncEnumerable<MetricSample> GetDiskFreeAsync(IApplicationInsightsContext context, TimeSpan timeSpan, CancellationToken cancellationToken = default) => Empty<MetricSample>();
+        public IAsyncEnumerable<DiskCapacity> GetDiskCapacityAsync(IApplicationInsightsContext context, TimeSpan timeSpan, CancellationToken cancellationToken = default) => Empty<DiskCapacity>();
+        public IAsyncEnumerable<MetricSample> GetNetworkThroughputAsync(IApplicationInsightsContext context, TimeSpan timeSpan, CancellationToken cancellationToken = default) => Empty<MetricSample>();
+        public IAsyncEnumerable<LogCountByServiceCell> GetLogCountByServiceAsync(IApplicationInsightsContext context, TimeSpan timeSpan, CancellationToken cancellationToken = default) => Empty<LogCountByServiceCell>();
+
+        private static async IAsyncEnumerable<T> Empty<T>()
+        {
+            await Task.CompletedTask;
+            yield break;
+        }
+
+        private static async IAsyncEnumerable<T> Of<T>(params T[] items)
+        {
+            await Task.CompletedTask;
+            foreach (var i in items) yield return i;
+        }
+    }
+}

--- a/Quilt4Net.Toolkit.Blazor.Tests/MetricsViewClusterTests.cs
+++ b/Quilt4Net.Toolkit.Blazor.Tests/MetricsViewClusterTests.cs
@@ -50,12 +50,12 @@ public class MetricsViewClusterTests : BunitContext
 
         var cut = Render<MetricsView>(p => p.Add(c => c.Context, new TestContext()));
 
-        // The Hosts section always renders; the Cluster section must collapse once loading
-        // completes and no node series came back.
+        // The Physical machines tab always renders; the Cluster tab must not appear once loading
+        // completes and no node series came back (no "Whole-cluster total" toggle present).
         cut.WaitForAssertion(() =>
         {
-            cut.Markup.Should().Contain("Hosts");
-            cut.Markup.Should().NotContain("Cluster nodes");
+            cut.Markup.Should().Contain("Physical machines");
+            cut.Markup.Should().NotContain("Whole-cluster total");
         });
     }
 
@@ -85,6 +85,12 @@ public class MetricsViewClusterTests : BunitContext
             => Of(Sample("agents/web-1", 0.1));
         public IAsyncEnumerable<MetricSample> GetClusterPodMemoryAsync(IApplicationInsightsContext context, string node, TimeSpan timeSpan, CancellationToken cancellationToken = default)
             => Of(Sample("agents/web-1", 200));
+        public IAsyncEnumerable<MetricSample> GetClusterTotalCpuAsync(IApplicationInsightsContext context, TimeSpan timeSpan, CancellationToken cancellationToken = default)
+            => _hasNodes ? Of(Sample("Cluster", 1.1)) : Empty<MetricSample>();
+        public IAsyncEnumerable<MetricSample> GetClusterTotalMemoryAsync(IApplicationInsightsContext context, TimeSpan timeSpan, CancellationToken cancellationToken = default)
+            => _hasNodes ? Of(Sample("Cluster", 31)) : Empty<MetricSample>();
+        public IAsyncEnumerable<MetricSample> GetClusterTotalFilesystemAsync(IApplicationInsightsContext context, TimeSpan timeSpan, CancellationToken cancellationToken = default)
+            => _hasNodes ? Of(Sample("Cluster", 3)) : Empty<MetricSample>();
 
         // Everything else returns empty — the view only needs the metric methods to render.
         public Task<bool> CanConnectAsync(IApplicationInsightsContext context) => Task.FromResult(true);

--- a/Quilt4Net.Toolkit.Blazor/Features/Log/CapTimelineView.razor
+++ b/Quilt4Net.Toolkit.Blazor/Features/Log/CapTimelineView.razor
@@ -1,0 +1,221 @@
+@using Microsoft.Extensions.DependencyInjection
+@using Quilt4Net.Toolkit.Blazor.Features.ApplicationInsights
+@using Quilt4Net.Toolkit.Features.ApplicationInsights
+@inject IServiceProvider ServiceProvider
+@implements IDisposable
+
+@* Daily ingestion-cap timeline: one column per UTC day of billed volume, a dashed reference line at
+   the configured daily cap, and — for days the cap was hit — a marker showing the extrapolated
+   "uncapped" volume (what the day would have ingested had the cap not throttled it). The grid below
+   gives the precise first-hit time per day, which is the "at what time does it happen" the operator
+   asked for. Degrades to an informational alert when the workspace Usage/Operation tables can't be
+   read (or there simply is no cap configured / no data in range). *@
+
+@if (_configError != null)
+{
+    <RadzenAlert AlertStyle="AlertStyle.Info" Shade="Shade.Lighter" AllowClose="false">@_configError</RadzenAlert>
+}
+else
+{
+    <RadzenStack Orientation="Orientation.Vertical" Gap="0" class="rz-mb-2">
+        <RadzenText TextStyle="TextStyle.Caption" Text="Range" />
+        <RadzenSelectBar @bind-Value="_days" TValue="int" Size="ButtonSize.Small" Change="@(_ => LoadAsync())">
+            <Items>
+                <RadzenSelectBarItem Text="14 days" Value="14" />
+                <RadzenSelectBarItem Text="30 days" Value="30" />
+                <RadzenSelectBarItem Text="90 days" Value="90" />
+            </Items>
+        </RadzenSelectBar>
+    </RadzenStack>
+
+    @if (_loading || Model == null)
+    {
+        <Loading />
+    }
+    else if (Model.Length == 0)
+    {
+        <RadzenAlert AlertStyle="AlertStyle.Warning" Shade="Shade.Lighter" AllowClose="false">
+            No ingestion-cap data for this range — the workspace <code>Usage</code>/<code>Operation</code>
+            tables are empty or not readable.
+        </RadzenAlert>
+    }
+    else
+    {
+        <RadzenText TextStyle="TextStyle.H6" Text="@HeaderText" />
+        @if (_capGb.HasValue && _hitDays > 0)
+        {
+            <RadzenText TextStyle="TextStyle.Caption" class="rz-mb-2"
+                        Text="@($"Estimated volume lost to the cap over this range: {_estLostGb:N1} GB (sum of est. uncapped − ingested on hit days).")" />
+        }
+
+        <RadzenChart>
+            <RadzenColumnSeries Data="@Model" CategoryProperty="DateLabel" ValueProperty="IngestedGb" Title="Ingested" />
+            @if (_capGb.HasValue)
+            {
+                @* Constant value on every row → renders as a horizontal reference line at the cap. *@
+                <RadzenLineSeries Data="@Model" CategoryProperty="DateLabel" ValueProperty="CapLineGb" Title="Daily cap" LineType="LineType.Dashed" />
+            }
+            @* Markers-only line: only hit days carry a value, so this shows as discrete points above
+               the cap line marking how much each capped day would have ingested unthrottled. *@
+            <RadzenLineSeries Data="@Model" CategoryProperty="DateLabel" ValueProperty="EstUncappedGb" Title="Est. uncapped" Smooth="false">
+                <RadzenMarkers MarkerType="MarkerType.Diamond" />
+            </RadzenLineSeries>
+            <RadzenCategoryAxis>
+                <RadzenAxisTitle Text="Day (UTC)" />
+            </RadzenCategoryAxis>
+            <RadzenValueAxis FormatString="{0:0.#} GB">
+                <RadzenAxisTitle Text="Billed volume" />
+            </RadzenValueAxis>
+            <RadzenLegend Position="LegendPosition.Bottom" />
+        </RadzenChart>
+
+        <RadzenDataGrid Data="@Model" TItem="Row" AllowSorting="true" AllowPaging="true" PageSize="15" class="rz-mt-2">
+            <Columns>
+                <RadzenDataGridColumn Title="Day (UTC)" Property="@nameof(Row.DateUtc)" SortOrder="SortOrder.Descending">
+                    <Template>@context.DateUtc.ToString("yyyy-MM-dd")</Template>
+                </RadzenDataGridColumn>
+                <RadzenDataGridColumn Title="Ingested" Property="@nameof(Row.IngestedGb)" TextAlign="TextAlign.Right">
+                    <Template>@context.IngestedGb.ToString("N2") GB</Template>
+                </RadzenDataGridColumn>
+                <RadzenDataGridColumn Title="Cap hit (UTC)" Property="@nameof(Row.HitSortKey)" TextAlign="TextAlign.Right">
+                    <Template>
+                        @if (context.CapHitUtc.HasValue)
+                        {
+                            <RadzenBadge BadgeStyle="BadgeStyle.Danger" Text="@context.CapHitUtc.Value.ToString("HH:mm")" />
+                        }
+                        else
+                        {
+                            <text>—</text>
+                        }
+                    </Template>
+                </RadzenDataGridColumn>
+                <RadzenDataGridColumn Title="Est. uncapped" Property="@nameof(Row.EstUncappedGb)" TextAlign="TextAlign.Right">
+                    <Template>@(context.EstUncappedGb.HasValue ? $"{context.EstUncappedGb.Value:N1} GB" : "—")</Template>
+                </RadzenDataGridColumn>
+            </Columns>
+        </RadzenDataGrid>
+    }
+}
+
+@code {
+    private Row[] Model { get; set; }
+    private double? _capGb;
+    private int _hitDays;
+    private double _estLostGb;
+    private string _configError;
+    private IApplicationInsightsService _ais;
+    private IApplicationInsightsConfigurationSelector _selector;
+    private CancellationTokenSource _cts;
+    private bool _loading;
+    private int _days = 30;
+
+    [Parameter]
+    public IApplicationInsightsContext Context { get; set; }
+
+    /// <summary>Initial number of days; the user can change it with the in-view 14/30/90 selector.</summary>
+    [Parameter]
+    public int Days { get; set; } = 30;
+
+    private IApplicationInsightsContext EffectiveContext => Context ?? _selector?.Selected;
+
+    private string HeaderText => _capGb.HasValue
+        ? $"Daily cap: {_capGb.Value:N0} GB · hit on {_hitDays} of {Model.Length} days"
+        : $"No daily cap configured · {Model.Length} days of billed volume";
+
+    protected override async Task OnInitializedAsync()
+    {
+        _days = Days;
+
+        _ais = LogConfigurationGuard.TryResolve(ServiceProvider);
+        if (_ais == null)
+        {
+            _configError = LogConfigurationGuard.ServiceNotRegisteredMessage;
+            return;
+        }
+
+        // Remote/selector mode: no explicit Context → track the shared config selector so this view
+        // queries the same workspace as the other AI views.
+        if (Context == null)
+        {
+            _selector = ServiceProvider.GetService<IApplicationInsightsConfigurationSelector>();
+            if (_selector != null)
+            {
+                _selector.OnChanged += OnSelectorChanged;
+                if (!_selector.IsLoaded) await _selector.LoadAsync();
+            }
+        }
+
+        if (EffectiveContext == null)
+        {
+            _configError = "No Application Insights configuration available.";
+            return;
+        }
+
+        await LoadAsync();
+    }
+
+    private async void OnSelectorChanged() => await InvokeAsync(LoadAsync);
+
+    private async Task LoadAsync()
+    {
+        var ctx = EffectiveContext;
+        if (ctx == null) return;
+
+        _cts?.Cancel();
+        _cts?.Dispose();
+        _cts = new CancellationTokenSource();
+        var token = _cts.Token;
+
+        _loading = true;
+        Model = null;
+        StateHasChanged();
+
+        try
+        {
+            var timeline = await _ais.GetCapTimelineAsync(ctx, _days, token);
+            if (token.IsCancellationRequested) return;
+
+            _capGb = timeline.CapGb;
+            Model = timeline.Days
+                .OrderBy(d => d.DateUtc)
+                .Select(d => new Row(
+                    d.DateUtc,
+                    d.DateUtc.ToString("MM-dd"),
+                    d.IngestedGb,
+                    timeline.CapGb,
+                    d.CapHitUtc,
+                    d.EstimatedUncappedGb))
+                .ToArray();
+
+            _hitDays = Model.Count(r => r.CapHitUtc.HasValue);
+            _estLostGb = Model
+                .Where(r => r.EstUncappedGb.HasValue)
+                .Sum(r => Math.Max(0, r.EstUncappedGb.Value - r.IngestedGb));
+        }
+        catch (OperationCanceledException) when (token.IsCancellationRequested)
+        {
+        }
+        finally
+        {
+            if (!token.IsCancellationRequested)
+            {
+                _loading = false;
+                StateHasChanged();
+            }
+        }
+    }
+
+    public void Dispose()
+    {
+        if (_selector != null) _selector.OnChanged -= OnSelectorChanged;
+        _cts?.Cancel();
+        _cts?.Dispose();
+    }
+
+    // HitSortKey lets the "Cap hit" column sort chronologically (DateTime.MaxValue floats no-hit days
+    // to the end) while the cell itself renders just the HH:mm badge.
+    private sealed record Row(DateTime DateUtc, string DateLabel, double IngestedGb, double? CapLineGb, DateTime? CapHitUtc, double? EstUncappedGb)
+    {
+        public DateTime HitSortKey => CapHitUtc ?? DateTime.MaxValue;
+    }
+}

--- a/Quilt4Net.Toolkit.Blazor/Features/Log/CapTimelineView.razor
+++ b/Quilt4Net.Toolkit.Blazor/Features/Log/CapTimelineView.razor
@@ -52,14 +52,21 @@ else
             <RadzenColumnSeries Data="@Model" CategoryProperty="DateLabel" ValueProperty="IngestedGb" Title="Ingested" />
             @if (_capGb.HasValue)
             {
-                @* Constant value on every row → renders as a horizontal reference line at the cap. *@
-                <RadzenLineSeries Data="@Model" CategoryProperty="DateLabel" ValueProperty="CapLineGb" Title="Daily cap" LineType="LineType.Dashed" />
+                @* Constant value on every row → renders as a horizontal reference line at the cap.
+                   CapLine is a non-nullable double (the series only renders when a cap exists) so
+                   Radzen's tooltip lambda never dereferences a null. *@
+                <RadzenLineSeries Data="@Model" CategoryProperty="DateLabel" ValueProperty="CapLine" Title="Daily cap" LineType="LineType.Dashed" />
             }
-            @* Markers-only line: only hit days carry a value, so this shows as discrete points above
-               the cap line marking how much each capped day would have ingested unthrottled. *@
-            <RadzenLineSeries Data="@Model" CategoryProperty="DateLabel" ValueProperty="EstUncappedGb" Title="Est. uncapped" Smooth="false">
-                <RadzenMarkers MarkerType="MarkerType.Diamond" />
-            </RadzenLineSeries>
+            @if (_uncappedPoints.Length > 0)
+            {
+                @* Bound to a *filtered* set (hit days only) with a non-nullable value — feeding the
+                   full Model here would put nulls on non-hit days and Radzen's tooltip lambda would
+                   throw "Nullable object must have a value". Markers mark how much each capped day
+                   would have ingested unthrottled. *@
+                <RadzenLineSeries Data="@_uncappedPoints" CategoryProperty="DateLabel" ValueProperty="EstUncappedGb" Title="Est. uncapped" Smooth="false">
+                    <RadzenMarkers MarkerType="MarkerType.Diamond" />
+                </RadzenLineSeries>
+            }
             <RadzenCategoryAxis>
                 <RadzenAxisTitle Text="Day (UTC)" />
             </RadzenCategoryAxis>
@@ -99,6 +106,7 @@ else
 
 @code {
     private Row[] Model { get; set; }
+    private UncappedPoint[] _uncappedPoints = [];
     private double? _capGb;
     private int _hitDays;
     private double _estLostGb;
@@ -168,6 +176,7 @@ else
 
         _loading = true;
         Model = null;
+        _uncappedPoints = [];
         StateHasChanged();
 
         try
@@ -182,9 +191,16 @@ else
                     d.DateUtc,
                     d.DateUtc.ToString("MM-dd"),
                     d.IngestedGb,
-                    timeline.CapGb,
+                    timeline.CapGb ?? 0,
                     d.CapHitUtc,
                     d.EstimatedUncappedGb))
+                .ToArray();
+
+            // Filtered, non-nullable points for the est-uncapped marker series — keeps nulls out of
+            // the Radzen series (the chart tooltip lambda can't handle a null value).
+            _uncappedPoints = Model
+                .Where(r => r.EstUncappedGb.HasValue)
+                .Select(r => new UncappedPoint(r.DateLabel, r.EstUncappedGb.Value))
                 .ToArray();
 
             _hitDays = Model.Count(r => r.CapHitUtc.HasValue);
@@ -213,9 +229,16 @@ else
     }
 
     // HitSortKey lets the "Cap hit" column sort chronologically (DateTime.MaxValue floats no-hit days
-    // to the end) while the cell itself renders just the HH:mm badge.
-    private sealed record Row(DateTime DateUtc, string DateLabel, double IngestedGb, double? CapLineGb, DateTime? CapHitUtc, double? EstUncappedGb)
+    // to the end) while the cell itself renders just the HH:mm badge. CapLine is the (non-nullable)
+    // cap value repeated on every row so the reference-line series never sees a null; EstUncappedGb
+    // stays nullable for the grid ("—" on non-hit days) but is fed to the chart only via the filtered
+    // _uncappedPoints set.
+    private sealed record Row(DateTime DateUtc, string DateLabel, double IngestedGb, double CapLine, DateTime? CapHitUtc, double? EstUncappedGb)
     {
         public DateTime HitSortKey => CapHitUtc ?? DateTime.MaxValue;
     }
+
+    /// <summary>Hit-day-only point for the est-uncapped marker series — non-nullable value so the
+    /// Radzen chart tooltip never dereferences a null.</summary>
+    private sealed record UncappedPoint(string DateLabel, double EstUncappedGb);
 }

--- a/Quilt4Net.Toolkit.Blazor/Features/Log/LogCountByServiceView.razor
+++ b/Quilt4Net.Toolkit.Blazor/Features/Log/LogCountByServiceView.razor
@@ -206,6 +206,9 @@
     // Sources actually present in the current window's cube — drives the Source filter so a source
     // with no data (e.g. Event/PageView when nothing emits them) doesn't show a 0-everywhere button.
     private IReadOnlyList<LogSource> _candidateSources = [];
+    // raw → logical application alias map (resolved in OnInitializedAsync); folds deployment/role
+    // names into their logical app so the same app doesn't split into two service rows.
+    private IReadOnlyDictionary<string, string> _effectiveAliasMap;
 
     // Current user selections. Empty enumerable everywhere means "include all".
     private IEnumerable<string> _selectedConfigIds = [];
@@ -265,8 +268,19 @@
     [Parameter]
     public IReadOnlyList<string> EnvironmentOrder { get; set; }
 
+    /// <summary>
+    /// Optional raw → logical application alias map. Service rows that fall back to a deployment /
+    /// cloud-role name (e.g. <c>eplicta-prod-aggregator-web</c>) because the row lacks a logical
+    /// <c>ApplicationName</c> are folded into their logical app, matching the other log views. When
+    /// null, falls back to the static map from <see cref="ApplicationInsightsOptions.ApplicationAlias"/>.
+    /// </summary>
+    [Parameter]
+    public IReadOnlyDictionary<string, string> ApplicationAliasMap { get; set; }
+
     protected override async Task OnInitializedAsync()
     {
+        _effectiveAliasMap = ApplicationAliasMap ?? AiOptions.Value?.ApplicationAlias?.ToResolverDictionary();
+
         // Scoped cache holds the cell cube across page navigations within this Blazor circuit.
         // Optional — hosts that didn't call AddQuilt4NetBlazorApplicationInsightsClientRemote
         // still work, they just lose the cross-page persistence.
@@ -524,7 +538,7 @@
         // rows we render no matter what the filter matches — entries with no matches show a row of
         // zeros so toggling a filter never makes a row vanish (keeps the grid stable across clicks).
         var allKeys = allCells
-            .Select(t => (Service: t.Cell.Service ?? "unknown", Machine: MachineKey(t)))
+            .Select(t => (Service: Fold(t.Cell.Service), Machine: MachineKey(t)))
             .Distinct(new ServiceMachineComparer())
             .ToArray();
 
@@ -536,7 +550,7 @@
             if (envSet.Count > 0 && !envSet.Contains(t.Cell.Environment)) continue;
             if (sourceSet.Count > 0 && !sourceSet.Contains(t.Cell.Source)) continue;
 
-            var key = (t.Cell.Service ?? "unknown", MachineKey(t), t.Cell.Severity);
+            var key = (Fold(t.Cell.Service), MachineKey(t), t.Cell.Severity);
             aggregated[key] = aggregated.GetValueOrDefault(key) + (_metric == Metric.Volume ? t.Cell.Bytes : t.Cell.Count);
         }
 
@@ -632,6 +646,13 @@
         if (mb >= 1024) return $"{mb / 1024.0:N2} GB";
         if (mb >= 1) return $"{mb:N1} MB";
         return $"{mb * 1024.0:N0} KB";
+    }
+
+    // Fold a raw service/role name to its logical app via the alias map (null/empty → "unknown").
+    private string Fold(string rawService)
+    {
+        var s = string.IsNullOrEmpty(rawService) ? "unknown" : rawService;
+        return _effectiveAliasMap is { Count: > 0 } map ? map.GetValueOrDefault(s, s) : s;
     }
 
     private sealed record Slice(string Label, double Value);

--- a/Quilt4Net.Toolkit.Blazor/Features/Log/LogCountByServiceView.razor
+++ b/Quilt4Net.Toolkit.Blazor/Features/Log/LogCountByServiceView.razor
@@ -86,7 +86,6 @@
                     <RadzenSelectBarItem Text="Dependency" Value="LogSource.Dependency" />
                     <RadzenSelectBarItem Text="Event" Value="LogSource.Event" />
                     <RadzenSelectBarItem Text="PageView" Value="LogSource.PageView" />
-                    <RadzenSelectBarItem Text="Availability" Value="LogSource.Availability" />
                 </Items>
             </RadzenSelectBar>
         </RadzenStack>

--- a/Quilt4Net.Toolkit.Blazor/Features/Log/LogCountByServiceView.razor
+++ b/Quilt4Net.Toolkit.Blazor/Features/Log/LogCountByServiceView.razor
@@ -75,20 +75,21 @@
                 </RadzenSelectBar>
             </RadzenStack>
         }
-        <RadzenStack Orientation="Orientation.Vertical" Gap="0">
-            <RadzenText TextStyle="TextStyle.Caption" Text="Source" />
-            <RadzenSelectBar @bind-Value="_selectedSources" TValue="IEnumerable<LogSource>" Multiple="true" Size="ButtonSize.Small"
-                             Change="@(_ => RecomputeRows())">
-                <Items>
-                    <RadzenSelectBarItem Text="Trace" Value="LogSource.Trace" />
-                    <RadzenSelectBarItem Text="Exception" Value="LogSource.Exception" />
-                    <RadzenSelectBarItem Text="Request" Value="LogSource.Request" />
-                    <RadzenSelectBarItem Text="Dependency" Value="LogSource.Dependency" />
-                    <RadzenSelectBarItem Text="Event" Value="LogSource.Event" />
-                    <RadzenSelectBarItem Text="PageView" Value="LogSource.PageView" />
-                </Items>
-            </RadzenSelectBar>
-        </RadzenStack>
+        @if (_candidateSources.Count > 1)
+        {
+            <RadzenStack Orientation="Orientation.Vertical" Gap="0">
+                <RadzenText TextStyle="TextStyle.Caption" Text="Source" />
+                <RadzenSelectBar @bind-Value="_selectedSources" TValue="IEnumerable<LogSource>" Multiple="true" Size="ButtonSize.Small"
+                                 Change="@(_ => RecomputeRows())">
+                    <Items>
+                        @foreach (var source in _candidateSources)
+                        {
+                            <RadzenSelectBarItem Text="@source.ToString()" Value="@source" />
+                        }
+                    </Items>
+                </RadzenSelectBar>
+            </RadzenStack>
+        }
         <RadzenStack Orientation="Orientation.Vertical" Gap="0">
             <RadzenText TextStyle="TextStyle.Caption" Text="Show" />
             <RadzenSelectBar @bind-Value="_metric" TValue="Metric" Size="ButtonSize.Small"
@@ -202,6 +203,9 @@
     // Candidate sets (everything offered by the AI workspaces) — separate from the user's picks.
     private IReadOnlyList<ApplicationInsightsConfigurationResponse> _candidateConfigs = [];
     private IReadOnlyList<string> _candidateEnvironments = [];
+    // Sources actually present in the current window's cube — drives the Source filter so a source
+    // with no data (e.g. Event/PageView when nothing emits them) doesn't show a 0-everywhere button.
+    private IReadOnlyList<LogSource> _candidateSources = [];
 
     // Current user selections. Empty enumerable everywhere means "include all".
     private IEnumerable<string> _selectedConfigIds = [];
@@ -493,8 +497,16 @@
             _rows = [];
             _columnTotals = NewEmptyTotals();
             _grandTotal = 0;
+            _severitySlices = [];
+            _serviceSlices = [];
+            _candidateSources = [];
             return;
         }
+
+        // Data-driven source options: only sources present in the cube. Prune any selection that
+        // no longer applies so chip state stays honest.
+        _candidateSources = allCells.Select(t => t.Cell.Source).Distinct().OrderBy(s => (int)s).ToArray();
+        _selectedSources = (_selectedSources ?? []).Where(_candidateSources.Contains).ToArray();
 
         var configSet = (_selectedConfigIds ?? []).ToHashSet(System.StringComparer.OrdinalIgnoreCase);
         var envSet = (_selectedEnvironments ?? []).ToHashSet(System.StringComparer.OrdinalIgnoreCase);

--- a/Quilt4Net.Toolkit.Blazor/Features/Log/LogCountByServiceView.razor
+++ b/Quilt4Net.Toolkit.Blazor/Features/Log/LogCountByServiceView.razor
@@ -83,6 +83,20 @@
                     <RadzenSelectBarItem Text="Trace" Value="LogSource.Trace" />
                     <RadzenSelectBarItem Text="Exception" Value="LogSource.Exception" />
                     <RadzenSelectBarItem Text="Request" Value="LogSource.Request" />
+                    <RadzenSelectBarItem Text="Dependency" Value="LogSource.Dependency" />
+                    <RadzenSelectBarItem Text="Event" Value="LogSource.Event" />
+                    <RadzenSelectBarItem Text="PageView" Value="LogSource.PageView" />
+                    <RadzenSelectBarItem Text="Availability" Value="LogSource.Availability" />
+                </Items>
+            </RadzenSelectBar>
+        </RadzenStack>
+        <RadzenStack Orientation="Orientation.Vertical" Gap="0">
+            <RadzenText TextStyle="TextStyle.Caption" Text="Show" />
+            <RadzenSelectBar @bind-Value="_metric" TValue="Metric" Size="ButtonSize.Small"
+                             Change="@(_ => RecomputeRows())">
+                <Items>
+                    <RadzenSelectBarItem Text="Count" Value="Metric.Count" />
+                    <RadzenSelectBarItem Text="Volume" Value="Metric.Volume" />
                 </Items>
             </RadzenSelectBar>
         </RadzenStack>
@@ -135,26 +149,48 @@
                     <FooterTemplate><strong>Total</strong></FooterTemplate>
                 </RadzenDataGridColumn>
                 <RadzenDataGridColumn TItem="ServiceRow" Title="Machine" Property="@nameof(ServiceRow.Machine)" Visible="@_perMachine" />
-                <RadzenDataGridColumn TItem="ServiceRow" Title="Verbose" Property="@nameof(ServiceRow.Verbose)" Width="120px" TextAlign="TextAlign.Right" FormatString="{0:N0}">
-                    <FooterTemplate><strong>@_columnTotals[SeverityLevel.Verbose].ToString("N0")</strong></FooterTemplate>
+                <RadzenDataGridColumn TItem="ServiceRow" Title="Verbose" Property="@nameof(ServiceRow.Verbose)" Width="120px" TextAlign="TextAlign.Right">
+                    <Template>@FormatMetric(context.Verbose)</Template>
+                    <FooterTemplate><strong>@FormatMetric(_columnTotals[SeverityLevel.Verbose])</strong></FooterTemplate>
                 </RadzenDataGridColumn>
-                <RadzenDataGridColumn TItem="ServiceRow" Title="Information" Property="@nameof(ServiceRow.Information)" Width="140px" TextAlign="TextAlign.Right" FormatString="{0:N0}">
-                    <FooterTemplate><strong>@_columnTotals[SeverityLevel.Information].ToString("N0")</strong></FooterTemplate>
+                <RadzenDataGridColumn TItem="ServiceRow" Title="Information" Property="@nameof(ServiceRow.Information)" Width="140px" TextAlign="TextAlign.Right">
+                    <Template>@FormatMetric(context.Information)</Template>
+                    <FooterTemplate><strong>@FormatMetric(_columnTotals[SeverityLevel.Information])</strong></FooterTemplate>
                 </RadzenDataGridColumn>
-                <RadzenDataGridColumn TItem="ServiceRow" Title="Warning" Property="@nameof(ServiceRow.Warning)" Width="120px" TextAlign="TextAlign.Right" FormatString="{0:N0}">
-                    <FooterTemplate><strong>@_columnTotals[SeverityLevel.Warning].ToString("N0")</strong></FooterTemplate>
+                <RadzenDataGridColumn TItem="ServiceRow" Title="Warning" Property="@nameof(ServiceRow.Warning)" Width="120px" TextAlign="TextAlign.Right">
+                    <Template>@FormatMetric(context.Warning)</Template>
+                    <FooterTemplate><strong>@FormatMetric(_columnTotals[SeverityLevel.Warning])</strong></FooterTemplate>
                 </RadzenDataGridColumn>
-                <RadzenDataGridColumn TItem="ServiceRow" Title="Error" Property="@nameof(ServiceRow.Error)" Width="120px" TextAlign="TextAlign.Right" FormatString="{0:N0}">
-                    <FooterTemplate><strong>@_columnTotals[SeverityLevel.Error].ToString("N0")</strong></FooterTemplate>
+                <RadzenDataGridColumn TItem="ServiceRow" Title="Error" Property="@nameof(ServiceRow.Error)" Width="120px" TextAlign="TextAlign.Right">
+                    <Template>@FormatMetric(context.Error)</Template>
+                    <FooterTemplate><strong>@FormatMetric(_columnTotals[SeverityLevel.Error])</strong></FooterTemplate>
                 </RadzenDataGridColumn>
-                <RadzenDataGridColumn TItem="ServiceRow" Title="Critical" Property="@nameof(ServiceRow.Critical)" Width="120px" TextAlign="TextAlign.Right" FormatString="{0:N0}">
-                    <FooterTemplate><strong>@_columnTotals[SeverityLevel.Critical].ToString("N0")</strong></FooterTemplate>
+                <RadzenDataGridColumn TItem="ServiceRow" Title="Critical" Property="@nameof(ServiceRow.Critical)" Width="120px" TextAlign="TextAlign.Right">
+                    <Template>@FormatMetric(context.Critical)</Template>
+                    <FooterTemplate><strong>@FormatMetric(_columnTotals[SeverityLevel.Critical])</strong></FooterTemplate>
                 </RadzenDataGridColumn>
-                <RadzenDataGridColumn TItem="ServiceRow" Title="Total" Property="@nameof(ServiceRow.Total)" Width="120px" TextAlign="TextAlign.Right" FormatString="{0:N0}">
-                    <FooterTemplate><strong>@_grandTotal.ToString("N0")</strong></FooterTemplate>
+                <RadzenDataGridColumn TItem="ServiceRow" Title="Total" Property="@nameof(ServiceRow.Total)" Width="120px" TextAlign="TextAlign.Right">
+                    <Template>@FormatMetric(context.Total)</Template>
+                    <FooterTemplate><strong>@FormatMetric(_grandTotal)</strong></FooterTemplate>
                 </RadzenDataGridColumn>
             </Columns>
         </RadzenDataGrid>
+
+        @* Marginal pies: severity = the table's bottom totals; service = its right totals. *@
+        <RadzenRow Gap="1rem" class="rz-mt-3">
+            <RadzenColumn Size="12" SizeMD="6">
+                <RadzenText TextStyle="TextStyle.Subtitle2" Text="By severity" />
+                <RadzenChart>
+                    <RadzenPieSeries Data="@_severitySlices" CategoryProperty="Label" ValueProperty="Value" />
+                </RadzenChart>
+            </RadzenColumn>
+            <RadzenColumn Size="12" SizeMD="6">
+                <RadzenText TextStyle="TextStyle.Subtitle2" Text="By service" />
+                <RadzenChart>
+                    <RadzenPieSeries Data="@_serviceSlices" CategoryProperty="Label" ValueProperty="Value" />
+                </RadzenChart>
+            </RadzenColumn>
+        </RadzenRow>
     }
 </RadzenStack>
 
@@ -191,6 +227,13 @@
     private List<ServiceRow> _rows = [];
     private Dictionary<SeverityLevel, long> _columnTotals = NewEmptyTotals();
     private long _grandTotal;
+
+    // Count vs ingested-volume view. Both Count and Bytes ride on every cell, so flipping this is a
+    // pure local recompute (no fetch). Drives the table cells/totals and the two pies.
+    private enum Metric { Count, Volume }
+    private Metric _metric = Metric.Count;
+    private List<Slice> _severitySlices = [];
+    private List<Slice> _serviceSlices = [];
     private System.DateTime? _lastRefreshUtc; // for the refresh-button "loaded at" tooltip
     private static readonly System.TimeSpan _cacheTtl = System.TimeSpan.FromMinutes(10);
     private Quilt4Net.Toolkit.Blazor.Framework.IBrowserTimeZoneAccessor _browserTime;
@@ -483,7 +526,7 @@
             if (sourceSet.Count > 0 && !sourceSet.Contains(t.Cell.Source)) continue;
 
             var key = (t.Cell.Service ?? "unknown", MachineKey(t), t.Cell.Severity);
-            aggregated[key] = aggregated.GetValueOrDefault(key) + t.Cell.Count;
+            aggregated[key] = aggregated.GetValueOrDefault(key) + (_metric == Metric.Volume ? t.Cell.Bytes : t.Cell.Count);
         }
 
         _rows = allKeys
@@ -509,6 +552,17 @@
             }
         }
         _grandTotal = _rows.Sum(r => r.Total);
+
+        // Marginals for the two pies: severity = column totals (bottom row), service = row totals
+        // (right column). Both follow the active metric (count or volume) and current filters.
+        _severitySlices = _columnTotals
+            .Where(kv => kv.Value > 0)
+            .Select(kv => new Slice(kv.Key.ToString(), kv.Value))
+            .ToList();
+        _serviceSlices = _rows
+            .Where(r => r.Total > 0)
+            .Select(r => new Slice(_perMachine ? $"{r.Service} / {r.Machine}" : r.Service, r.Total))
+            .ToList();
     }
 
     /// <summary>
@@ -557,6 +611,19 @@
     {
         if (_selector != null) _selector.OnChanged -= OnSelectorChanged;
     }
+
+    // Count → "N0"; Volume → auto-scaled size from the megabyte value (Bytes are summed in the cube).
+    private string FormatMetric(long value)
+        => _metric == Metric.Volume ? FormatSize(value / 1048576.0) : value.ToString("N0");
+
+    private static string FormatSize(double mb)
+    {
+        if (mb >= 1024) return $"{mb / 1024.0:N2} GB";
+        if (mb >= 1) return $"{mb:N1} MB";
+        return $"{mb * 1024.0:N0} KB";
+    }
+
+    private sealed record Slice(string Label, double Value);
 
     /// <summary>
     /// Row shape with one explicit property per severity so the grid can sort each amount column

--- a/Quilt4Net.Toolkit.Blazor/Features/Log/LogCountByServiceView.razor
+++ b/Quilt4Net.Toolkit.Blazor/Features/Log/LogCountByServiceView.razor
@@ -191,6 +191,41 @@
                 </RadzenChart>
             </RadzenColumn>
         </RadzenRow>
+
+        @* Sampling correction: what the current selection would have cost without ingestion
+           sampling. Retained = records actually kept; Est. true = sum(ItemCount). When nothing is
+           sampled (ItemCount == 1 everywhere) the two are equal and we say so plainly — that itself
+           answers "are we sampling?". AppMetrics is intentionally absent (not in the cube) since its
+           ItemCount is an aggregation count, not a sampling weight. *@
+        <RadzenCard class="rz-mt-3">
+            <RadzenText TextStyle="TextStyle.Subtitle2" Text="Sampling" />
+            @if (!_anySampling)
+            {
+                <RadzenAlert AlertStyle="AlertStyle.Info" Shade="Shade.Lighter" AllowClose="false">
+                    Ingestion sampling is <strong>not in effect</strong> for this selection — every record is
+                    retained (100%), so the @MetricNoun shown above already equals the true @MetricNoun.
+                </RadzenAlert>
+            }
+            else
+            {
+                <RadzenText TextStyle="TextStyle.Body2" class="rz-mb-2"
+                            Text="@($"Effective sampling: {_effectiveRatePct:N1}% of records retained. Showing {FormatMetric(_samplingRetained)} of an estimated {FormatMetric(_samplingTrue)} {MetricNoun} without sampling.")" />
+                <RadzenDataGrid Data="@_samplingRows" TItem="SamplingRow" AllowSorting="true">
+                    <Columns>
+                        <RadzenDataGridColumn TItem="SamplingRow" Title="Source" Property="@nameof(SamplingRow.Source)" />
+                        <RadzenDataGridColumn TItem="SamplingRow" Title="Retained" Property="@nameof(SamplingRow.Retained)" TextAlign="TextAlign.Right">
+                            <Template>@FormatMetric(context.Retained)</Template>
+                        </RadzenDataGridColumn>
+                        <RadzenDataGridColumn TItem="SamplingRow" Title="Est. true" Property="@nameof(SamplingRow.EstTrue)" TextAlign="TextAlign.Right" SortOrder="SortOrder.Descending">
+                            <Template>@FormatMetric(context.EstTrue)</Template>
+                        </RadzenDataGridColumn>
+                        <RadzenDataGridColumn TItem="SamplingRow" Title="Retained %" Property="@nameof(SamplingRow.RatePct)" TextAlign="TextAlign.Right">
+                            <Template>@context.RatePct.ToString("N1") %</Template>
+                        </RadzenDataGridColumn>
+                    </Columns>
+                </RadzenDataGrid>
+            }
+        </RadzenCard>
     }
 </RadzenStack>
 
@@ -240,6 +275,15 @@
     private Metric _metric = Metric.Count;
     private List<Slice> _severitySlices = [];
     private List<Slice> _serviceSlices = [];
+
+    // Sampling correction: each cell carries retained (Count/Bytes) and sampling-corrected
+    // (TrueCount/TrueBytes, via sum(ItemCount)) figures. The per-source table and overall summary
+    // are recomputed under the same filters as the main grid, in the active metric's unit.
+    private List<SamplingRow> _samplingRows = [];
+    private long _samplingRetained;   // active-metric unit (records or bytes)
+    private long _samplingTrue;       // active-metric unit, sampling-corrected
+    private double _effectiveRatePct = 100; // count-based: 100 * retained-count / true-count
+    private bool _anySampling;        // true once any source's true-count exceeds its retained-count
     private System.DateTime? _lastRefreshUtc; // for the refresh-button "loaded at" tooltip
     private static readonly System.TimeSpan _cacheTtl = System.TimeSpan.FromMinutes(10);
     private Quilt4Net.Toolkit.Blazor.Framework.IBrowserTimeZoneAccessor _browserTime;
@@ -514,6 +558,10 @@
             _severitySlices = [];
             _serviceSlices = [];
             _candidateSources = [];
+            _samplingRows = [];
+            _samplingRetained = _samplingTrue = 0;
+            _effectiveRatePct = 100;
+            _anySampling = false;
             return;
         }
 
@@ -544,6 +592,8 @@
 
         var aggregated = new Dictionary<(string Service, string Machine, SeverityLevel Severity), long>(
             new ServiceMachineSeverityComparer());
+        // Per-source sampling accumulator: (retained count, true count, retained bytes, true bytes).
+        var samp = new Dictionary<LogSource, (long Rc, long Tc, long Rb, long Tb)>();
         foreach (var t in allCells)
         {
             if (configSet.Count > 0 && !configSet.Contains(t.ConfigId)) continue;
@@ -552,7 +602,12 @@
 
             var key = (Fold(t.Cell.Service), MachineKey(t), t.Cell.Severity);
             aggregated[key] = aggregated.GetValueOrDefault(key) + (_metric == Metric.Volume ? t.Cell.Bytes : t.Cell.Count);
+
+            var cur = samp.GetValueOrDefault(t.Cell.Source);
+            samp[t.Cell.Source] = (cur.Rc + t.Cell.Count, cur.Tc + t.Cell.TrueCount, cur.Rb + t.Cell.Bytes, cur.Tb + t.Cell.TrueBytes);
         }
+
+        BuildSampling(samp);
 
         _rows = allKeys
             .OrderBy(k => k.Service, System.StringComparer.OrdinalIgnoreCase)
@@ -637,6 +692,39 @@
         if (_selector != null) _selector.OnChanged -= OnSelectorChanged;
     }
 
+    /// <summary>
+    /// Turn the per-source (retained, true) sampling accumulator into the display rows + overall
+    /// summary. The effective rate is count-based (records dropped, not bytes) since that's the
+    /// cleanest measure of the sampling decision; the Retained / Est. true figures follow the active
+    /// metric. <c>TrueCount &gt;= Count</c> always (each retained row weighs <c>ItemCount &gt;= 1</c>),
+    /// so a source is "sampled" exactly when its true-count exceeds its retained-count.
+    /// </summary>
+    private void BuildSampling(Dictionary<LogSource, (long Rc, long Tc, long Rb, long Tb)> samp)
+    {
+        _samplingRows = samp
+            .Select(kv =>
+            {
+                var (rc, tc, rb, tb) = kv.Value;
+                var retained = _metric == Metric.Volume ? rb : rc;
+                var estTrue = _metric == Metric.Volume ? tb : tc;
+                var ratePct = tc > 0 ? 100.0 * rc / tc : 100.0;
+                return new SamplingRow(kv.Key.ToString(), retained, estTrue, ratePct);
+            })
+            .OrderByDescending(r => r.EstTrue)
+            .ToList();
+
+        var totRc = samp.Values.Sum(v => v.Rc);
+        var totTc = samp.Values.Sum(v => v.Tc);
+        var totRb = samp.Values.Sum(v => v.Rb);
+        var totTb = samp.Values.Sum(v => v.Tb);
+        _samplingRetained = _metric == Metric.Volume ? totRb : totRc;
+        _samplingTrue = _metric == Metric.Volume ? totTb : totTc;
+        _effectiveRatePct = totTc > 0 ? 100.0 * totRc / totTc : 100.0;
+        _anySampling = totTc > totRc;
+    }
+
+    private string MetricNoun => _metric == Metric.Volume ? "volume" : "records";
+
     // Count → "N0"; Volume → auto-scaled size from the megabyte value (Bytes are summed in the cube).
     private string FormatMetric(long value)
         => _metric == Metric.Volume ? FormatSize(value / 1048576.0) : value.ToString("N0");
@@ -656,6 +744,10 @@
     }
 
     private sealed record Slice(string Label, double Value);
+
+    /// <summary>One source's sampling picture: retained vs sampling-corrected ("true") figure in the
+    /// active metric's unit, plus the count-based retained percentage (100 = nothing sampled out).</summary>
+    private sealed record SamplingRow(string Source, long Retained, long EstTrue, double RatePct);
 
     /// <summary>
     /// Row shape with one explicit property per severity so the grid can sort each amount column

--- a/Quilt4Net.Toolkit.Blazor/Features/Log/LogVolumeView.razor
+++ b/Quilt4Net.Toolkit.Blazor/Features/Log/LogVolumeView.razor
@@ -1,3 +1,5 @@
+@using Microsoft.Extensions.DependencyInjection
+@using Quilt4Net.Toolkit.Blazor.Features.ApplicationInsights
 @using Quilt4Net.Toolkit.Features.ApplicationInsights
 @inject IServiceProvider ServiceProvider
 
@@ -41,6 +43,7 @@ else
     private double _totalMb;
     private string _configError;
     private IApplicationInsightsService _ais;
+    private IApplicationInsightsConfigurationSelector _selector;
     private CancellationTokenSource _cts;
     private bool _loading;
 
@@ -50,24 +53,44 @@ else
     [Parameter]
     public TimeSpan Range { get; set; } = TimeSpan.FromDays(7);
 
-    protected override void OnInitialized()
+    private IApplicationInsightsContext EffectiveContext => Context ?? _selector?.Selected;
+
+    protected override async Task OnInitializedAsync()
     {
         _ais = LogConfigurationGuard.TryResolve(ServiceProvider);
         if (_ais == null)
         {
             _configError = LogConfigurationGuard.ServiceNotRegisteredMessage;
+            return;
         }
+
+        // Remote/selector mode: no explicit Context → track the shared config selector so this view
+        // queries the same workspace as the other AI views (MetricsView, LogView, …).
+        if (Context == null)
+        {
+            _selector = ServiceProvider.GetService<IApplicationInsightsConfigurationSelector>();
+            if (_selector != null)
+            {
+                _selector.OnChanged += OnSelectorChanged;
+                if (!_selector.IsLoaded) await _selector.LoadAsync();
+            }
+        }
+
+        if (EffectiveContext == null)
+        {
+            _configError = "No Application Insights configuration available.";
+            return;
+        }
+
+        await LoadAsync();
     }
 
-    public void Dispose()
-    {
-        _cts?.Cancel();
-        _cts?.Dispose();
-    }
+    private async void OnSelectorChanged() => await InvokeAsync(LoadAsync);
 
-    protected override async Task OnParametersSetAsync()
+    private async Task LoadAsync()
     {
-        if (_configError != null) return;
+        var ctx = EffectiveContext;
+        if (ctx == null) return;
 
         _cts?.Cancel();
         _cts?.Dispose();
@@ -80,7 +103,7 @@ else
 
         try
         {
-            var loaded = await _ais.GetVolumeBySourceAsync(Context, Range, token).ToArrayAsync(token);
+            var loaded = await _ais.GetVolumeBySourceAsync(ctx, Range, token).ToArrayAsync(token);
             if (token.IsCancellationRequested) return;
 
             Model = loaded;
@@ -97,5 +120,12 @@ else
                 StateHasChanged();
             }
         }
+    }
+
+    public void Dispose()
+    {
+        if (_selector != null) _selector.OnChanged -= OnSelectorChanged;
+        _cts?.Cancel();
+        _cts?.Dispose();
     }
 }

--- a/Quilt4Net.Toolkit.Blazor/Features/Log/LogVolumeView.razor
+++ b/Quilt4Net.Toolkit.Blazor/Features/Log/LogVolumeView.razor
@@ -7,49 +7,66 @@
 {
     <RadzenAlert AlertStyle="AlertStyle.Info" Shade="Shade.Lighter" AllowClose="false">@_configError</RadzenAlert>
 }
-else if (_loading || Model == null)
-{
-    <Loading />
-}
-else if (Model.Length == 0)
-{
-    <RadzenAlert AlertStyle="AlertStyle.Warning" Shade="Shade.Lighter" AllowClose="false">
-        No billed ingestion volume found for this range — the workspace <code>Usage</code> table is empty or not readable.
-    </RadzenAlert>
-}
 else
 {
-    <RadzenText TextStyle="TextStyle.H6" Text="@($"Total ingested: {_totalMb:N0} MB over the last {Range.TotalDays:N0} day(s)")" />
-    <RadzenChart>
-        <RadzenPieSeries Data="@Model" CategoryProperty="Source" ValueProperty="Mb" Title="MB" />
-    </RadzenChart>
-    <RadzenDataGrid Data="@Model" TItem="VolumeBySource" AllowSorting="true" AllowPaging="true" PageSize="10">
-        <Columns>
-            <RadzenDataGridColumn Title="Source" Property="@nameof(VolumeBySource.Source)" />
-            <RadzenDataGridColumn Title="MB" Property="@nameof(VolumeBySource.Mb)">
-                <Template>@context.Mb.ToString("N1")</Template>
-            </RadzenDataGridColumn>
-            <RadzenDataGridColumn Title="Share" Sortable="false">
-                <Template>@((_totalMb > 0 ? context.Mb / _totalMb : 0).ToString("P1"))</Template>
-            </RadzenDataGridColumn>
-        </Columns>
-    </RadzenDataGrid>
+    <RadzenStack Orientation="Orientation.Vertical" Gap="0" class="rz-mb-2">
+        <RadzenText TextStyle="TextStyle.Caption" Text="Range" />
+        <RadzenSelectBar @bind-Value="_range" TValue="TimeSpan" Size="ButtonSize.Small" Change="@(_ => LoadAsync())">
+            <Items>
+                <RadzenSelectBarItem Text="1h" Value="@TimeSpan.FromHours(1)" />
+                <RadzenSelectBarItem Text="24h" Value="@TimeSpan.FromHours(24)" />
+                <RadzenSelectBarItem Text="7d" Value="@TimeSpan.FromDays(7)" />
+            </Items>
+        </RadzenSelectBar>
+    </RadzenStack>
+
+    @if (_loading || Model == null)
+    {
+        <Loading />
+    }
+    else if (Model.Length == 0)
+    {
+        <RadzenAlert AlertStyle="AlertStyle.Warning" Shade="Shade.Lighter" AllowClose="false">
+            No billed ingestion volume found for this range — the workspace <code>Usage</code> table is empty or not readable.
+        </RadzenAlert>
+    }
+    else
+    {
+        <RadzenText TextStyle="TextStyle.H6" Text="@($"Total ingested: {FormatSize(_totalMb)} over the last {RangeLabel(_range)}")" />
+        <RadzenChart>
+            <RadzenPieSeries Data="@Model" CategoryProperty="Source" ValueProperty="Mb" Title="Size" />
+        </RadzenChart>
+        <RadzenDataGrid Data="@Model" TItem="Row" AllowSorting="true" AllowPaging="true" PageSize="10">
+            <Columns>
+                <RadzenDataGridColumn Title="Source" Property="@nameof(Row.Source)" />
+                @* Sort on the raw MB value (always MB) so ordering is correct even though the cell shows GB/MB/KB. *@
+                <RadzenDataGridColumn Title="Size" Property="@nameof(Row.Mb)" TextAlign="TextAlign.Right" SortOrder="SortOrder.Descending">
+                    <Template>@FormatSize(context.Mb)</Template>
+                </RadzenDataGridColumn>
+                <RadzenDataGridColumn Title="Share" Property="@nameof(Row.Share)" TextAlign="TextAlign.Right">
+                    <Template>@context.Share.ToString("P1")</Template>
+                </RadzenDataGridColumn>
+            </Columns>
+        </RadzenDataGrid>
+    }
 }
 
 @implements IDisposable
 
 @code {
-    private VolumeBySource[] Model { get; set; }
+    private Row[] Model { get; set; }
     private double _totalMb;
     private string _configError;
     private IApplicationInsightsService _ais;
     private IApplicationInsightsConfigurationSelector _selector;
     private CancellationTokenSource _cts;
     private bool _loading;
+    private TimeSpan _range = TimeSpan.FromDays(7);
 
     [Parameter]
     public IApplicationInsightsContext Context { get; set; }
 
+    /// <summary>Initial range; the user can change it with the in-view 1h/24h/7d selector.</summary>
     [Parameter]
     public TimeSpan Range { get; set; } = TimeSpan.FromDays(7);
 
@@ -57,6 +74,8 @@ else
 
     protected override async Task OnInitializedAsync()
     {
+        _range = Range;
+
         _ais = LogConfigurationGuard.TryResolve(ServiceProvider);
         if (_ais == null)
         {
@@ -103,11 +122,13 @@ else
 
         try
         {
-            var loaded = await _ais.GetVolumeBySourceAsync(ctx, Range, token).ToArrayAsync(token);
+            var loaded = await _ais.GetVolumeBySourceAsync(ctx, _range, token).ToArrayAsync(token);
             if (token.IsCancellationRequested) return;
 
-            Model = loaded;
             _totalMb = loaded.Sum(x => x.Mb);
+            Model = loaded
+                .Select(x => new Row(x.Source, x.Mb, _totalMb > 0 ? x.Mb / _totalMb : 0))
+                .ToArray();
         }
         catch (OperationCanceledException) when (token.IsCancellationRequested)
         {
@@ -122,10 +143,26 @@ else
         }
     }
 
+    // Auto-scaled display from a megabyte value. Sorting uses the raw MB (always MB), so the unit
+    // shown per row (GB/MB/KB) never affects ordering.
+    private static string FormatSize(double mb)
+    {
+        if (mb >= 1024) return $"{mb / 1024.0:N2} GB";
+        if (mb >= 1) return $"{mb:N1} MB";
+        return $"{mb * 1024.0:N0} KB";
+    }
+
+    private static string RangeLabel(TimeSpan range)
+        => range >= TimeSpan.FromDays(7) ? "7 days"
+            : range >= TimeSpan.FromHours(24) ? "24 hours"
+            : "1 hour";
+
     public void Dispose()
     {
         if (_selector != null) _selector.OnChanged -= OnSelectorChanged;
         _cts?.Cancel();
         _cts?.Dispose();
     }
+
+    private sealed record Row(string Source, double Mb, double Share);
 }

--- a/Quilt4Net.Toolkit.Blazor/Features/Log/LogVolumeView.razor
+++ b/Quilt4Net.Toolkit.Blazor/Features/Log/LogVolumeView.razor
@@ -1,0 +1,101 @@
+@using Quilt4Net.Toolkit.Features.ApplicationInsights
+@inject IServiceProvider ServiceProvider
+
+@if (_configError != null)
+{
+    <RadzenAlert AlertStyle="AlertStyle.Info" Shade="Shade.Lighter" AllowClose="false">@_configError</RadzenAlert>
+}
+else if (_loading || Model == null)
+{
+    <Loading />
+}
+else if (Model.Length == 0)
+{
+    <RadzenAlert AlertStyle="AlertStyle.Warning" Shade="Shade.Lighter" AllowClose="false">
+        No billed ingestion volume found for this range — the workspace <code>Usage</code> table is empty or not readable.
+    </RadzenAlert>
+}
+else
+{
+    <RadzenText TextStyle="TextStyle.H6" Text="@($"Total ingested: {_totalMb:N0} MB over the last {Range.TotalDays:N0} day(s)")" />
+    <RadzenChart>
+        <RadzenPieSeries Data="@Model" CategoryProperty="Source" ValueProperty="Mb" Title="MB" />
+    </RadzenChart>
+    <RadzenDataGrid Data="@Model" TItem="VolumeBySource" AllowSorting="true" AllowPaging="true" PageSize="10">
+        <Columns>
+            <RadzenDataGridColumn Title="Source" Property="@nameof(VolumeBySource.Source)" />
+            <RadzenDataGridColumn Title="MB" Property="@nameof(VolumeBySource.Mb)">
+                <Template>@context.Mb.ToString("N1")</Template>
+            </RadzenDataGridColumn>
+            <RadzenDataGridColumn Title="Share" Sortable="false">
+                <Template>@((_totalMb > 0 ? context.Mb / _totalMb : 0).ToString("P1"))</Template>
+            </RadzenDataGridColumn>
+        </Columns>
+    </RadzenDataGrid>
+}
+
+@implements IDisposable
+
+@code {
+    private VolumeBySource[] Model { get; set; }
+    private double _totalMb;
+    private string _configError;
+    private IApplicationInsightsService _ais;
+    private CancellationTokenSource _cts;
+    private bool _loading;
+
+    [Parameter]
+    public IApplicationInsightsContext Context { get; set; }
+
+    [Parameter]
+    public TimeSpan Range { get; set; } = TimeSpan.FromDays(7);
+
+    protected override void OnInitialized()
+    {
+        _ais = LogConfigurationGuard.TryResolve(ServiceProvider);
+        if (_ais == null)
+        {
+            _configError = LogConfigurationGuard.ServiceNotRegisteredMessage;
+        }
+    }
+
+    public void Dispose()
+    {
+        _cts?.Cancel();
+        _cts?.Dispose();
+    }
+
+    protected override async Task OnParametersSetAsync()
+    {
+        if (_configError != null) return;
+
+        _cts?.Cancel();
+        _cts?.Dispose();
+        _cts = new CancellationTokenSource();
+        var token = _cts.Token;
+
+        _loading = true;
+        Model = null;
+        StateHasChanged();
+
+        try
+        {
+            var loaded = await _ais.GetVolumeBySourceAsync(Context, Range, token).ToArrayAsync(token);
+            if (token.IsCancellationRequested) return;
+
+            Model = loaded;
+            _totalMb = loaded.Sum(x => x.Mb);
+        }
+        catch (OperationCanceledException) when (token.IsCancellationRequested)
+        {
+        }
+        finally
+        {
+            if (!token.IsCancellationRequested)
+            {
+                _loading = false;
+                StateHasChanged();
+            }
+        }
+    }
+}

--- a/Quilt4Net.Toolkit.Blazor/Features/Metrics/MetricChart.razor
+++ b/Quilt4Net.Toolkit.Blazor/Features/Metrics/MetricChart.razor
@@ -38,7 +38,7 @@
             {
                 <RadzenLineSeries Data="@points" CategoryProperty="@nameof(MetricSample.Timestamp)" ValueProperty="@nameof(MetricSample.Value)" Title="@label" Smooth="true" />
             }
-            <RadzenCategoryAxis FormatString="{0:HH:mm}" />
+            <RadzenCategoryAxis FormatString="@_categoryFormat" />
             @if (LogScale)
             {
                 @* Values were transformed to log10 in OnParametersSet; the axis lives in log
@@ -97,6 +97,9 @@
     [Parameter] public double LogScaleEpsilon { get; set; } = 0.001;
 
     private IReadOnlyList<(string Label, MetricSample[] Points)> _series = [];
+    // Category-axis date/time format, chosen from the data's span: a 7-day window needs dates
+    // (HH:mm alone repeats every midnight and is unreadable), a single day needs the time.
+    private string _categoryFormat = "{0:HH:mm}";
     private IBrowserTimeZoneAccessor _browserTime; // optional — null when no host wires it up
     private string _chartKey = "linear-fullpct"; // recomputed in OnParametersSet; gates RadzenChart's @key
     private RadzenChart _chart; // captured via @ref so OnAfterRenderAsync can call Reload() on axis flips
@@ -126,6 +129,24 @@
         // transform values to log10 space — RadzenChart's value axis is linear, so we trade one
         // round-trip through the values (log10 here, 10^x in the axis Formatter) for log-scale
         // plotting without depending on the chart library to support it natively.
+        // Pick the axis label format from how much wall-clock the data covers: multi-day windows
+        // show a date (otherwise every midnight reads identically), a day or less shows the time.
+        var samples = Samples ?? [];
+        if (samples.Length > 0)
+        {
+            var min = samples[0].Timestamp;
+            var max = samples[0].Timestamp;
+            foreach (var s in samples)
+            {
+                if (s.Timestamp < min) min = s.Timestamp;
+                if (s.Timestamp > max) max = s.Timestamp;
+            }
+            var span = max - min;
+            _categoryFormat = span > System.TimeSpan.FromDays(3) ? "{0:MMM dd}"
+                : span > System.TimeSpan.FromDays(1) ? "{0:ddd HH:mm}"
+                : "{0:HH:mm}";
+        }
+
         var tz = _browserTime?.Current ?? System.TimeZoneInfo.Local;
         _series = (Samples ?? [])
             .GroupBy(s => s.Series ?? "")

--- a/Quilt4Net.Toolkit.Blazor/Features/Metrics/MetricsSeriesCache.cs
+++ b/Quilt4Net.Toolkit.Blazor/Features/Metrics/MetricsSeriesCache.cs
@@ -4,11 +4,13 @@ using Quilt4Net.Toolkit.Features.ApplicationInsights;
 namespace Quilt4Net.Toolkit.Blazor.Features.Metrics;
 
 /// <summary>
-/// Circuit-scoped store for <see cref="MetricsView"/>'s four series (CPU / memory / disk / network)
-/// plus the timestamp they were loaded at. Lets navigating away from /monitor/metrics and back
-/// render the charts immediately without re-running four KQL queries, and keeps the refresh-button
-/// "Data loaded at …" tooltip honest across navigations. Same lifecycle as <c>LogCountCellCache</c>:
-/// scoped (per-circuit), TTL applied on read, force-evicted by the Refresh button.
+/// Circuit-scoped store for <see cref="MetricsView"/>'s host series (CPU / memory / disk) and the
+/// cluster node series (node CPU / memory / filesystem), plus the timestamp they were loaded at.
+/// Lets navigating away from /monitor/metrics and back render the charts immediately without
+/// re-running the KQL queries, and keeps the refresh-button "Data loaded at …" tooltip honest
+/// across navigations. Same lifecycle as <c>LogCountCellCache</c>: scoped (per-circuit), TTL
+/// applied on read, force-evicted by the Refresh button. Pod drill-down series are loaded
+/// on demand per node and are not cached here.
 /// </summary>
 internal sealed class MetricsSeriesCache
 {
@@ -28,10 +30,10 @@ internal sealed class MetricsSeriesCache
     }
 
     public void Set(string configKey, System.TimeSpan range,
-        MetricSample[] cpu, MetricSample[] memory, MetricSample[] disk, MetricSample[] network,
-        DiskCapacity[] diskCapacity,
+        MetricSample[] cpu, MetricSample[] memory, MetricSample[] disk, DiskCapacity[] diskCapacity,
+        MetricSample[] nodeCpu, MetricSample[] nodeMemory, MetricSample[] nodeFilesystem,
         System.DateTime loadedUtc)
-        => _entries[(configKey, range)] = new CacheEntry(cpu, memory, disk, network, diskCapacity, loadedUtc);
+        => _entries[(configKey, range)] = new CacheEntry(cpu, memory, disk, diskCapacity, nodeCpu, nodeMemory, nodeFilesystem, loadedUtc);
 
     public void Invalidate(string configKey, System.TimeSpan range)
         => _entries.Remove((configKey, range));
@@ -45,7 +47,9 @@ internal sealed class MetricsSeriesCache
         MetricSample[] Cpu,
         MetricSample[] Memory,
         MetricSample[] Disk,
-        MetricSample[] Network,
         DiskCapacity[] DiskCapacity,
+        MetricSample[] NodeCpu,
+        MetricSample[] NodeMemory,
+        MetricSample[] NodeFilesystem,
         System.DateTime LoadedUtc);
 }

--- a/Quilt4Net.Toolkit.Blazor/Features/Metrics/MetricsView.razor
+++ b/Quilt4Net.Toolkit.Blazor/Features/Metrics/MetricsView.razor
@@ -62,52 +62,76 @@
         </RadzenAlert>
     }
 
-    <RadzenText TextStyle="TextStyle.H6" Text="Hosts" Style="margin: 0;" />
-    <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(420px, 1fr)); gap: 1rem;">
-        <MetricChart Title="CPU %" Unit="%" Samples="@_cpu" Loading="@_busy" FullPercentScale="@_fullPercentScale" />
-        <MetricChart Title="Memory %" Unit="%" Samples="@_memory" Loading="@_busy" FullPercentScale="@_fullPercentScale" />
-        @* Disk used uses a bar-per-host snapshot — over a 1h/24h/7d window the value barely
-           moves so a line chart degenerates into N flat lines. The bar fills as the volume fills
-           up (longer = more used), and the chart's LessIsBad=false threshold logic turns the bar
-           amber over 80% and red over 90% of capacity. The delta badge (▲ +1.2 GB / 24h) signals
-           growth with a utilisation-is-bad colour scheme; the inline sparkline keeps the shape
-           visible for cases where a sudden spike matters. *@
-        <MetricLatestChart Title="Disk used (GB)" Unit="GB" Samples="@_disk" Capacity="@_diskCapacity" Range="@_window" Loading="@_busy" LessIsBad="false" />
-    </div>
-
-    @* Cluster section — Kubernetes node metrics (kubeletstats). Only shown when the workspace
-       actually has node telemetry, so non-cluster consumers don't see an empty section. CPU is
-       absolute cores (no node CPU-capacity metric to percentage against); memory and filesystem
-       are % of node total. *@
-    @if (_busy || _nodes.Length > 0)
-    {
-        <RadzenText TextStyle="TextStyle.H6" Text="Cluster nodes" Style="margin: 0.5rem 0 0 0;" />
-        <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(420px, 1fr)); gap: 1rem;">
-            <MetricChart Title="Node CPU (cores)" Unit="cores" Samples="@_nodeCpu" Loading="@_busy" FullPercentScale="false" />
-            <MetricChart Title="Node memory %" Unit="%" Samples="@_nodeMemory" Loading="@_busy" FullPercentScale="@_fullPercentScale" />
-            <MetricChart Title="Node filesystem %" Unit="%" Samples="@_nodeFilesystem" Loading="@_busy" FullPercentScale="@_fullPercentScale" />
-        </div>
-
-        @* Node→pod drill-down: pick a node to load the pods scheduled on it. Pod series are
-           fetched on demand (not part of the scoped cache) since they're a detail view. *@
-        @if (_nodes.Length > 0)
-        {
-            <RadzenStack Orientation="Orientation.Vertical" Gap="0" Style="margin-top: 0.5rem;">
-                <RadzenText TextStyle="TextStyle.Caption" Text="Drill into node (pods)" />
-                <RadzenDropDown Data="@_nodes" @bind-Value="_selectedNode" TValue="string"
-                                AllowClear="true" Placeholder="Select a node…"
-                                Change="@(_ => LoadPodsAsync())" Style="max-width: 320px;" />
-            </RadzenStack>
-
-            @if (!string.IsNullOrEmpty(_selectedNode))
-            {
+    @* Physical machines (hostmetrics) and the Kubernetes cluster (kubeletstats) live on separate
+       tabs. The Cluster tab only appears when the workspace actually has node telemetry, so
+       non-cluster consumers just see the Physical machines tab. *@
+    <RadzenTabs>
+        <Tabs>
+            <RadzenTabsItem Text="Physical machines">
                 <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(420px, 1fr)); gap: 1rem;">
-                    <MetricChart Title="@($"Pods on {_selectedNode} — CPU (cores)")" Unit="cores" Samples="@_podCpu" Loading="@_podBusy" FullPercentScale="false" />
-                    <MetricChart Title="@($"Pods on {_selectedNode} — memory (MB)")" Unit="MB" Samples="@_podMemory" Loading="@_podBusy" FullPercentScale="false" />
+                    <MetricChart Title="CPU %" Unit="%" Samples="@_cpu" Loading="@_busy" FullPercentScale="@_fullPercentScale" />
+                    <MetricChart Title="Memory %" Unit="%" Samples="@_memory" Loading="@_busy" FullPercentScale="@_fullPercentScale" />
+                    @* Disk used uses a bar-per-host snapshot — over a 1h/24h/7d window the value barely
+                       moves so a line chart degenerates into N flat lines. The bar fills as the volume fills
+                       up (longer = more used), and the chart's LessIsBad=false threshold logic turns the bar
+                       amber over 80% and red over 90% of capacity. The delta badge (▲ +1.2 GB / 24h) signals
+                       growth with a utilisation-is-bad colour scheme; the inline sparkline keeps the shape
+                       visible for cases where a sudden spike matters. *@
+                    <MetricLatestChart Title="Disk used (GB)" Unit="GB" Samples="@_disk" Capacity="@_diskCapacity" Range="@_window" Loading="@_busy" LessIsBad="false" />
                 </div>
+            </RadzenTabsItem>
+
+            @if (_nodes.Length > 0)
+            {
+                <RadzenTabsItem Text="Cluster">
+                    <RadzenStack Orientation="Orientation.Vertical" Gap="1rem">
+                        @* Whole-cluster total toggle: off = per-node lines; on = one capacity-weighted
+                           line per metric aggregated across all nodes. Aggregates are fetched lazily. *@
+                        <RadzenStack Orientation="Orientation.Horizontal" AlignItems="AlignItems.Center" Gap="0.4rem">
+                            <RadzenSwitch @bind-Value="_clusterAggregate" TValue="bool" Name="clusterAggregate" Change="@(_ => OnAggregateToggledAsync())" />
+                            <RadzenLabel Component="clusterAggregate" Text="Whole-cluster total" />
+                        </RadzenStack>
+
+                        @if (_clusterAggregate)
+                        {
+                            @* Capacity-weighted totals across every node. CPU is cores (no node
+                               CPU-capacity metric yet — enable k8s.node.allocatable_cpu for a %). *@
+                            <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(420px, 1fr)); gap: 1rem;">
+                                <MetricChart Title="Cluster CPU (cores)" Unit="cores" Samples="@_aggCpu" Loading="@(_busy || _aggBusy)" FullPercentScale="false" />
+                                <MetricChart Title="Cluster memory %" Unit="%" Samples="@_aggMemory" Loading="@(_busy || _aggBusy)" FullPercentScale="@_fullPercentScale" />
+                                <MetricChart Title="Cluster filesystem %" Unit="%" Samples="@_aggFilesystem" Loading="@(_busy || _aggBusy)" FullPercentScale="@_fullPercentScale" />
+                            </div>
+                        }
+                        else
+                        {
+                            <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(420px, 1fr)); gap: 1rem;">
+                                <MetricChart Title="Node CPU (cores)" Unit="cores" Samples="@_nodeCpu" Loading="@_busy" FullPercentScale="false" />
+                                <MetricChart Title="Node memory %" Unit="%" Samples="@_nodeMemory" Loading="@_busy" FullPercentScale="@_fullPercentScale" />
+                                <MetricChart Title="Node filesystem %" Unit="%" Samples="@_nodeFilesystem" Loading="@_busy" FullPercentScale="@_fullPercentScale" />
+                            </div>
+
+                            @* Node→pod drill-down: pick a node to load the pods scheduled on it. Pod
+                               series are fetched on demand (not part of the scoped cache). *@
+                            <RadzenStack Orientation="Orientation.Vertical" Gap="0" Style="margin-top: 0.5rem;">
+                                <RadzenText TextStyle="TextStyle.Caption" Text="Drill into node (pods)" />
+                                <RadzenDropDown Data="@_nodes" @bind-Value="_selectedNode" TValue="string"
+                                                AllowClear="true" Placeholder="Select a node…"
+                                                Change="@(_ => LoadPodsAsync())" Style="max-width: 320px;" />
+                            </RadzenStack>
+
+                            @if (!string.IsNullOrEmpty(_selectedNode))
+                            {
+                                <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(420px, 1fr)); gap: 1rem;">
+                                    <MetricChart Title="@($"Pods on {_selectedNode} — CPU (cores)")" Unit="cores" Samples="@_podCpu" Loading="@_podBusy" FullPercentScale="false" />
+                                    <MetricChart Title="@($"Pods on {_selectedNode} — memory (MB)")" Unit="MB" Samples="@_podMemory" Loading="@_podBusy" FullPercentScale="false" />
+                                </div>
+                            }
+                        }
+                    </RadzenStack>
+                </RadzenTabsItem>
             }
-        }
-    }
+        </Tabs>
+    </RadzenTabs>
 </RadzenStack>
 
 @code {
@@ -135,6 +159,15 @@
     private MetricSample[] _podCpu = [];
     private MetricSample[] _podMemory = [];
     private bool _podBusy;
+
+    // Whole-cluster aggregate toggle + lazily-loaded total series (one "Cluster" line each).
+    // Not in the scoped cache — fetched on demand per window and refreshed on range/refresh.
+    private bool _clusterAggregate;
+    private MetricSample[] _aggCpu = [];
+    private MetricSample[] _aggMemory = [];
+    private MetricSample[] _aggFilesystem = [];
+    private bool _aggBusy;
+    private System.TimeSpan? _aggLoadedWindow;
 
     private IApplicationInsightsConfigurationSelector _selector;
     private ApplicationInsightsConfigurationResponse _selectedConfig;
@@ -224,6 +257,8 @@
             _loadError = null;
             _busy = false;
             StateHasChanged();
+            // Aggregates aren't cached — refresh them for this window if the toggle is on.
+            await RefreshAggregatesForWindowAsync();
             return;
         }
 
@@ -270,6 +305,8 @@
             {
                 await LoadPodsAsync();
             }
+            // Aggregates are window-specific and not cached — refresh if the toggle is on.
+            await RefreshAggregatesForWindowAsync();
             // Stamp the load completion. Only on success — a failed load shouldn't claim freshness.
             var loadedUtc = System.DateTime.UtcNow;
             _lastRefreshUtc = loadedUtc;
@@ -342,6 +379,66 @@
         finally
         {
             _podBusy = false;
+            StateHasChanged();
+        }
+    }
+
+    /// <summary>
+    /// Fired when the "Whole-cluster total" switch flips. Loads the aggregate series on first
+    /// enable for the current window (cheap no-op if already loaded for this window).
+    /// </summary>
+    private async Task OnAggregateToggledAsync()
+    {
+        if (_clusterAggregate && _aggLoadedWindow != _window)
+        {
+            await LoadAggregateAsync();
+        }
+        StateHasChanged();
+    }
+
+    /// <summary>
+    /// Reset and (if the toggle is on) reload the cluster aggregate series for the current window.
+    /// Called on range change / refresh / cache-hit so the totals never show a stale window.
+    /// </summary>
+    private async Task RefreshAggregatesForWindowAsync()
+    {
+        _aggLoadedWindow = null;
+        _aggCpu = [];
+        _aggMemory = [];
+        _aggFilesystem = [];
+        if (_clusterAggregate)
+        {
+            await LoadAggregateAsync();
+        }
+    }
+
+    /// <summary>
+    /// Load the three whole-cluster total series (CPU cores, memory %, filesystem %) for the
+    /// current window. Errors surface in the shared banner; charts stay empty.
+    /// </summary>
+    private async Task LoadAggregateAsync()
+    {
+        var ctx = EffectiveContext;
+        if (ctx == null) return;
+
+        _aggBusy = true;
+        StateHasChanged();
+        try
+        {
+            _aggCpu = await Ai.GetClusterTotalCpuAsync(ctx, _window).ToArrayAsync();
+            StateHasChanged();
+            _aggMemory = await Ai.GetClusterTotalMemoryAsync(ctx, _window).ToArrayAsync();
+            StateHasChanged();
+            _aggFilesystem = await Ai.GetClusterTotalFilesystemAsync(ctx, _window).ToArrayAsync();
+            _aggLoadedWindow = _window;
+        }
+        catch (System.Exception e)
+        {
+            _loadError = e.Message;
+        }
+        finally
+        {
+            _aggBusy = false;
             StateHasChanged();
         }
     }

--- a/Quilt4Net.Toolkit.Blazor/Features/Metrics/MetricsView.razor
+++ b/Quilt4Net.Toolkit.Blazor/Features/Metrics/MetricsView.razor
@@ -62,6 +62,7 @@
         </RadzenAlert>
     }
 
+    <RadzenText TextStyle="TextStyle.H6" Text="Hosts" Style="margin: 0;" />
     <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(420px, 1fr)); gap: 1rem;">
         <MetricChart Title="CPU %" Unit="%" Samples="@_cpu" Loading="@_busy" FullPercentScale="@_fullPercentScale" />
         <MetricChart Title="Memory %" Unit="%" Samples="@_memory" Loading="@_busy" FullPercentScale="@_fullPercentScale" />
@@ -72,12 +73,41 @@
            growth with a utilisation-is-bad colour scheme; the inline sparkline keeps the shape
            visible for cases where a sudden spike matters. *@
         <MetricLatestChart Title="Disk used (GB)" Unit="GB" Samples="@_disk" Capacity="@_diskCapacity" Range="@_window" Loading="@_busy" LessIsBad="false" />
-        @* Network values commonly span 3-4 orders of magnitude across hosts — idle web boxes sit
-           at ~0.01 MB/s while a single backup job spikes to 50+ MB/s. On a linear axis the idle
-           hosts vanish into a flat line at the bottom; log scale gives each host's shape its own
-           visible band. Ticks reverse-format back to MB/s so the axis still reads naturally. *@
-        <MetricChart Title="Network (MB/s)" Unit="MB/s" Samples="@_network" Loading="@_busy" LogScale="true" />
     </div>
+
+    @* Cluster section — Kubernetes node metrics (kubeletstats). Only shown when the workspace
+       actually has node telemetry, so non-cluster consumers don't see an empty section. CPU is
+       absolute cores (no node CPU-capacity metric to percentage against); memory and filesystem
+       are % of node total. *@
+    @if (_busy || _nodes.Length > 0)
+    {
+        <RadzenText TextStyle="TextStyle.H6" Text="Cluster nodes" Style="margin: 0.5rem 0 0 0;" />
+        <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(420px, 1fr)); gap: 1rem;">
+            <MetricChart Title="Node CPU (cores)" Unit="cores" Samples="@_nodeCpu" Loading="@_busy" FullPercentScale="false" />
+            <MetricChart Title="Node memory %" Unit="%" Samples="@_nodeMemory" Loading="@_busy" FullPercentScale="@_fullPercentScale" />
+            <MetricChart Title="Node filesystem %" Unit="%" Samples="@_nodeFilesystem" Loading="@_busy" FullPercentScale="@_fullPercentScale" />
+        </div>
+
+        @* Node→pod drill-down: pick a node to load the pods scheduled on it. Pod series are
+           fetched on demand (not part of the scoped cache) since they're a detail view. *@
+        @if (_nodes.Length > 0)
+        {
+            <RadzenStack Orientation="Orientation.Vertical" Gap="0" Style="margin-top: 0.5rem;">
+                <RadzenText TextStyle="TextStyle.Caption" Text="Drill into node (pods)" />
+                <RadzenDropDown Data="@_nodes" @bind-Value="_selectedNode" TValue="string"
+                                AllowClear="true" Placeholder="Select a node…"
+                                Change="@(_ => LoadPodsAsync())" Style="max-width: 320px;" />
+            </RadzenStack>
+
+            @if (!string.IsNullOrEmpty(_selectedNode))
+            {
+                <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(420px, 1fr)); gap: 1rem;">
+                    <MetricChart Title="@($"Pods on {_selectedNode} — CPU (cores)")" Unit="cores" Samples="@_podCpu" Loading="@_podBusy" FullPercentScale="false" />
+                    <MetricChart Title="@($"Pods on {_selectedNode} — memory (MB)")" Unit="MB" Samples="@_podMemory" Loading="@_podBusy" FullPercentScale="false" />
+                </div>
+            }
+        }
+    }
 </RadzenStack>
 
 @code {
@@ -94,8 +124,17 @@
     private MetricSample[] _cpu = [];
     private MetricSample[] _memory = [];
     private MetricSample[] _disk = [];
-    private MetricSample[] _network = [];
     private DiskCapacity[] _diskCapacity = [];
+
+    // Cluster node series + node→pod drill-down state.
+    private MetricSample[] _nodeCpu = [];
+    private MetricSample[] _nodeMemory = [];
+    private MetricSample[] _nodeFilesystem = [];
+    private string[] _nodes = [];
+    private string _selectedNode;
+    private MetricSample[] _podCpu = [];
+    private MetricSample[] _podMemory = [];
+    private bool _podBusy;
 
     private IApplicationInsightsConfigurationSelector _selector;
     private ApplicationInsightsConfigurationResponse _selectedConfig;
@@ -176,8 +215,11 @@
             _cpu = entry.Cpu;
             _memory = entry.Memory;
             _disk = entry.Disk;
-            _network = entry.Network;
             _diskCapacity = entry.DiskCapacity;
+            _nodeCpu = entry.NodeCpu;
+            _nodeMemory = entry.NodeMemory;
+            _nodeFilesystem = entry.NodeFilesystem;
+            _nodes = NodeNames(_nodeCpu);
             _lastRefreshUtc = entry.LoadedUtc;
             _loadError = null;
             _busy = false;
@@ -207,11 +249,31 @@
             // capacity-join the second time.
             _disk = ToDiskUsed(freeSamples, _diskCapacity);
             StateHasChanged();
-            _network = await Ai.GetNetworkThroughputAsync(ctx, _window).ToArrayAsync();
+            // Cluster node series (kubeletstats). Empty on non-cluster workspaces — the Cluster
+            // section then collapses to nothing.
+            _nodeCpu = await Ai.GetClusterNodeCpuAsync(ctx, _window).ToArrayAsync();
+            _nodes = NodeNames(_nodeCpu);
+            StateHasChanged();
+            _nodeMemory = await Ai.GetClusterNodeMemoryAsync(ctx, _window).ToArrayAsync();
+            StateHasChanged();
+            _nodeFilesystem = await Ai.GetClusterNodeFilesystemAsync(ctx, _window).ToArrayAsync();
+            StateHasChanged();
+            // A previously-selected node may no longer exist after a reload — drop the drill-down
+            // if so, otherwise refresh its pods for the new window.
+            if (!string.IsNullOrEmpty(_selectedNode) && !_nodes.Contains(_selectedNode))
+            {
+                _selectedNode = null;
+                _podCpu = [];
+                _podMemory = [];
+            }
+            else if (!string.IsNullOrEmpty(_selectedNode))
+            {
+                await LoadPodsAsync();
+            }
             // Stamp the load completion. Only on success — a failed load shouldn't claim freshness.
             var loadedUtc = System.DateTime.UtcNow;
             _lastRefreshUtc = loadedUtc;
-            _scopedCache?.Set(key, _window, _cpu, _memory, _disk, _network, _diskCapacity, loadedUtc);
+            _scopedCache?.Set(key, _window, _cpu, _memory, _disk, _diskCapacity, _nodeCpu, _nodeMemory, _nodeFilesystem, loadedUtc);
         }
         catch (System.Exception e)
         {
@@ -243,6 +305,45 @@
     public void Dispose()
     {
         if (_selector != null) _selector.OnChanged -= OnSelectorChanged;
+    }
+
+    /// <summary>Distinct node names (sorted) from a node series, for the drill-down dropdown.</summary>
+    private static string[] NodeNames(MetricSample[] nodeSamples)
+        => MetricsViewLogic.NodeNames(nodeSamples);
+
+    /// <summary>
+    /// Load the pod CPU/memory series for the currently selected node. Cleared and skipped when
+    /// no node is selected (the AllowClear dropdown sets it to null). Errors surface in the same
+    /// banner as the main load; pod charts just stay empty.
+    /// </summary>
+    private async Task LoadPodsAsync()
+    {
+        var ctx = EffectiveContext;
+        if (ctx == null || string.IsNullOrEmpty(_selectedNode))
+        {
+            _podCpu = [];
+            _podMemory = [];
+            StateHasChanged();
+            return;
+        }
+
+        _podBusy = true;
+        StateHasChanged();
+        try
+        {
+            _podCpu = await Ai.GetClusterPodCpuAsync(ctx, _selectedNode, _window).ToArrayAsync();
+            StateHasChanged();
+            _podMemory = await Ai.GetClusterPodMemoryAsync(ctx, _selectedNode, _window).ToArrayAsync();
+        }
+        catch (System.Exception e)
+        {
+            _loadError = e.Message;
+        }
+        finally
+        {
+            _podBusy = false;
+            StateHasChanged();
+        }
     }
 
     /// <summary>

--- a/Quilt4Net.Toolkit.Blazor/Features/Metrics/MetricsView.razor
+++ b/Quilt4Net.Toolkit.Blazor/Features/Metrics/MetricsView.razor
@@ -252,7 +252,7 @@
             _nodeCpu = entry.NodeCpu;
             _nodeMemory = entry.NodeMemory;
             _nodeFilesystem = entry.NodeFilesystem;
-            _nodes = NodeNames(_nodeCpu);
+            _nodes = NodeNames(_nodeCpu, _nodeMemory, _nodeFilesystem);
             _lastRefreshUtc = entry.LoadedUtc;
             _loadError = null;
             _busy = false;
@@ -285,13 +285,17 @@
             _disk = ToDiskUsed(freeSamples, _diskCapacity);
             StateHasChanged();
             // Cluster node series (kubeletstats). Empty on non-cluster workspaces — the Cluster
-            // section then collapses to nothing.
+            // tab then doesn't appear. The node list is the UNION across series: CPU% only has
+            // rows where allocatable overlaps the window, but memory/filesystem are always present,
+            // so the tab stays visible even when CPU% is momentarily empty.
             _nodeCpu = await Ai.GetClusterNodeCpuAsync(ctx, _window).ToArrayAsync();
             _nodes = NodeNames(_nodeCpu);
             StateHasChanged();
             _nodeMemory = await Ai.GetClusterNodeMemoryAsync(ctx, _window).ToArrayAsync();
+            _nodes = NodeNames(_nodeCpu, _nodeMemory);
             StateHasChanged();
             _nodeFilesystem = await Ai.GetClusterNodeFilesystemAsync(ctx, _window).ToArrayAsync();
+            _nodes = NodeNames(_nodeCpu, _nodeMemory, _nodeFilesystem);
             StateHasChanged();
             // A previously-selected node may no longer exist after a reload — drop the drill-down
             // if so, otherwise refresh its pods for the new window.
@@ -344,9 +348,10 @@
         if (_selector != null) _selector.OnChanged -= OnSelectorChanged;
     }
 
-    /// <summary>Distinct node names (sorted) from a node series, for the drill-down dropdown.</summary>
-    private static string[] NodeNames(MetricSample[] nodeSamples)
-        => MetricsViewLogic.NodeNames(nodeSamples);
+    /// <summary>Distinct node names (sorted) across the node series — union, so a node shows even
+    /// when its CPU% series is empty (allocatable not yet in the window).</summary>
+    private static string[] NodeNames(params MetricSample[][] sets)
+        => MetricsViewLogic.NodeNames(sets);
 
     /// <summary>
     /// Load the pod CPU/memory series for the currently selected node. Cleared and skipped when

--- a/Quilt4Net.Toolkit.Blazor/Features/Metrics/MetricsView.razor
+++ b/Quilt4Net.Toolkit.Blazor/Features/Metrics/MetricsView.razor
@@ -97,7 +97,7 @@
                             @* Capacity-weighted totals across every node. CPU is cores (no node
                                CPU-capacity metric yet — enable k8s.node.allocatable_cpu for a %). *@
                             <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(420px, 1fr)); gap: 1rem;">
-                                <MetricChart Title="Cluster CPU (cores)" Unit="cores" Samples="@_aggCpu" Loading="@(_busy || _aggBusy)" FullPercentScale="false" />
+                                <MetricChart Title="Cluster CPU %" Unit="%" Samples="@_aggCpu" Loading="@(_busy || _aggBusy)" FullPercentScale="@_fullPercentScale" />
                                 <MetricChart Title="Cluster memory %" Unit="%" Samples="@_aggMemory" Loading="@(_busy || _aggBusy)" FullPercentScale="@_fullPercentScale" />
                                 <MetricChart Title="Cluster filesystem %" Unit="%" Samples="@_aggFilesystem" Loading="@(_busy || _aggBusy)" FullPercentScale="@_fullPercentScale" />
                             </div>
@@ -105,7 +105,7 @@
                         else
                         {
                             <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(420px, 1fr)); gap: 1rem;">
-                                <MetricChart Title="Node CPU (cores)" Unit="cores" Samples="@_nodeCpu" Loading="@_busy" FullPercentScale="false" />
+                                <MetricChart Title="Node CPU %" Unit="%" Samples="@_nodeCpu" Loading="@_busy" FullPercentScale="@_fullPercentScale" />
                                 <MetricChart Title="Node memory %" Unit="%" Samples="@_nodeMemory" Loading="@_busy" FullPercentScale="@_fullPercentScale" />
                                 <MetricChart Title="Node filesystem %" Unit="%" Samples="@_nodeFilesystem" Loading="@_busy" FullPercentScale="@_fullPercentScale" />
                             </div>

--- a/Quilt4Net.Toolkit.Blazor/Features/Metrics/MetricsViewLogic.cs
+++ b/Quilt4Net.Toolkit.Blazor/Features/Metrics/MetricsViewLogic.cs
@@ -22,4 +22,19 @@ internal static class MetricsViewLogic
             .Distinct(StringComparer.OrdinalIgnoreCase)
             .OrderBy(s => s, StringComparer.OrdinalIgnoreCase)
             .ToArray();
+
+    /// <summary>
+    /// Distinct node names across several node series (union). Used so the cluster tab / drill-down
+    /// list reflects every node seen in any chart — important because the CPU% series only has rows
+    /// where <c>allocatable_cpu</c> overlaps the window, while memory/filesystem are always present.
+    /// </summary>
+    public static string[] NodeNames(params MetricSample[][] sets)
+        => (sets ?? [])
+            .Where(s => s != null)
+            .SelectMany(s => s)
+            .Select(s => s.Series ?? "")
+            .Where(s => !string.IsNullOrWhiteSpace(s))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .OrderBy(s => s, StringComparer.OrdinalIgnoreCase)
+            .ToArray();
 }

--- a/Quilt4Net.Toolkit.Blazor/Features/Metrics/MetricsViewLogic.cs
+++ b/Quilt4Net.Toolkit.Blazor/Features/Metrics/MetricsViewLogic.cs
@@ -1,0 +1,25 @@
+using System;
+using System.Linq;
+using Quilt4Net.Toolkit.Features.ApplicationInsights;
+
+namespace Quilt4Net.Toolkit.Blazor.Features.Metrics;
+
+/// <summary>
+/// Pure helpers for <see cref="MetricsView"/> — extracted so the node→pod drill-down logic can be
+/// unit-tested without rendering the Radzen charts (which need a real browser for layout).
+/// </summary>
+internal static class MetricsViewLogic
+{
+    /// <summary>
+    /// Distinct, case-insensitively sorted node names from a cluster-node metric series, used to
+    /// populate the drill-down dropdown. Empty/whitespace series are dropped (a sample with no
+    /// <c>k8s.node.name</c> shouldn't appear as a selectable node).
+    /// </summary>
+    public static string[] NodeNames(MetricSample[] nodeSamples)
+        => (nodeSamples ?? [])
+            .Select(s => s.Series ?? "")
+            .Where(s => !string.IsNullOrWhiteSpace(s))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .OrderBy(s => s, StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+}

--- a/Quilt4Net.Toolkit.Blazor/README.md
+++ b/Quilt4Net.Toolkit.Blazor/README.md
@@ -831,14 +831,15 @@ host identity are excluded so unattributed node hostmetrics don't merge into bla
 
 | Chart | Source | Unit |
 |-------|--------|------|
-| Node CPU | `k8s.node.cpu.usage` | cores (absolute — there is no node CPU-capacity metric to form a %) |
+| Node CPU % | `100 × k8s.node.cpu.usage / k8s.node.allocatable_cpu` | % |
 | Node memory % | `k8s.node.memory.usage / (usage + available)` | % |
 | Node filesystem % | `k8s.node.filesystem.usage / capacity` | % |
 
 **Whole-cluster total toggle** — a switch on the Cluster tab swaps the per-node lines for a
 single **capacity-weighted total** line per metric, aggregated across all nodes (a 12-core node
-contributes more than a 2-core one): CPU = `Σ usage` (cores), memory = `100 × Σ usage / Σ (usage + available)`,
-filesystem = `100 × Σ usage / Σ capacity`. Totals are fetched on demand when the toggle is on.
+contributes more than a 2-core one): CPU = `100 × Σ usage / Σ allocatable_cpu`, memory =
+`100 × Σ usage / Σ (usage + available)`, filesystem = `100 × Σ usage / Σ capacity`. Totals are
+fetched on demand when the toggle is on.
 
 **Node → pod drill-down** — in per-node mode, pick a node from the dropdown to load the pods
 scheduled on it (`k8s.pod.cpu.usage` in cores and `k8s.pod.memory.usage` in MB, labelled

--- a/Quilt4Net.Toolkit.Blazor/README.md
+++ b/Quilt4Net.Toolkit.Blazor/README.md
@@ -814,9 +814,12 @@ cluster) exporting OTel `system.*` / `k8s.*` semantic-convention metrics into yo
 
 It uses the same Application Insights client and configuration selector as `LogView` (local or
 remote mode — see [Log viewer](#log-viewer)), and a circuit-scoped cache so navigating away and
-back is instant. A range selector (1h / 24h / 7d) and a Refresh button sit at the top.
+back is instant. A range selector (1h / 24h / 7d) and a Refresh button sit at the top, and the
+charts are split across two tabs: **Physical machines** and **Cluster** (the Cluster tab appears
+only when the workspace has Kubernetes node telemetry).
 
-**Hosts** (per machine, from `system.*`, grouped by `host.name`):
+**Physical machines** tab (per machine, from `system.*`, grouped by `host.name` — rows with no
+host identity are excluded so unattributed node hostmetrics don't merge into blank series):
 
 | Chart | Source |
 |-------|--------|
@@ -824,8 +827,7 @@ back is instant. A range selector (1h / 24h / 7d) and a Refresh button sit at th
 | Memory % | `system.memory.utilization` |
 | Disk used (GB) | `system.filesystem.usage` (per host + volume, with capacity bars) |
 
-**Cluster nodes** — shown only when the workspace has Kubernetes telemetry (otherwise the
-section collapses), one line per node (`k8s.node.name`):
+**Cluster** tab — one line per node (`k8s.node.name`):
 
 | Chart | Source | Unit |
 |-------|--------|------|
@@ -833,8 +835,13 @@ section collapses), one line per node (`k8s.node.name`):
 | Node memory % | `k8s.node.memory.usage / (usage + available)` | % |
 | Node filesystem % | `k8s.node.filesystem.usage / capacity` | % |
 
-**Node → pod drill-down** — pick a node from the dropdown to load the pods scheduled on it
-(`k8s.pod.cpu.usage` in cores and `k8s.pod.memory.usage` in MB, labelled
+**Whole-cluster total toggle** — a switch on the Cluster tab swaps the per-node lines for a
+single **capacity-weighted total** line per metric, aggregated across all nodes (a 12-core node
+contributes more than a 2-core one): CPU = `Σ usage` (cores), memory = `100 × Σ usage / Σ (usage + available)`,
+filesystem = `100 × Σ usage / Σ capacity`. Totals are fetched on demand when the toggle is on.
+
+**Node → pod drill-down** — in per-node mode, pick a node from the dropdown to load the pods
+scheduled on it (`k8s.pod.cpu.usage` in cores and `k8s.pod.memory.usage` in MB, labelled
 `{namespace}/{pod}`). Pod series are fetched on demand and are not cached.
 
 > Network throughput and swap/paging are intentionally not charted. Per-host load average

--- a/Quilt4Net.Toolkit.Blazor/README.md
+++ b/Quilt4Net.Toolkit.Blazor/README.md
@@ -780,6 +780,19 @@ protected override async Task OnInitializedAsync()
 }
 ```
 
+### Cost & volume
+
+Two components turn the workspace into a cost picture using billing-grade data from the `Usage` table (no sampled-telemetry estimates), so figures reconcile with the Azure bill:
+
+```razor
+@using Quilt4Net.Toolkit.Blazor.Features.Log
+
+<LogVolumeView Range="TimeSpan.FromDays(7)" />   @* pie of billed volume by source table + size table; 1h/24h/7d selector *@
+<CapTimelineView Days="30" />                     @* billed GB/day vs the daily cap, first-hit times, est. uncapped; 14/30/90d selector *@
+```
+
+`LogCountByServiceView` also gains a **Show: Count / Volume** toggle (record count ↔ billed volume, a local recompute), two marginal pies (by severity / by service), and a **Sampling** section that reports retained vs sampling-corrected (`sum(ItemCount)`) figures and the effective sampling rate per source — stating plainly when sampling is not in effect. On Quilt4Net Server these surface as the **Logging volume** and **Daily cap** tabs on `/monitor/metrics` and `/developer/metrics`. Full reference: [Log views → Cost & volume](https://quilt4net.com/articles/log-views.html).
+
 ## Version matrix
 
 `VersionMatrixDisplay` shows the latest version of each application per environment, scanned from Application Insights. It uses the same Application Insights client (local or remote) as `LogView`.

--- a/Quilt4Net.Toolkit.Blazor/README.md
+++ b/Quilt4Net.Toolkit.Blazor/README.md
@@ -801,6 +801,47 @@ When the team has more than one configured workspace (remote mode, or an explici
 
 Two column toggles — **Show Development** and **Show Unknown** — are off by default. Each hides its environment column (`Development` / `(unknown)`) and drops any application row left without values in the remaining columns, so dev-only / unknown-only apps stay out of the default view. Toggling is instant (no re-query).
 
+## Metrics view
+
+`MetricsView` charts host and Kubernetes-cluster resource metrics read back from Application
+Insights (the `AppMetrics` table). Quilt4Net **reads** these — it does not produce them; the
+series come from an OpenTelemetry Collector (`hostmetrics` for machines, `kubeletstats` for the
+cluster) exporting OTel `system.*` / `k8s.*` semantic-convention metrics into your workspace.
+
+```razor
+<MetricsView />
+```
+
+It uses the same Application Insights client and configuration selector as `LogView` (local or
+remote mode — see [Log viewer](#log-viewer)), and a circuit-scoped cache so navigating away and
+back is instant. A range selector (1h / 24h / 7d) and a Refresh button sit at the top.
+
+**Hosts** (per machine, from `system.*`, grouped by `host.name`):
+
+| Chart | Source |
+|-------|--------|
+| CPU % | `system.cpu.utilization` (idle → busy %) |
+| Memory % | `system.memory.utilization` |
+| Disk used (GB) | `system.filesystem.usage` (per host + volume, with capacity bars) |
+
+**Cluster nodes** — shown only when the workspace has Kubernetes telemetry (otherwise the
+section collapses), one line per node (`k8s.node.name`):
+
+| Chart | Source | Unit |
+|-------|--------|------|
+| Node CPU | `k8s.node.cpu.usage` | cores (absolute — there is no node CPU-capacity metric to form a %) |
+| Node memory % | `k8s.node.memory.usage / (usage + available)` | % |
+| Node filesystem % | `k8s.node.filesystem.usage / capacity` | % |
+
+**Node → pod drill-down** — pick a node from the dropdown to load the pods scheduled on it
+(`k8s.pod.cpu.usage` in cores and `k8s.pod.memory.usage` in MB, labelled
+`{namespace}/{pod}`). Pod series are fetched on demand and are not cached.
+
+> Network throughput and swap/paging are intentionally not charted. Per-host load average
+> (`system.cpu.load_average.*`) is also omitted: the collector currently emits it without a host
+> resource attribute, so it can't be attributed to a machine — a producer-side fix is needed
+> before it can be shown here.
+
 ## Developer monitoring pages
 
 The usual convention is to expose the log and version views on developer-only pages at `/developer/log` and `/developer/version`, gated by a `Developer` role:

--- a/Quilt4Net.Toolkit.Tests/ApplicationInsightsServiceClientCacheTests.cs
+++ b/Quilt4Net.Toolkit.Tests/ApplicationInsightsServiceClientCacheTests.cs
@@ -71,6 +71,7 @@ public class ApplicationInsightsServiceClientCacheTests
 
         return new ApplicationInsightsService(
             Mock.Of<ITimeToLiveCache>(),
+            new LogCubeDayCache(TimeSpan.FromMinutes(5), () => DateTimeOffset.UtcNow),
             options,
             NullLogger<ApplicationInsightsService>.Instance);
     }

--- a/Quilt4Net.Toolkit.Tests/GetSummaryMaxItemsTests.cs
+++ b/Quilt4Net.Toolkit.Tests/GetSummaryMaxItemsTests.cs
@@ -76,6 +76,7 @@ public class GetSummaryMaxItemsTests
 
         return new ApplicationInsightsService(
             cache.Object,
+            new LogCubeDayCache(TimeSpan.FromMinutes(5), () => DateTimeOffset.UtcNow),
             options,
             NullLogger<ApplicationInsightsService>.Instance);
     }

--- a/Quilt4Net.Toolkit.Tests/LogCubeDayCacheTests.cs
+++ b/Quilt4Net.Toolkit.Tests/LogCubeDayCacheTests.cs
@@ -1,0 +1,112 @@
+using FluentAssertions;
+using Quilt4Net.Toolkit.Features.ApplicationInsights;
+using Xunit;
+
+namespace Quilt4Net.Toolkit.Tests;
+
+/// <summary>
+/// Pins the day-chunk cache contract: a finished UTC day is fetched once and then immutable; the
+/// current day refreshes on the TTL; different workspaces / days are isolated; and the Merge fold
+/// sums same-key cells across day chunks.
+/// </summary>
+public class LogCubeDayCacheTests
+{
+    private static LogCountByServiceCell Cell(string service, LogSource source, long count, long bytes, long trueCount, long trueBytes)
+        => new(service, SeverityLevel.Information, "prod", source, count, bytes, "m", trueCount, trueBytes);
+
+    [Fact]
+    public async Task MissingDay_Fetches_Once_And_Returns_Cells()
+    {
+        var now = new DateTimeOffset(2026, 6, 17, 12, 0, 0, TimeSpan.Zero);
+        var cache = new LogCubeDayCache(TimeSpan.FromMinutes(5), () => now);
+
+        var calls = 0;
+        var expected = new[] { Cell("svc", LogSource.Trace, 1, 10, 1, 10) };
+        var result = await cache.GetDayAsync("ws", new DateOnly(2026, 6, 16), _ => { calls++; return Task.FromResult(expected); });
+
+        calls.Should().Be(1);
+        result.Should().BeSameAs(expected);
+    }
+
+    [Fact]
+    public async Task PastDay_Is_Immutable_Even_After_Ttl_And_Day_Rollover()
+    {
+        var now = new DateTimeOffset(2026, 6, 17, 12, 0, 0, TimeSpan.Zero);
+        var cache = new LogCubeDayCache(TimeSpan.FromMinutes(5), () => now);
+
+        var calls = 0;
+        Task<LogCountByServiceCell[]> Fetch(DateOnly _) { calls++; return Task.FromResult(new[] { Cell("svc", LogSource.Trace, 1, 1, 1, 1) }); }
+
+        var past = new DateOnly(2026, 6, 16);
+        await cache.GetDayAsync("ws", past, Fetch);
+        now = now.AddHours(2);        // well past the 5-minute TTL
+        await cache.GetDayAsync("ws", past, Fetch);
+        now = now.AddDays(3);         // the "today" anchor has moved on; past stays cached
+        await cache.GetDayAsync("ws", past, Fetch);
+
+        calls.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task Today_Refetches_Once_The_Ttl_Lapses()
+    {
+        var now = new DateTimeOffset(2026, 6, 17, 12, 0, 0, TimeSpan.Zero);
+        var cache = new LogCubeDayCache(TimeSpan.FromMinutes(5), () => now);
+
+        var calls = 0;
+        Task<LogCountByServiceCell[]> Fetch(DateOnly _) { calls++; return Task.FromResult(new[] { Cell("svc", LogSource.Trace, 1, 1, 1, 1) }); }
+
+        var today = new DateOnly(2026, 6, 17);
+        await cache.GetDayAsync("ws", today, Fetch);   // fetch #1
+        now = now.AddMinutes(2);
+        await cache.GetDayAsync("ws", today, Fetch);   // within TTL → cached
+        calls.Should().Be(1);
+
+        now = now.AddMinutes(5);                       // 7 min total → stale
+        await cache.GetDayAsync("ws", today, Fetch);   // fetch #2
+        calls.Should().Be(2);
+    }
+
+    [Fact]
+    public async Task Distinct_Days_And_Workspaces_Are_Isolated()
+    {
+        var now = new DateTimeOffset(2026, 6, 17, 12, 0, 0, TimeSpan.Zero);
+        var cache = new LogCubeDayCache(TimeSpan.FromMinutes(5), () => now);
+
+        var calls = 0;
+        Task<LogCountByServiceCell[]> Fetch(DateOnly _) { calls++; return Task.FromResult(new[] { Cell("svc", LogSource.Trace, 1, 1, 1, 1) }); }
+
+        await cache.GetDayAsync("ws", new DateOnly(2026, 6, 14), Fetch);
+        await cache.GetDayAsync("ws", new DateOnly(2026, 6, 15), Fetch);
+        await cache.GetDayAsync("ws2", new DateOnly(2026, 6, 14), Fetch); // different workspace, same date
+        // re-request the first two — both past, both cached
+        await cache.GetDayAsync("ws", new DateOnly(2026, 6, 14), Fetch);
+        await cache.GetDayAsync("ws", new DateOnly(2026, 6, 15), Fetch);
+
+        calls.Should().Be(3);
+    }
+
+    [Fact]
+    public void Merge_Sums_Same_Key_Cells_And_Keeps_Distinct_Keys()
+    {
+        var dayA = new[]
+        {
+            Cell("svc", LogSource.Trace, 2, 10, 2, 10),
+            Cell("svc", LogSource.Request, 1, 5, 1, 5),
+        };
+        var dayB = new[]
+        {
+            Cell("svc", LogSource.Trace, 3, 20, 4, 40), // same key as dayA[0] → sums
+        };
+
+        var merged = LogCubeDayCache.Merge(dayA.Concat(dayB));
+
+        merged.Should().HaveCount(2);
+        var trace = merged.Single(c => c.Source == LogSource.Trace);
+        trace.Count.Should().Be(5);
+        trace.Bytes.Should().Be(30);
+        trace.TrueCount.Should().Be(6);
+        trace.TrueBytes.Should().Be(50);
+        merged.Single(c => c.Source == LogSource.Request).Count.Should().Be(1);
+    }
+}

--- a/Quilt4Net.Toolkit/ApplicationInsightsRegistration.cs
+++ b/Quilt4Net.Toolkit/ApplicationInsightsRegistration.cs
@@ -104,6 +104,11 @@ public static class ApplicationInsightsRegistration
             {
                 x.DefaultFreshSpan = TimeSpan.FromMinutes(10);
             });
+            // Daily ingestion-cap timeline (Operation + Usage). Daily-grained; 10 minutes is plenty.
+            s.RegisterType<CapTimeline, IMemory>(x =>
+            {
+                x.DefaultFreshSpan = TimeSpan.FromMinutes(10);
+            });
         });
     }
 
@@ -168,6 +173,7 @@ public static class ApplicationInsightsRegistration
             s.RegisterType<DiskCapacity[], IMemory>(x => { x.DefaultFreshSpan = TimeSpan.FromMinutes(10); });
             s.RegisterType<LogCountByServiceCell[], IMemory>(x => { x.DefaultFreshSpan = TimeSpan.FromMinutes(10); });
             s.RegisterType<VolumeBySource[], IMemory>(x => { x.DefaultFreshSpan = TimeSpan.FromMinutes(10); });
+            s.RegisterType<CapTimeline, IMemory>(x => { x.DefaultFreshSpan = TimeSpan.FromMinutes(10); });
         });
     }
 }

--- a/Quilt4Net.Toolkit/ApplicationInsightsRegistration.cs
+++ b/Quilt4Net.Toolkit/ApplicationInsightsRegistration.cs
@@ -98,6 +98,12 @@ public static class ApplicationInsightsRegistration
             {
                 x.DefaultFreshSpan = TimeSpan.FromMinutes(10);
             });
+            // Billed ingestion volume per source (from the Usage table). Billing data updates slowly;
+            // 10 minutes matches the other cost/metric surfaces. (Superseded later by the day-chunk cache.)
+            s.RegisterType<VolumeBySource[], IMemory>(x =>
+            {
+                x.DefaultFreshSpan = TimeSpan.FromMinutes(10);
+            });
         });
     }
 
@@ -161,6 +167,7 @@ public static class ApplicationInsightsRegistration
             s.RegisterType<MetricSample[], IMemory>(x => { x.DefaultFreshSpan = TimeSpan.FromMinutes(10); });
             s.RegisterType<DiskCapacity[], IMemory>(x => { x.DefaultFreshSpan = TimeSpan.FromMinutes(10); });
             s.RegisterType<LogCountByServiceCell[], IMemory>(x => { x.DefaultFreshSpan = TimeSpan.FromMinutes(10); });
+            s.RegisterType<VolumeBySource[], IMemory>(x => { x.DefaultFreshSpan = TimeSpan.FromMinutes(10); });
         });
     }
 }

--- a/Quilt4Net.Toolkit/ApplicationInsightsRegistration.cs
+++ b/Quilt4Net.Toolkit/ApplicationInsightsRegistration.cs
@@ -38,6 +38,10 @@ public static class ApplicationInsightsRegistration
         services.AddSingleton<IVersionMatrixService, VersionMatrixService>();
         services.AddTransient<IHealthClient, HealthClient>();
 
+        // Process-wide per-UTC-day cache for the log-count cube. Past days are immutable; the live
+        // "today" chunk refreshes on this short TTL. Multi-day views compose from these chunks.
+        services.AddSingleton(new LogCubeDayCache(TimeSpan.FromMinutes(5), () => DateTimeOffset.UtcNow));
+
         services.AddCache(s =>
         {
             // Environment list rarely changes — hold it for an hour.
@@ -159,6 +163,9 @@ public static class ApplicationInsightsRegistration
         services.AddTransient<IApplicationInsightsService, ApplicationInsightsService>();
         services.AddSingleton<IVersionMatrixService, VersionMatrixService>();
         services.AddTransient<IHealthClient, HealthClient>();
+
+        // Process-wide per-UTC-day cache for the log-count cube (see local-mode registration above).
+        services.AddSingleton(new LogCubeDayCache(TimeSpan.FromMinutes(5), () => DateTimeOffset.UtcNow));
 
         services.AddCache(s =>
         {

--- a/Quilt4Net.Toolkit/Features/ApplicationInsights/ApplicationInsightsService.cs
+++ b/Quilt4Net.Toolkit/Features/ApplicationInsights/ApplicationInsightsService.cs
@@ -1532,7 +1532,7 @@ AppMetrics
     // (e.g. cog-audry / vm-ygg-cp-1), a separate telemetry family from the host system.* metrics
     // above. Per-row "average value" uses the same sum(Sum)/sum(ItemCount) weighted average.
 
-    public IAsyncEnumerable<MetricSample> GetClusterNodeCpuAsync(IApplicationInsightsContext context, TimeSpan timeSpan, [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken = default)
+    public IAsyncEnumerable<MetricSample> GetClusterNodeCpuAsync(IApplicationInsightsContext context, TimeSpan timeSpan, CancellationToken cancellationToken = default)
     {
         // Node CPU used %, = 100 * k8s.node.cpu.usage / k8s.node.allocatable_cpu (cores / total
         // schedulable cores). Both averaged per (node, bin) first, then combined. Only bins where
@@ -1552,7 +1552,7 @@ AppMetrics
         return RunMetricQueryAsync(context, query, timeSpan, $"nodecpupct|{context.ToKey()}|{timeSpan}", cancellationToken);
     }
 
-    public IAsyncEnumerable<MetricSample> GetClusterNodeMemoryAsync(IApplicationInsightsContext context, TimeSpan timeSpan, [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken = default)
+    public IAsyncEnumerable<MetricSample> GetClusterNodeMemoryAsync(IApplicationInsightsContext context, TimeSpan timeSpan, CancellationToken cancellationToken = default)
     {
         // No node memory-capacity metric, but usage + available sum to total, so memory-used %
         // is 100 * usage / (usage + available). Both metrics are averaged per (node, bin) first,
@@ -1572,7 +1572,7 @@ AppMetrics
         return RunMetricQueryAsync(context, query, timeSpan, $"nodemem|{context.ToKey()}|{timeSpan}", cancellationToken);
     }
 
-    public IAsyncEnumerable<MetricSample> GetClusterPodCpuAsync(IApplicationInsightsContext context, string node, TimeSpan timeSpan, [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken = default)
+    public IAsyncEnumerable<MetricSample> GetClusterPodCpuAsync(IApplicationInsightsContext context, string node, TimeSpan timeSpan, CancellationToken cancellationToken = default)
     {
         // Drill-down for one node: pods scheduled on it, CPU in cores. Series = namespace/pod.
         var bin = MetricsBinSelector.PickBin(timeSpan);
@@ -1589,7 +1589,7 @@ AppMetrics
         return RunMetricQueryAsync(context, query, timeSpan, $"podcpu|{context.ToKey()}|{node}|{timeSpan}", cancellationToken);
     }
 
-    public IAsyncEnumerable<MetricSample> GetClusterPodMemoryAsync(IApplicationInsightsContext context, string node, TimeSpan timeSpan, [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken = default)
+    public IAsyncEnumerable<MetricSample> GetClusterPodMemoryAsync(IApplicationInsightsContext context, string node, TimeSpan timeSpan, CancellationToken cancellationToken = default)
     {
         // Drill-down for one node: pods scheduled on it, memory in MB (absolute — pods have no
         // consistent capacity to percentage against). Series = namespace/pod.
@@ -1607,7 +1607,7 @@ AppMetrics
         return RunMetricQueryAsync(context, query, timeSpan, $"podmem|{context.ToKey()}|{node}|{timeSpan}", cancellationToken);
     }
 
-    public IAsyncEnumerable<MetricSample> GetClusterNodeFilesystemAsync(IApplicationInsightsContext context, TimeSpan timeSpan, [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken = default)
+    public IAsyncEnumerable<MetricSample> GetClusterNodeFilesystemAsync(IApplicationInsightsContext context, TimeSpan timeSpan, CancellationToken cancellationToken = default)
     {
         // usage / capacity per node → filesystem-used %. Both averaged per (node, bin) then combined.
         var bin = MetricsBinSelector.PickBin(timeSpan);
@@ -1629,7 +1629,7 @@ AppMetrics
     // result is a real capacity-weighted total (a 12-core / large-RAM node contributes more than a
     // small one), not a mean of per-node ratios. One "Cluster" series.
 
-    public IAsyncEnumerable<MetricSample> GetClusterTotalCpuAsync(IApplicationInsightsContext context, TimeSpan timeSpan, [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken = default)
+    public IAsyncEnumerable<MetricSample> GetClusterTotalCpuAsync(IApplicationInsightsContext context, TimeSpan timeSpan, CancellationToken cancellationToken = default)
     {
         // Whole-cluster CPU used %, capacity-weighted: 100 * Σ usage / Σ allocatable_cpu across all
         // nodes per bin (a 12-core node weighs 6× a 2-core one). Only bins with allocatable render.
@@ -1649,7 +1649,7 @@ AppMetrics
         return RunMetricQueryAsync(context, query, timeSpan, $"clustercpupct|{context.ToKey()}|{timeSpan}", cancellationToken);
     }
 
-    public IAsyncEnumerable<MetricSample> GetClusterTotalMemoryAsync(IApplicationInsightsContext context, TimeSpan timeSpan, [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken = default)
+    public IAsyncEnumerable<MetricSample> GetClusterTotalMemoryAsync(IApplicationInsightsContext context, TimeSpan timeSpan, CancellationToken cancellationToken = default)
     {
         var bin = MetricsBinSelector.PickBin(timeSpan);
         var query = $@"
@@ -1667,7 +1667,7 @@ AppMetrics
         return RunMetricQueryAsync(context, query, timeSpan, $"clustermem|{context.ToKey()}|{timeSpan}", cancellationToken);
     }
 
-    public IAsyncEnumerable<MetricSample> GetClusterTotalFilesystemAsync(IApplicationInsightsContext context, TimeSpan timeSpan, [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken = default)
+    public IAsyncEnumerable<MetricSample> GetClusterTotalFilesystemAsync(IApplicationInsightsContext context, TimeSpan timeSpan, CancellationToken cancellationToken = default)
     {
         var bin = MetricsBinSelector.PickBin(timeSpan);
         var query = $@"

--- a/Quilt4Net.Toolkit/Features/ApplicationInsights/ApplicationInsightsService.cs
+++ b/Quilt4Net.Toolkit/Features/ApplicationInsights/ApplicationInsightsService.cs
@@ -1686,7 +1686,7 @@ AppMetrics
     {
         // Cache key versioned so schema changes don't serve stale cells from the TtlCache after a
         // hot reload (Machine column → v2; Bytes + extra severity-bearing sources → v3).
-        var cacheKey = $"logcount-v3|{context.ToKey()}|{timeSpan}";
+        var cacheKey = $"logcount-v4|{context.ToKey()}|{timeSpan}";
         var items = await _timeToLiveCache.GetAsync(cacheKey, async () =>
         {
             var list = new List<LogCountByServiceCell>();
@@ -1721,8 +1721,9 @@ union withsource=_Source AppTraces, AppExceptions, AppRequests, AppDependencies,
         _Source == 'AppEvents', 1,
         _Source == 'AppPageViews', 1,
         toint(SeverityLevel))
-| summarize Count = count(), Bytes = sum(_BilledSize) by Service, EffectiveSeverity, Environment, _Source, Machine
-| project Service, Severity = EffectiveSeverity, Environment, Source = _Source, Count, Bytes, Machine";
+| extend _w = coalesce(toint(ItemCount), 1)
+| summarize Count = count(), Bytes = sum(_BilledSize), TrueCount = sum(_w), TrueBytes = sum(_BilledSize * _w) by Service, EffectiveSeverity, Environment, _Source, Machine
+| project Service, Severity = EffectiveSeverity, Environment, Source = _Source, Count, Bytes, Machine, TrueCount, TrueBytes";
 
             var response = await client.QueryWorkspaceAsync(workspaceId, query, new LogsQueryTimeRange(timeSpan));
             foreach (var table in response.Value.AllTables)
@@ -1734,6 +1735,8 @@ union withsource=_Source AppTraces, AppExceptions, AppRequests, AppDependencies,
                 var countIdx = GetColumnIndex(table, "Count");
                 var bytesIdx = GetColumnIndex(table, "Bytes");
                 var machineIdx = GetColumnIndex(table, "Machine");
+                var trueCountIdx = GetColumnIndex(table, "TrueCount");
+                var trueBytesIdx = GetColumnIndex(table, "TrueBytes");
                 foreach (var row in table.Rows)
                 {
                     var service = row[serviceIdx]?.ToString() ?? "unknown";
@@ -1751,7 +1754,9 @@ union withsource=_Source AppTraces, AppExceptions, AppRequests, AppDependencies,
                     var count = System.Convert.ToInt64(row[countIdx] ?? 0L, System.Globalization.CultureInfo.InvariantCulture);
                     var bytes = System.Convert.ToInt64(row[bytesIdx] ?? 0L, System.Globalization.CultureInfo.InvariantCulture);
                     var machine = row[machineIdx]?.ToString() ?? "";
-                    list.Add(new LogCountByServiceCell(service, severity, environment, source, count, bytes, machine));
+                    var trueCount = System.Convert.ToInt64(row[trueCountIdx] ?? 0L, System.Globalization.CultureInfo.InvariantCulture);
+                    var trueBytes = System.Convert.ToInt64(row[trueBytesIdx] ?? 0L, System.Globalization.CultureInfo.InvariantCulture);
+                    list.Add(new LogCountByServiceCell(service, severity, environment, source, count, bytes, machine, trueCount, trueBytes));
                 }
             }
             return list.ToArray();

--- a/Quilt4Net.Toolkit/Features/ApplicationInsights/ApplicationInsightsService.cs
+++ b/Quilt4Net.Toolkit/Features/ApplicationInsights/ApplicationInsightsService.cs
@@ -1599,9 +1599,9 @@ AppMetrics
 
     public async IAsyncEnumerable<LogCountByServiceCell> GetLogCountByServiceAsync(IApplicationInsightsContext context, TimeSpan timeSpan, [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
-        // Cache key bumped to v2 when the Machine column was added — without that suffix, a hot-
-        // reloaded process would keep serving pre-Machine cells from the TtlCache.
-        var cacheKey = $"logcount-v2|{context.ToKey()}|{timeSpan}";
+        // Cache key versioned so schema changes don't serve stale cells from the TtlCache after a
+        // hot reload (Machine column → v2; Bytes + extra severity-bearing sources → v3).
+        var cacheKey = $"logcount-v3|{context.ToKey()}|{timeSpan}";
         var items = await _timeToLiveCache.GetAsync(cacheKey, async () =>
         {
             var list = new List<LogCountByServiceCell>();
@@ -1610,12 +1610,14 @@ AppMetrics
 
             // Group by every dimension the admin UI may filter on (env + source) so the same
             // result set powers every subsequent filter combination without another KQL run.
+            // Bytes = sum(_BilledSize) lets the view toggle count ↔ ingested volume locally.
             // Unified severity:
             //   - AppTraces: own SeverityLevel (Verbose..Critical = 0..4)
             //   - AppExceptions: always Error (3) — no useful gradient on raw exceptions
-            //   - AppRequests: Information (1) on success, Error (3) on failure
+            //   - AppRequests / AppDependencies / AppAvailabilityResults: Information (1) on success, Error (3) on failure
+            //   - AppEvents / AppPageViews: Information (1) — no severity/success on the row
             var query = $@"
-union withsource=_Source AppTraces, AppExceptions, AppRequests
+union withsource=_Source AppTraces, AppExceptions, AppRequests, AppDependencies, AppEvents, AppPageViews, AppAvailabilityResults
 | extend _p = todynamic(Properties)
 | extend
     Service = coalesce(tostring(_p['ApplicationName']), tostring(AppRoleName), 'unknown'),
@@ -1629,10 +1631,14 @@ union withsource=_Source AppTraces, AppExceptions, AppRequests
         'unknown'),
     EffectiveSeverity = case(
         _Source == 'AppExceptions', 3,
-        _Source == 'AppRequests',   iif(tobool(coalesce(Success, true)), 1, 3),
+        _Source == 'AppRequests', iif(tobool(coalesce(Success, true)), 1, 3),
+        _Source == 'AppDependencies', iif(tobool(coalesce(Success, true)), 1, 3),
+        _Source == 'AppAvailabilityResults', iif(tobool(coalesce(Success, true)), 1, 3),
+        _Source == 'AppEvents', 1,
+        _Source == 'AppPageViews', 1,
         toint(SeverityLevel))
-| summarize Count = count() by Service, EffectiveSeverity, Environment, _Source, Machine
-| project Service, Severity = EffectiveSeverity, Environment, Source = _Source, Count, Machine";
+| summarize Count = count(), Bytes = sum(_BilledSize) by Service, EffectiveSeverity, Environment, _Source, Machine
+| project Service, Severity = EffectiveSeverity, Environment, Source = _Source, Count, Bytes, Machine";
 
             var response = await client.QueryWorkspaceAsync(workspaceId, query, new LogsQueryTimeRange(timeSpan));
             foreach (var table in response.Value.AllTables)
@@ -1642,6 +1648,7 @@ union withsource=_Source AppTraces, AppExceptions, AppRequests
                 var envIdx = GetColumnIndex(table, "Environment");
                 var sourceIdx = GetColumnIndex(table, "Source");
                 var countIdx = GetColumnIndex(table, "Count");
+                var bytesIdx = GetColumnIndex(table, "Bytes");
                 var machineIdx = GetColumnIndex(table, "Machine");
                 foreach (var row in table.Rows)
                 {
@@ -1652,11 +1659,16 @@ union withsource=_Source AppTraces, AppExceptions, AppRequests
                     {
                         "AppExceptions" => LogSource.Exception,
                         "AppRequests" => LogSource.Request,
+                        "AppDependencies" => LogSource.Dependency,
+                        "AppEvents" => LogSource.Event,
+                        "AppPageViews" => LogSource.PageView,
+                        "AppAvailabilityResults" => LogSource.Availability,
                         _ => LogSource.Trace,
                     };
                     var count = System.Convert.ToInt64(row[countIdx] ?? 0L, System.Globalization.CultureInfo.InvariantCulture);
+                    var bytes = System.Convert.ToInt64(row[bytesIdx] ?? 0L, System.Globalization.CultureInfo.InvariantCulture);
                     var machine = row[machineIdx]?.ToString() ?? "";
-                    list.Add(new LogCountByServiceCell(service, severity, environment, source, count, machine));
+                    list.Add(new LogCountByServiceCell(service, severity, environment, source, count, bytes, machine));
                 }
             }
             return list.ToArray();

--- a/Quilt4Net.Toolkit/Features/ApplicationInsights/ApplicationInsightsService.cs
+++ b/Quilt4Net.Toolkit/Features/ApplicationInsights/ApplicationInsightsService.cs
@@ -1244,6 +1244,12 @@ union withsource=_Source AppTraces, AppExceptions, AppRequests
     // first (what the Quilt4Net SDK enriches every record with — `Environment.MachineName`), then
     // Properties['host.name'] (the OpenTelemetry resource attribute), and finally AppRoleInstance
     // (Azure Monitor's per-instance id) as a last-resort fallback.
+    //
+    // `where isnotempty(host)` drops rows with no host identity at all. The k3s nodes run a
+    // hostmetrics DaemonSet that emits system.* WITHOUT host.name/AppRole*, so without this filter
+    // every node's same-named device (e.g. /dev/sda1) collapses into one blank-prefixed series and
+    // averages unrelated machines together. Those cluster nodes are charted per-node via the
+    // k8s.node.* methods instead (GetClusterNode*). Identified hosts (e.g. Eplicta1-7) are unaffected.
 
     public IAsyncEnumerable<MetricSample> GetCpuUtilizationAsync(IApplicationInsightsContext context, TimeSpan timeSpan, [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
@@ -1254,6 +1260,7 @@ AppMetrics
 | where Name == 'system.cpu.utilization'
 | where tostring(Properties.state) == 'idle'
 | extend host = coalesce(tostring(Properties['MachineName']), tostring(Properties['host.name']), AppRoleInstance)
+| where isnotempty(host)
 | summarize avg_idle = sum(Sum) / todouble(sum(ItemCount)) by host, bin(TimeGenerated, {MetricsBinSelector.ToKqlLiteral(bin)})
 | extend cpu_busy_pct = 100.0 * (1 - avg_idle)
 | project Series = host, Timestamp = TimeGenerated, Value = cpu_busy_pct";
@@ -1269,6 +1276,7 @@ AppMetrics
 | where Name == 'system.memory.utilization'
 | where tostring(Properties.state) == 'used'
 | extend host = coalesce(tostring(Properties['MachineName']), tostring(Properties['host.name']), AppRoleInstance)
+| where isnotempty(host)
 | summarize mem_used_pct = 100.0 * sum(Sum) / todouble(sum(ItemCount)) by host, bin(TimeGenerated, {MetricsBinSelector.ToKqlLiteral(bin)})
 | project Series = host, Timestamp = TimeGenerated, Value = mem_used_pct";
         return RunMetricQueryAsync(context, query, timeSpan, $"mem|{context.ToKey()}|{timeSpan}", cancellationToken);
@@ -1289,6 +1297,7 @@ AppMetrics
 | where Name == 'system.filesystem.usage'
 | where tostring(Properties.state) == 'free'
 | extend host = coalesce(tostring(Properties['MachineName']), tostring(Properties['host.name']), AppRoleInstance)
+| where isnotempty(host)
 | extend volume = strcat(host, ' ', tostring(Properties['device']))
 | summarize free_gb = (sum(Sum) / todouble(sum(ItemCount))) / 1073741824.0 by volume, bin(TimeGenerated, {MetricsBinSelector.ToKqlLiteral(bin)})
 | project Series = volume, Timestamp = TimeGenerated, Value = free_gb";
@@ -1307,6 +1316,7 @@ AppMetrics
 | where TimeGenerated > ago({MetricsBinSelector.ToKqlLiteral(timeSpan)})
 | where Name == 'system.filesystem.usage'
 | extend host = coalesce(tostring(Properties['MachineName']), tostring(Properties['host.name']), AppRoleInstance)
+| where isnotempty(host)
 | extend volume = strcat(host, ' ', tostring(Properties['device']))
 | extend state = tostring(Properties.state)
 | summarize gb = (sum(Sum) / todouble(sum(ItemCount))) / 1073741824.0 by volume, state
@@ -1363,6 +1373,7 @@ AppMetrics
 | where TimeGenerated > ago({MetricsBinSelector.ToKqlLiteral(timeSpan)})
 | where Name == 'system.network.io'
 | extend host = coalesce(tostring(Properties['MachineName']), tostring(Properties['host.name']), AppRoleInstance)
+| where isnotempty(host)
 | summarize total_bytes = sum(Sum) by host, bin(TimeGenerated, {MetricsBinSelector.ToKqlLiteral(bin)})
 | order by host asc, TimeGenerated asc
 | extend prev_bytes = prev(total_bytes), prev_host = prev(host), prev_t = prev(TimeGenerated)

--- a/Quilt4Net.Toolkit/Features/ApplicationInsights/ApplicationInsightsService.cs
+++ b/Quilt4Net.Toolkit/Features/ApplicationInsights/ApplicationInsightsService.cs
@@ -87,6 +87,7 @@ union startup_pick, (log_pick | join kind=leftanti startup_pick on ApplicationNa
 | order by ApplicationName asc, Environment asc, Machine asc";
     private readonly ConcurrentDictionary<ClientKey, LogsQueryClient> _clientCache = new();
     private readonly ITimeToLiveCache _timeToLiveCache;
+    private readonly LogCubeDayCache _logCubeDayCache;
     private readonly ApplicationInsightsOptions _options;
     private readonly ILogger<ApplicationInsightsService> _logger;
 
@@ -94,10 +95,12 @@ union startup_pick, (log_pick | join kind=leftanti startup_pick on ApplicationNa
 
     public ApplicationInsightsService(
         ITimeToLiveCache timeToLiveCache,
+        LogCubeDayCache logCubeDayCache,
         IOptions<ApplicationInsightsOptions> options,
         ILogger<ApplicationInsightsService> logger)
     {
         _timeToLiveCache = timeToLiveCache;
+        _logCubeDayCache = logCubeDayCache;
         _options = options.Value;
         _logger = logger;
     }
@@ -1682,26 +1685,18 @@ AppMetrics
         return RunMetricQueryAsync(context, query, timeSpan, $"clusterfs|{context.ToKey()}|{timeSpan}", cancellationToken);
     }
 
-    public async IAsyncEnumerable<LogCountByServiceCell> GetLogCountByServiceAsync(IApplicationInsightsContext context, TimeSpan timeSpan, [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken = default)
-    {
-        // Cache key versioned so schema changes don't serve stale cells from the TtlCache after a
-        // hot reload (Machine column → v2; Bytes + extra severity-bearing sources → v3).
-        var cacheKey = $"logcount-v4|{context.ToKey()}|{timeSpan}";
-        var items = await _timeToLiveCache.GetAsync(cacheKey, async () =>
-        {
-            var list = new List<LogCountByServiceCell>();
-            var client = GetClient(context);
-            var workspaceId = context?.WorkspaceId ?? _options.WorkspaceId;
-
-            // Group by every dimension the admin UI may filter on (env + source) so the same
-            // result set powers every subsequent filter combination without another KQL run.
-            // Bytes = sum(_BilledSize) lets the view toggle count ↔ ingested volume locally.
-            // Unified severity:
-            //   - AppTraces: own SeverityLevel (Verbose..Critical = 0..4)
-            //   - AppExceptions: always Error (3) — no useful gradient on raw exceptions
-            //   - AppRequests / AppDependencies: Information (1) on success, Error (3) on failure
-            //   - AppEvents / AppPageViews: Information (1) — no severity/success on the row
-            var query = $@"
+    /// <summary>
+    /// The log-count cube query. Groups by every dimension the admin UI may filter on (service ×
+    /// severity × environment × source × machine) so one result set powers every subsequent filter
+    /// combination without another KQL run. <c>Bytes = sum(_BilledSize)</c> lets the view toggle
+    /// count ↔ ingested volume locally; <c>TrueCount/TrueBytes</c> (weighted by <c>ItemCount</c>)
+    /// carry the sampling-corrected figures. Unified severity:
+    ///   - AppTraces: own SeverityLevel (Verbose..Critical = 0..4)
+    ///   - AppExceptions: always Error (3) — no useful gradient on raw exceptions
+    ///   - AppRequests / AppDependencies: Information (1) on success, Error (3) on failure
+    ///   - AppEvents / AppPageViews: Information (1) — no severity/success on the row
+    /// </summary>
+    private static readonly string _logCubeQuery = $@"
 union withsource=_Source AppTraces, AppExceptions, AppRequests, AppDependencies, AppEvents, AppPageViews
 | extend _p = todynamic(Properties)
 | extend
@@ -1725,47 +1720,99 @@ union withsource=_Source AppTraces, AppExceptions, AppRequests, AppDependencies,
 | summarize Count = count(), Bytes = sum(_BilledSize), TrueCount = sum(_w), TrueBytes = sum(_BilledSize * _w) by Service, EffectiveSeverity, Environment, _Source, Machine
 | project Service, Severity = EffectiveSeverity, Environment, Source = _Source, Count, Bytes, Machine, TrueCount, TrueBytes";
 
-            var response = await client.QueryWorkspaceAsync(workspaceId, query, new LogsQueryTimeRange(timeSpan));
-            foreach (var table in response.Value.AllTables)
-            {
-                var serviceIdx = GetColumnIndex(table, "Service");
-                var sevIdx = GetColumnIndex(table, "Severity");
-                var envIdx = GetColumnIndex(table, "Environment");
-                var sourceIdx = GetColumnIndex(table, "Source");
-                var countIdx = GetColumnIndex(table, "Count");
-                var bytesIdx = GetColumnIndex(table, "Bytes");
-                var machineIdx = GetColumnIndex(table, "Machine");
-                var trueCountIdx = GetColumnIndex(table, "TrueCount");
-                var trueBytesIdx = GetColumnIndex(table, "TrueBytes");
-                foreach (var row in table.Rows)
-                {
-                    var service = row[serviceIdx]?.ToString() ?? "unknown";
-                    var severity = (SeverityLevel)GetInt(row, sevIdx);
-                    var environment = row[envIdx]?.ToString() ?? "";
-                    var source = (row[sourceIdx]?.ToString()) switch
-                    {
-                        "AppExceptions" => LogSource.Exception,
-                        "AppRequests" => LogSource.Request,
-                        "AppDependencies" => LogSource.Dependency,
-                        "AppEvents" => LogSource.Event,
-                        "AppPageViews" => LogSource.PageView,
-                        _ => LogSource.Trace,
-                    };
-                    var count = System.Convert.ToInt64(row[countIdx] ?? 0L, System.Globalization.CultureInfo.InvariantCulture);
-                    var bytes = System.Convert.ToInt64(row[bytesIdx] ?? 0L, System.Globalization.CultureInfo.InvariantCulture);
-                    var machine = row[machineIdx]?.ToString() ?? "";
-                    var trueCount = System.Convert.ToInt64(row[trueCountIdx] ?? 0L, System.Globalization.CultureInfo.InvariantCulture);
-                    var trueBytes = System.Convert.ToInt64(row[trueBytesIdx] ?? 0L, System.Globalization.CultureInfo.InvariantCulture);
-                    list.Add(new LogCountByServiceCell(service, severity, environment, source, count, bytes, machine, trueCount, trueBytes));
-                }
-            }
-            return list.ToArray();
-        });
+    public async IAsyncEnumerable<LogCountByServiceCell> GetLogCountByServiceAsync(IApplicationInsightsContext context, TimeSpan timeSpan, [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        // Whole-day multi-day windows (7d, 30d, …) compose from per-day chunks — only the live "today"
+        // slice re-queries on refresh; finished days are served from the process-wide cache. Sub-day
+        // ranges (1h / 24h) can't be assembled from whole-day chunks, so they stay on the live path.
+        var days = (int)Math.Round(timeSpan.TotalDays);
+        var calendarMode = days >= 2 && Math.Abs(timeSpan.TotalDays - days) < 0.01;
+
+        var items = calendarMode
+            ? await GetLogCubeByDaysAsync(context, days)
+            : await GetLogCubeLiveAsync(context, timeSpan);
+
         foreach (var item in items)
         {
             cancellationToken.ThrowIfCancellationRequested();
             yield return item;
         }
+    }
+
+    // Sub-day path: one query over the rolling window, cached by the TtlCache. Key versioned so schema
+    // changes don't serve stale cells after a hot reload (Machine → v2; Bytes + extra sources → v3;
+    // TrueCount/TrueBytes → v4).
+    private async Task<LogCountByServiceCell[]> GetLogCubeLiveAsync(IApplicationInsightsContext context, TimeSpan timeSpan)
+    {
+        var cacheKey = $"logcount-v4|{context.ToKey()}|{timeSpan}";
+        return await _timeToLiveCache.GetAsync(cacheKey, () => FetchLogCubeAsync(context, new LogsQueryTimeRange(timeSpan)));
+    }
+
+    // Multi-day path: compose the window from `days` whole UTC-day chunks ending today (calendar
+    // aligned), then fold same-key cells across days back into the flat cube shape.
+    private async Task<LogCountByServiceCell[]> GetLogCubeByDaysAsync(IApplicationInsightsContext context, int days)
+    {
+        var workspaceKey = context.ToKey();
+        var today = DateOnly.FromDateTime(DateTime.UtcNow);
+        var composed = new List<LogCountByServiceCell>();
+        for (var i = 0; i < days; i++)
+        {
+            var date = today.AddDays(-i);
+            var dayCells = await _logCubeDayCache.GetDayAsync(workspaceKey, date, d => FetchLogCubeAsync(context, DayRange(d)));
+            composed.AddRange(dayCells);
+        }
+        return LogCubeDayCache.Merge(composed);
+    }
+
+    // A full UTC calendar day [00:00, next-00:00). For today the end is in the future; Log Analytics
+    // simply returns up to "now", and the day-cache's short TTL keeps it fresh.
+    private static LogsQueryTimeRange DayRange(DateOnly dateUtc)
+    {
+        var start = new DateTimeOffset(dateUtc.ToDateTime(TimeOnly.MinValue, DateTimeKind.Utc));
+        return new LogsQueryTimeRange(start, start.AddDays(1));
+    }
+
+    private async Task<LogCountByServiceCell[]> FetchLogCubeAsync(IApplicationInsightsContext context, LogsQueryTimeRange range)
+    {
+        var list = new List<LogCountByServiceCell>();
+        var client = GetClient(context);
+        var workspaceId = context?.WorkspaceId ?? _options.WorkspaceId;
+
+        var response = await client.QueryWorkspaceAsync(workspaceId, _logCubeQuery, range);
+        foreach (var table in response.Value.AllTables)
+        {
+            var serviceIdx = GetColumnIndex(table, "Service");
+            var sevIdx = GetColumnIndex(table, "Severity");
+            var envIdx = GetColumnIndex(table, "Environment");
+            var sourceIdx = GetColumnIndex(table, "Source");
+            var countIdx = GetColumnIndex(table, "Count");
+            var bytesIdx = GetColumnIndex(table, "Bytes");
+            var machineIdx = GetColumnIndex(table, "Machine");
+            var trueCountIdx = GetColumnIndex(table, "TrueCount");
+            var trueBytesIdx = GetColumnIndex(table, "TrueBytes");
+            foreach (var row in table.Rows)
+            {
+                var service = row[serviceIdx]?.ToString() ?? "unknown";
+                var severity = (SeverityLevel)GetInt(row, sevIdx);
+                var environment = row[envIdx]?.ToString() ?? "";
+                var source = (row[sourceIdx]?.ToString()) switch
+                {
+                    "AppExceptions" => LogSource.Exception,
+                    "AppRequests" => LogSource.Request,
+                    "AppDependencies" => LogSource.Dependency,
+                    "AppEvents" => LogSource.Event,
+                    "AppPageViews" => LogSource.PageView,
+                    _ => LogSource.Trace,
+                };
+                var count = System.Convert.ToInt64(row[countIdx] ?? 0L, System.Globalization.CultureInfo.InvariantCulture);
+                var bytes = System.Convert.ToInt64(row[bytesIdx] ?? 0L, System.Globalization.CultureInfo.InvariantCulture);
+                var machine = row[machineIdx]?.ToString() ?? "";
+                var trueCount = System.Convert.ToInt64(row[trueCountIdx] ?? 0L, System.Globalization.CultureInfo.InvariantCulture);
+                var trueBytes = System.Convert.ToInt64(row[trueBytesIdx] ?? 0L, System.Globalization.CultureInfo.InvariantCulture);
+                list.Add(new LogCountByServiceCell(service, severity, environment, source, count, bytes, machine, trueCount, trueBytes));
+            }
+        }
+        return list.ToArray();
     }
 
     /// <summary>

--- a/Quilt4Net.Toolkit/Features/ApplicationInsights/ApplicationInsightsService.cs
+++ b/Quilt4Net.Toolkit/Features/ApplicationInsights/ApplicationInsightsService.cs
@@ -1614,10 +1614,10 @@ AppMetrics
             // Unified severity:
             //   - AppTraces: own SeverityLevel (Verbose..Critical = 0..4)
             //   - AppExceptions: always Error (3) — no useful gradient on raw exceptions
-            //   - AppRequests / AppDependencies / AppAvailabilityResults: Information (1) on success, Error (3) on failure
+            //   - AppRequests / AppDependencies: Information (1) on success, Error (3) on failure
             //   - AppEvents / AppPageViews: Information (1) — no severity/success on the row
             var query = $@"
-union withsource=_Source AppTraces, AppExceptions, AppRequests, AppDependencies, AppEvents, AppPageViews, AppAvailabilityResults
+union withsource=_Source AppTraces, AppExceptions, AppRequests, AppDependencies, AppEvents, AppPageViews
 | extend _p = todynamic(Properties)
 | extend
     Service = coalesce(tostring(_p['ApplicationName']), tostring(AppRoleName), 'unknown'),
@@ -1633,7 +1633,6 @@ union withsource=_Source AppTraces, AppExceptions, AppRequests, AppDependencies,
         _Source == 'AppExceptions', 3,
         _Source == 'AppRequests', iif(tobool(coalesce(Success, true)), 1, 3),
         _Source == 'AppDependencies', iif(tobool(coalesce(Success, true)), 1, 3),
-        _Source == 'AppAvailabilityResults', iif(tobool(coalesce(Success, true)), 1, 3),
         _Source == 'AppEvents', 1,
         _Source == 'AppPageViews', 1,
         toint(SeverityLevel))
@@ -1662,7 +1661,6 @@ union withsource=_Source AppTraces, AppExceptions, AppRequests, AppDependencies,
                         "AppDependencies" => LogSource.Dependency,
                         "AppEvents" => LogSource.Event,
                         "AppPageViews" => LogSource.PageView,
-                        "AppAvailabilityResults" => LogSource.Availability,
                         _ => LogSource.Trace,
                     };
                     var count = System.Convert.ToInt64(row[countIdx] ?? 0L, System.Globalization.CultureInfo.InvariantCulture);

--- a/Quilt4Net.Toolkit/Features/ApplicationInsights/ApplicationInsightsService.cs
+++ b/Quilt4Net.Toolkit/Features/ApplicationInsights/ApplicationInsightsService.cs
@@ -1373,6 +1373,99 @@ AppMetrics
         return RunMetricQueryAsync(context, query, timeSpan, $"net|{context.ToKey()}|{timeSpan}", cancellationToken);
     }
 
+    // Cluster (kubeletstats) metrics are grouped by k8s.node.name — these come from the k3s nodes
+    // (e.g. cog-audry / vm-ygg-cp-1), a separate telemetry family from the host system.* metrics
+    // above. Per-row "average value" uses the same sum(Sum)/sum(ItemCount) weighted average.
+
+    public IAsyncEnumerable<MetricSample> GetClusterNodeCpuAsync(IApplicationInsightsContext context, TimeSpan timeSpan, [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        // k8s.node.cpu.usage is a gauge in cores. No node CPU-capacity metric exists, so we
+        // surface absolute cores rather than a percentage. Series = node name.
+        var bin = MetricsBinSelector.PickBin(timeSpan);
+        var query = $@"
+AppMetrics
+| where TimeGenerated > ago({MetricsBinSelector.ToKqlLiteral(timeSpan)})
+| where Name == 'k8s.node.cpu.usage'
+| extend node = tostring(Properties['k8s.node.name'])
+| where isnotempty(node)
+| summarize cores = sum(Sum) / todouble(sum(ItemCount)) by node, bin(TimeGenerated, {MetricsBinSelector.ToKqlLiteral(bin)})
+| project Series = node, Timestamp = TimeGenerated, Value = cores";
+        return RunMetricQueryAsync(context, query, timeSpan, $"nodecpu|{context.ToKey()}|{timeSpan}", cancellationToken);
+    }
+
+    public IAsyncEnumerable<MetricSample> GetClusterNodeMemoryAsync(IApplicationInsightsContext context, TimeSpan timeSpan, [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        // No node memory-capacity metric, but usage + available sum to total, so memory-used %
+        // is 100 * usage / (usage + available). Both metrics are averaged per (node, bin) first,
+        // then combined. Series = node name.
+        var bin = MetricsBinSelector.PickBin(timeSpan);
+        var query = $@"
+AppMetrics
+| where TimeGenerated > ago({MetricsBinSelector.ToKqlLiteral(timeSpan)})
+| where Name in ('k8s.node.memory.usage', 'k8s.node.memory.available')
+| extend node = tostring(Properties['k8s.node.name'])
+| where isnotempty(node)
+| summarize val = sum(Sum) / todouble(sum(ItemCount)) by node, Name, ts = bin(TimeGenerated, {MetricsBinSelector.ToKqlLiteral(bin)})
+| extend used = iif(Name == 'k8s.node.memory.usage', val, 0.0), avail = iif(Name == 'k8s.node.memory.available', val, 0.0)
+| summarize used = sum(used), avail = sum(avail) by node, ts
+| where used + avail > 0
+| project Series = node, Timestamp = ts, Value = 100.0 * used / (used + avail)";
+        return RunMetricQueryAsync(context, query, timeSpan, $"nodemem|{context.ToKey()}|{timeSpan}", cancellationToken);
+    }
+
+    public IAsyncEnumerable<MetricSample> GetClusterPodCpuAsync(IApplicationInsightsContext context, string node, TimeSpan timeSpan, [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        // Drill-down for one node: pods scheduled on it, CPU in cores. Series = namespace/pod.
+        var bin = MetricsBinSelector.PickBin(timeSpan);
+        var nodeLiteral = EscapeKqlSingleQuoted(node);
+        var query = $@"
+AppMetrics
+| where TimeGenerated > ago({MetricsBinSelector.ToKqlLiteral(timeSpan)})
+| where Name == 'k8s.pod.cpu.usage'
+| where tostring(Properties['k8s.node.name']) == '{nodeLiteral}'
+| extend pod = strcat(tostring(Properties['k8s.namespace.name']), '/', tostring(Properties['k8s.pod.name']))
+| where isnotempty(pod)
+| summarize cores = sum(Sum) / todouble(sum(ItemCount)) by pod, bin(TimeGenerated, {MetricsBinSelector.ToKqlLiteral(bin)})
+| project Series = pod, Timestamp = TimeGenerated, Value = cores";
+        return RunMetricQueryAsync(context, query, timeSpan, $"podcpu|{context.ToKey()}|{node}|{timeSpan}", cancellationToken);
+    }
+
+    public IAsyncEnumerable<MetricSample> GetClusterPodMemoryAsync(IApplicationInsightsContext context, string node, TimeSpan timeSpan, [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        // Drill-down for one node: pods scheduled on it, memory in MB (absolute — pods have no
+        // consistent capacity to percentage against). Series = namespace/pod.
+        var bin = MetricsBinSelector.PickBin(timeSpan);
+        var nodeLiteral = EscapeKqlSingleQuoted(node);
+        var query = $@"
+AppMetrics
+| where TimeGenerated > ago({MetricsBinSelector.ToKqlLiteral(timeSpan)})
+| where Name == 'k8s.pod.memory.usage'
+| where tostring(Properties['k8s.node.name']) == '{nodeLiteral}'
+| extend pod = strcat(tostring(Properties['k8s.namespace.name']), '/', tostring(Properties['k8s.pod.name']))
+| where isnotempty(pod)
+| summarize mb = (sum(Sum) / todouble(sum(ItemCount))) / 1048576.0 by pod, bin(TimeGenerated, {MetricsBinSelector.ToKqlLiteral(bin)})
+| project Series = pod, Timestamp = TimeGenerated, Value = mb";
+        return RunMetricQueryAsync(context, query, timeSpan, $"podmem|{context.ToKey()}|{node}|{timeSpan}", cancellationToken);
+    }
+
+    public IAsyncEnumerable<MetricSample> GetClusterNodeFilesystemAsync(IApplicationInsightsContext context, TimeSpan timeSpan, [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        // usage / capacity per node → filesystem-used %. Both averaged per (node, bin) then combined.
+        var bin = MetricsBinSelector.PickBin(timeSpan);
+        var query = $@"
+AppMetrics
+| where TimeGenerated > ago({MetricsBinSelector.ToKqlLiteral(timeSpan)})
+| where Name in ('k8s.node.filesystem.usage', 'k8s.node.filesystem.capacity')
+| extend node = tostring(Properties['k8s.node.name'])
+| where isnotempty(node)
+| summarize val = sum(Sum) / todouble(sum(ItemCount)) by node, Name, ts = bin(TimeGenerated, {MetricsBinSelector.ToKqlLiteral(bin)})
+| extend used = iif(Name == 'k8s.node.filesystem.usage', val, 0.0), cap = iif(Name == 'k8s.node.filesystem.capacity', val, 0.0)
+| summarize used = sum(used), cap = sum(cap) by node, ts
+| where cap > 0
+| project Series = node, Timestamp = ts, Value = 100.0 * used / cap";
+        return RunMetricQueryAsync(context, query, timeSpan, $"nodefs|{context.ToKey()}|{timeSpan}", cancellationToken);
+    }
+
     public async IAsyncEnumerable<LogCountByServiceCell> GetLogCountByServiceAsync(IApplicationInsightsContext context, TimeSpan timeSpan, [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
         // Cache key bumped to v2 when the Machine column was added — without that suffix, a hot-

--- a/Quilt4Net.Toolkit/Features/ApplicationInsights/ApplicationInsightsService.cs
+++ b/Quilt4Net.Toolkit/Features/ApplicationInsights/ApplicationInsightsService.cs
@@ -158,6 +158,91 @@ Usage
         }
     }
 
+    public async Task<CapTimeline> GetCapTimelineAsync(IApplicationInsightsContext context, int days, CancellationToken cancellationToken = default)
+    {
+        var cacheKey = $"captimeline|{context.ToKey()}|{days}";
+        return await _timeToLiveCache.GetAsync(cacheKey, async () =>
+        {
+            try
+            {
+                var client = GetClient(context);
+                var workspaceId = context?.WorkspaceId ?? _options.WorkspaceId;
+
+                // Configured cap: latest "Daily quota changed to N" config event (rare — search wide).
+                double? capGb = null;
+                var capResp = await client.QueryWorkspaceAsync(workspaceId,
+                    "Operation | where Detail has 'Daily quota changed to' | top 1 by TimeGenerated desc | project Detail",
+                    new LogsQueryTimeRange(TimeSpan.FromDays(365)));
+                foreach (var table in capResp.Value.AllTables)
+                {
+                    var detailIdx = GetColumnIndex(table, "Detail");
+                    foreach (var row in table.Rows)
+                    {
+                        var m = System.Text.RegularExpressions.Regex.Match(row[detailIdx]?.ToString() ?? "", @"Daily quota changed to (\d+(?:\.\d+)?)");
+                        if (m.Success && double.TryParse(m.Groups[1].Value, System.Globalization.NumberStyles.Any, System.Globalization.CultureInfo.InvariantCulture, out var g)) capGb = g;
+                    }
+                }
+
+                var window = new LogsQueryTimeRange(TimeSpan.FromDays(days));
+
+                // First cap-hit per day, from the workspace "data collection stopped" operation events.
+                var hits = new Dictionary<DateTime, DateTime>();
+                var hitResp = await client.QueryWorkspaceAsync(workspaceId,
+                    "Operation | where OperationCategory == 'Data Collection Status' | where Detail has 'stopped due to daily limit' | summarize HitUtc = min(TimeGenerated) by Day = startofday(TimeGenerated)",
+                    window);
+                foreach (var table in hitResp.Value.AllTables)
+                {
+                    var dayIdx = GetColumnIndex(table, "Day");
+                    var hitIdx = GetColumnIndex(table, "HitUtc");
+                    foreach (var row in table.Rows) hits[GetDateTime(row, dayIdx)] = GetDateTime(row, hitIdx);
+                }
+
+                // Billed volume per day (GB).
+                var volume = new Dictionary<DateTime, double>();
+                var volResp = await client.QueryWorkspaceAsync(workspaceId,
+                    "Usage | where IsBillable == true | summarize Gb = sum(Quantity) / 1024.0 by Day = startofday(TimeGenerated)",
+                    window);
+                foreach (var table in volResp.Value.AllTables)
+                {
+                    var dayIdx = GetColumnIndex(table, "Day");
+                    var gbIdx = GetColumnIndex(table, "Gb");
+                    foreach (var row in table.Rows)
+                    {
+                        var raw = row[gbIdx];
+                        if (raw is null) continue;
+                        volume[GetDateTime(row, dayIdx)] = System.Convert.ToDouble(raw, System.Globalization.CultureInfo.InvariantCulture);
+                    }
+                }
+
+                var capDays = volume.Keys.Union(hits.Keys)
+                    .Distinct()
+                    .OrderByDescending(d => d)
+                    .Select(day =>
+                    {
+                        var gb = volume.GetValueOrDefault(day);
+                        DateTime? hit = hits.TryGetValue(day, out var h) ? h : null;
+                        double? est = null;
+                        if (hit.HasValue)
+                        {
+                            // Volume-at-hit ≈ the cap; extrapolate to a full day by the elapsed fraction.
+                            var hours = (hit.Value - day).TotalHours;
+                            var baseGb = capGb ?? gb;
+                            if (hours > 0) est = baseGb * 24.0 / hours;
+                        }
+                        return new CapDay { DateUtc = day, IngestedGb = gb, CapHitUtc = hit, EstimatedUncappedGb = est };
+                    })
+                    .ToArray();
+
+                return new CapTimeline { CapGb = capGb, Days = capDays };
+            }
+            catch (Exception e)
+            {
+                _logger.LogWarning(e, "Unable to build the ingestion-cap timeline (Operation/Usage not readable?). Returning empty.");
+                return new CapTimeline { CapGb = null, Days = [] };
+            }
+        });
+    }
+
     public async Task<bool> CanConnectAsync(IApplicationInsightsContext context)
     {
         var incidentId = IncidentId.New();

--- a/Quilt4Net.Toolkit/Features/ApplicationInsights/ApplicationInsightsService.cs
+++ b/Quilt4Net.Toolkit/Features/ApplicationInsights/ApplicationInsightsService.cs
@@ -102,6 +102,62 @@ union startup_pick, (log_pick | join kind=leftanti startup_pick on ApplicationNa
         _logger = logger;
     }
 
+    public async IAsyncEnumerable<VolumeBySource> GetVolumeBySourceAsync(
+        IApplicationInsightsContext context,
+        TimeSpan timeSpan,
+        [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        var cacheKey = $"volbysource|{context.ToKey()}|{timeSpan}";
+        var items = await _timeToLiveCache.GetAsync(cacheKey, async () =>
+        {
+            // Billing-grade volume straight from the Usage table — cheap, no telemetry scan.
+            const string query = @"
+Usage
+| where IsBillable == true
+| summarize Mb = sum(Quantity) by Source = DataType
+| where Mb > 0
+| order by Mb desc";
+            try
+            {
+                var client = GetClient(context);
+                var workspaceId = context?.WorkspaceId ?? _options.WorkspaceId;
+                var response = await client.QueryWorkspaceAsync(workspaceId, query, new LogsQueryTimeRange(timeSpan));
+
+                var list = new List<VolumeBySource>();
+                foreach (var table in response.Value.AllTables)
+                {
+                    var sourceIdx = GetColumnIndex(table, "Source");
+                    var mbIdx = GetColumnIndex(table, "Mb");
+                    foreach (var row in table.Rows)
+                    {
+                        var source = row[sourceIdx]?.ToString();
+                        if (string.IsNullOrEmpty(source)) continue;
+                        var raw = row[mbIdx];
+                        if (raw is null) continue;
+                        list.Add(new VolumeBySource
+                        {
+                            Source = source,
+                            Mb = System.Convert.ToDouble(raw, System.Globalization.CultureInfo.InvariantCulture)
+                        });
+                    }
+                }
+                return list.ToArray();
+            }
+            catch (Exception e)
+            {
+                // The Usage table may be unreadable (credential lacks workspace read). Degrade to
+                // empty so the cost view shows "unavailable" rather than failing the whole page.
+                _logger.LogWarning(e, "Unable to read the Usage table for volume-by-source. Returning empty.");
+                return Array.Empty<VolumeBySource>();
+            }
+        });
+        foreach (var item in items)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            yield return item;
+        }
+    }
+
     public async Task<bool> CanConnectAsync(IApplicationInsightsContext context)
     {
         var incidentId = IncidentId.New();

--- a/Quilt4Net.Toolkit/Features/ApplicationInsights/ApplicationInsightsService.cs
+++ b/Quilt4Net.Toolkit/Features/ApplicationInsights/ApplicationInsightsService.cs
@@ -1390,18 +1390,22 @@ AppMetrics
 
     public IAsyncEnumerable<MetricSample> GetClusterNodeCpuAsync(IApplicationInsightsContext context, TimeSpan timeSpan, [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
-        // k8s.node.cpu.usage is a gauge in cores. No node CPU-capacity metric exists, so we
-        // surface absolute cores rather than a percentage. Series = node name.
+        // Node CPU used %, = 100 * k8s.node.cpu.usage / k8s.node.allocatable_cpu (cores / total
+        // schedulable cores). Both averaged per (node, bin) first, then combined. Only bins where
+        // allocatable is present render — i.e. from when the collector started emitting it.
         var bin = MetricsBinSelector.PickBin(timeSpan);
         var query = $@"
 AppMetrics
 | where TimeGenerated > ago({MetricsBinSelector.ToKqlLiteral(timeSpan)})
-| where Name == 'k8s.node.cpu.usage'
+| where Name in ('k8s.node.cpu.usage', 'k8s.node.allocatable_cpu')
 | extend node = tostring(Properties['k8s.node.name'])
 | where isnotempty(node)
-| summarize cores = sum(Sum) / todouble(sum(ItemCount)) by node, bin(TimeGenerated, {MetricsBinSelector.ToKqlLiteral(bin)})
-| project Series = node, Timestamp = TimeGenerated, Value = cores";
-        return RunMetricQueryAsync(context, query, timeSpan, $"nodecpu|{context.ToKey()}|{timeSpan}", cancellationToken);
+| summarize val = sum(Sum) / todouble(sum(ItemCount)) by node, Name, ts = bin(TimeGenerated, {MetricsBinSelector.ToKqlLiteral(bin)})
+| extend used = iif(Name == 'k8s.node.cpu.usage', val, 0.0), cap = iif(Name == 'k8s.node.allocatable_cpu', val, 0.0)
+| summarize used = sum(used), cap = sum(cap) by node, ts
+| where cap > 0
+| project Series = node, Timestamp = ts, Value = 100.0 * used / cap";
+        return RunMetricQueryAsync(context, query, timeSpan, $"nodecpupct|{context.ToKey()}|{timeSpan}", cancellationToken);
     }
 
     public IAsyncEnumerable<MetricSample> GetClusterNodeMemoryAsync(IApplicationInsightsContext context, TimeSpan timeSpan, [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken = default)
@@ -1483,17 +1487,22 @@ AppMetrics
 
     public IAsyncEnumerable<MetricSample> GetClusterTotalCpuAsync(IApplicationInsightsContext context, TimeSpan timeSpan, [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
+        // Whole-cluster CPU used %, capacity-weighted: 100 * Σ usage / Σ allocatable_cpu across all
+        // nodes per bin (a 12-core node weighs 6× a 2-core one). Only bins with allocatable render.
         var bin = MetricsBinSelector.PickBin(timeSpan);
         var query = $@"
 AppMetrics
 | where TimeGenerated > ago({MetricsBinSelector.ToKqlLiteral(timeSpan)})
-| where Name == 'k8s.node.cpu.usage'
+| where Name in ('k8s.node.cpu.usage', 'k8s.node.allocatable_cpu')
 | extend node = tostring(Properties['k8s.node.name'])
 | where isnotempty(node)
-| summarize nodeCores = sum(Sum) / todouble(sum(ItemCount)) by node, ts = bin(TimeGenerated, {MetricsBinSelector.ToKqlLiteral(bin)})
-| summarize total = sum(nodeCores) by ts
-| project Series = 'Cluster', Timestamp = ts, Value = total";
-        return RunMetricQueryAsync(context, query, timeSpan, $"clustercpu|{context.ToKey()}|{timeSpan}", cancellationToken);
+| summarize val = sum(Sum) / todouble(sum(ItemCount)) by node, Name, ts = bin(TimeGenerated, {MetricsBinSelector.ToKqlLiteral(bin)})
+| extend used = iif(Name == 'k8s.node.cpu.usage', val, 0.0), cap = iif(Name == 'k8s.node.allocatable_cpu', val, 0.0)
+| summarize used = sum(used), cap = sum(cap) by node, ts
+| summarize tUsed = sum(used), tCap = sum(cap) by ts
+| where tCap > 0
+| project Series = 'Cluster', Timestamp = ts, Value = 100.0 * tUsed / tCap";
+        return RunMetricQueryAsync(context, query, timeSpan, $"clustercpupct|{context.ToKey()}|{timeSpan}", cancellationToken);
     }
 
     public IAsyncEnumerable<MetricSample> GetClusterTotalMemoryAsync(IApplicationInsightsContext context, TimeSpan timeSpan, [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken = default)

--- a/Quilt4Net.Toolkit/Features/ApplicationInsights/ApplicationInsightsService.cs
+++ b/Quilt4Net.Toolkit/Features/ApplicationInsights/ApplicationInsightsService.cs
@@ -1477,6 +1477,61 @@ AppMetrics
         return RunMetricQueryAsync(context, query, timeSpan, $"nodefs|{context.ToKey()}|{timeSpan}", cancellationToken);
     }
 
+    // Whole-cluster aggregates: average each node per bin first, THEN combine across nodes — so the
+    // result is a real capacity-weighted total (a 12-core / large-RAM node contributes more than a
+    // small one), not a mean of per-node ratios. One "Cluster" series.
+
+    public IAsyncEnumerable<MetricSample> GetClusterTotalCpuAsync(IApplicationInsightsContext context, TimeSpan timeSpan, [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        var bin = MetricsBinSelector.PickBin(timeSpan);
+        var query = $@"
+AppMetrics
+| where TimeGenerated > ago({MetricsBinSelector.ToKqlLiteral(timeSpan)})
+| where Name == 'k8s.node.cpu.usage'
+| extend node = tostring(Properties['k8s.node.name'])
+| where isnotempty(node)
+| summarize nodeCores = sum(Sum) / todouble(sum(ItemCount)) by node, ts = bin(TimeGenerated, {MetricsBinSelector.ToKqlLiteral(bin)})
+| summarize total = sum(nodeCores) by ts
+| project Series = 'Cluster', Timestamp = ts, Value = total";
+        return RunMetricQueryAsync(context, query, timeSpan, $"clustercpu|{context.ToKey()}|{timeSpan}", cancellationToken);
+    }
+
+    public IAsyncEnumerable<MetricSample> GetClusterTotalMemoryAsync(IApplicationInsightsContext context, TimeSpan timeSpan, [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        var bin = MetricsBinSelector.PickBin(timeSpan);
+        var query = $@"
+AppMetrics
+| where TimeGenerated > ago({MetricsBinSelector.ToKqlLiteral(timeSpan)})
+| where Name in ('k8s.node.memory.usage', 'k8s.node.memory.available')
+| extend node = tostring(Properties['k8s.node.name'])
+| where isnotempty(node)
+| summarize val = sum(Sum) / todouble(sum(ItemCount)) by node, Name, ts = bin(TimeGenerated, {MetricsBinSelector.ToKqlLiteral(bin)})
+| extend used = iif(Name == 'k8s.node.memory.usage', val, 0.0), avail = iif(Name == 'k8s.node.memory.available', val, 0.0)
+| summarize used = sum(used), avail = sum(avail) by node, ts
+| summarize tUsed = sum(used), tAvail = sum(avail) by ts
+| where tUsed + tAvail > 0
+| project Series = 'Cluster', Timestamp = ts, Value = 100.0 * tUsed / (tUsed + tAvail)";
+        return RunMetricQueryAsync(context, query, timeSpan, $"clustermem|{context.ToKey()}|{timeSpan}", cancellationToken);
+    }
+
+    public IAsyncEnumerable<MetricSample> GetClusterTotalFilesystemAsync(IApplicationInsightsContext context, TimeSpan timeSpan, [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        var bin = MetricsBinSelector.PickBin(timeSpan);
+        var query = $@"
+AppMetrics
+| where TimeGenerated > ago({MetricsBinSelector.ToKqlLiteral(timeSpan)})
+| where Name in ('k8s.node.filesystem.usage', 'k8s.node.filesystem.capacity')
+| extend node = tostring(Properties['k8s.node.name'])
+| where isnotempty(node)
+| summarize val = sum(Sum) / todouble(sum(ItemCount)) by node, Name, ts = bin(TimeGenerated, {MetricsBinSelector.ToKqlLiteral(bin)})
+| extend used = iif(Name == 'k8s.node.filesystem.usage', val, 0.0), cap = iif(Name == 'k8s.node.filesystem.capacity', val, 0.0)
+| summarize used = sum(used), cap = sum(cap) by node, ts
+| summarize tUsed = sum(used), tCap = sum(cap) by ts
+| where tCap > 0
+| project Series = 'Cluster', Timestamp = ts, Value = 100.0 * tUsed / tCap";
+        return RunMetricQueryAsync(context, query, timeSpan, $"clusterfs|{context.ToKey()}|{timeSpan}", cancellationToken);
+    }
+
     public async IAsyncEnumerable<LogCountByServiceCell> GetLogCountByServiceAsync(IApplicationInsightsContext context, TimeSpan timeSpan, [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
         // Cache key bumped to v2 when the Machine column was added — without that suffix, a hot-

--- a/Quilt4Net.Toolkit/Features/ApplicationInsights/CapTimeline.cs
+++ b/Quilt4Net.Toolkit/Features/ApplicationInsights/CapTimeline.cs
@@ -1,0 +1,37 @@
+namespace Quilt4Net.Toolkit.Features.ApplicationInsights;
+
+/// <summary>
+/// One day of the ingestion-cap timeline: how much was ingested, whether/when the daily cap was hit,
+/// and an estimate of what the day's volume would have been had the cap not stopped ingestion.
+/// </summary>
+public record CapDay
+{
+    /// <summary>The UTC day (midnight) this entry covers.</summary>
+    public required DateTime DateUtc { get; init; }
+
+    /// <summary>Billed volume ingested that day (GB). On a capped day this is roughly the cap.</summary>
+    public required double IngestedGb { get; init; }
+
+    /// <summary>When the daily cap was hit (UTC), or <c>null</c> if it wasn't hit that day.</summary>
+    public DateTime? CapHitUtc { get; init; }
+
+    /// <summary>
+    /// Estimated full-day volume (GB) had the cap not stopped ingestion — extrapolated from the
+    /// pre-cap rate (cap ÷ fraction-of-day-elapsed-at-hit). <c>null</c> when the cap wasn't hit, in
+    /// which case <see cref="IngestedGb"/> is already the real full-day volume.
+    /// </summary>
+    public double? EstimatedUncappedGb { get; init; }
+}
+
+/// <summary>
+/// Daily ingestion-cap timeline for a workspace: the configured daily cap plus a per-day breakdown of
+/// volume and cap-hit time. Backs the logging dashboard's cap graph.
+/// </summary>
+public record CapTimeline
+{
+    /// <summary>Configured daily cap in GB, or <c>null</c> if it couldn't be determined.</summary>
+    public double? CapGb { get; init; }
+
+    /// <summary>Per-day entries, newest first.</summary>
+    public required IReadOnlyList<CapDay> Days { get; init; }
+}

--- a/Quilt4Net.Toolkit/Features/ApplicationInsights/IApplicationInsightsService.cs
+++ b/Quilt4Net.Toolkit/Features/ApplicationInsights/IApplicationInsightsService.cs
@@ -11,6 +11,14 @@ public interface IApplicationInsightsService
     /// (permissions) rather than throwing, so the view degrades gracefully.
     /// </summary>
     IAsyncEnumerable<VolumeBySource> GetVolumeBySourceAsync(IApplicationInsightsContext context, TimeSpan timeSpan, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Daily ingestion-cap timeline over the last <paramref name="days"/> days: the configured daily
+    /// cap (GB) plus, per day, the ingested volume, the cap-hit time (from the workspace
+    /// "data collection stopped due to daily limit" operation events), and an estimate of the
+    /// uncapped volume. Degrades to an empty timeline when the Operation/Usage tables aren't readable.
+    /// </summary>
+    Task<CapTimeline> GetCapTimelineAsync(IApplicationInsightsContext context, int days, CancellationToken cancellationToken = default);
     IAsyncEnumerable<EnvironmentOption> GetEnvironments(IApplicationInsightsContext context);
     IAsyncEnumerable<LogItem> SearchAsync(IApplicationInsightsContext context, string environment, string text, TimeSpan timeSpan, SeverityLevel minSeverityLevel = SeverityLevel.Verbose, CancellationToken cancellationToken = default);
     IAsyncEnumerable<MeasureData> GetMeasureAsync(IApplicationInsightsContext context, string environment, TimeSpan timeSpan, CancellationToken cancellationToken = default);

--- a/Quilt4Net.Toolkit/Features/ApplicationInsights/IApplicationInsightsService.cs
+++ b/Quilt4Net.Toolkit/Features/ApplicationInsights/IApplicationInsightsService.cs
@@ -131,6 +131,31 @@ public interface IApplicationInsightsService
     IAsyncEnumerable<MetricSample> GetClusterNodeFilesystemAsync(IApplicationInsightsContext context, TimeSpan timeSpan, CancellationToken cancellationToken = default);
 
     /// <summary>
+    /// Whole-cluster total CPU in <b>cores</b> over <paramref name="timeSpan"/> — the sum of every
+    /// node's <c>k8s.node.cpu.usage</c> per bin (each node averaged first, then summed), so a
+    /// 12-core node contributes proportionally more than a 2-core node. <see cref="MetricSample.Series"/>
+    /// is <c>"Cluster"</c>. Reported as cores, not %, because the workspace has no node
+    /// CPU-capacity metric (enable <c>k8s.node.allocatable_cpu</c> on the collector to get a %).
+    /// </summary>
+    IAsyncEnumerable<MetricSample> GetClusterTotalCpuAsync(IApplicationInsightsContext context, TimeSpan timeSpan, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Whole-cluster total memory-used <b>percentage</b> over <paramref name="timeSpan"/>, weighted
+    /// by capacity: <c>100 * Σ usage / Σ (usage + available)</c> across all nodes per bin (so larger
+    /// nodes dominate the total). Source: <c>k8s.node.memory.usage</c> / <c>k8s.node.memory.available</c>.
+    /// <see cref="MetricSample.Series"/> is <c>"Cluster"</c>.
+    /// </summary>
+    IAsyncEnumerable<MetricSample> GetClusterTotalMemoryAsync(IApplicationInsightsContext context, TimeSpan timeSpan, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Whole-cluster total filesystem-used <b>percentage</b> over <paramref name="timeSpan"/>,
+    /// weighted by capacity: <c>100 * Σ usage / Σ capacity</c> across all nodes per bin. Source:
+    /// <c>k8s.node.filesystem.usage</c> / <c>k8s.node.filesystem.capacity</c>.
+    /// <see cref="MetricSample.Series"/> is <c>"Cluster"</c>.
+    /// </summary>
+    IAsyncEnumerable<MetricSample> GetClusterTotalFilesystemAsync(IApplicationInsightsContext context, TimeSpan timeSpan, CancellationToken cancellationToken = default);
+
+    /// <summary>
     /// Counts log entries per (service × severity × environment × source) across <c>AppTraces</c>,
     /// <c>AppExceptions</c> and <c>AppRequests</c> over <paramref name="timeSpan"/>. Severity is
     /// unified across sources: traces use their own <c>SeverityLevel</c>; exceptions are always

--- a/Quilt4Net.Toolkit/Features/ApplicationInsights/IApplicationInsightsService.cs
+++ b/Quilt4Net.Toolkit/Features/ApplicationInsights/IApplicationInsightsService.cs
@@ -3,6 +3,14 @@
 public interface IApplicationInsightsService
 {
     Task<bool> CanConnectAsync(IApplicationInsightsContext context);
+
+    /// <summary>
+    /// Billed ingestion volume (MB) per source table over <paramref name="timeSpan"/>, from the
+    /// workspace <c>Usage</c> table — billing-grade and cheap (no telemetry scan). Backs the logging
+    /// cost dashboard's per-source breakdown. Returns empty when the <c>Usage</c> table can't be read
+    /// (permissions) rather than throwing, so the view degrades gracefully.
+    /// </summary>
+    IAsyncEnumerable<VolumeBySource> GetVolumeBySourceAsync(IApplicationInsightsContext context, TimeSpan timeSpan, CancellationToken cancellationToken = default);
     IAsyncEnumerable<EnvironmentOption> GetEnvironments(IApplicationInsightsContext context);
     IAsyncEnumerable<LogItem> SearchAsync(IApplicationInsightsContext context, string environment, string text, TimeSpan timeSpan, SeverityLevel minSeverityLevel = SeverityLevel.Verbose, CancellationToken cancellationToken = default);
     IAsyncEnumerable<MeasureData> GetMeasureAsync(IApplicationInsightsContext context, string environment, TimeSpan timeSpan, CancellationToken cancellationToken = default);

--- a/Quilt4Net.Toolkit/Features/ApplicationInsights/IApplicationInsightsService.cs
+++ b/Quilt4Net.Toolkit/Features/ApplicationInsights/IApplicationInsightsService.cs
@@ -84,6 +84,53 @@ public interface IApplicationInsightsService
     IAsyncEnumerable<MetricSample> GetNetworkThroughputAsync(IApplicationInsightsContext context, TimeSpan timeSpan, CancellationToken cancellationToken = default);
 
     /// <summary>
+    /// Kubernetes node CPU usage in <b>cores</b> per node (<c>k8s.node.name</c>) over
+    /// <paramref name="timeSpan"/>. Source: kubeletstats <c>k8s.node.cpu.usage</c> (a gauge in
+    /// cores, e.g. 1.3 = 1.3 cores busy). There is no node CPU-capacity metric in the workspace,
+    /// so this is reported as absolute cores, not a percentage. <see cref="MetricSample.Series"/>
+    /// is the node name. Bin size scales with the window (see <see cref="MetricsBinSelector"/>).
+    /// </summary>
+    IAsyncEnumerable<MetricSample> GetClusterNodeCpuAsync(IApplicationInsightsContext context, TimeSpan timeSpan, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Kubernetes node memory-used <b>percentage</b> per node (<c>k8s.node.name</c>) over
+    /// <paramref name="timeSpan"/>. Computed per bin as
+    /// <c>100 * usage / (usage + available)</c> from kubeletstats <c>k8s.node.memory.usage</c>
+    /// and <c>k8s.node.memory.available</c> (there is no direct capacity metric; the pair sums to
+    /// total). <see cref="MetricSample.Series"/> is the node name. Bin size scales with the window.
+    /// </summary>
+    IAsyncEnumerable<MetricSample> GetClusterNodeMemoryAsync(IApplicationInsightsContext context, TimeSpan timeSpan, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Per-pod CPU usage in <b>cores</b> for the pods scheduled on <paramref name="node"/>
+    /// (<c>k8s.node.name</c>) over <paramref name="timeSpan"/>. Source: kubeletstats
+    /// <c>k8s.pod.cpu.usage</c>. This is the node→pod drill-down for
+    /// <see cref="GetClusterNodeCpuAsync"/>. <see cref="MetricSample.Series"/> is
+    /// <c>{k8s.namespace.name}/{k8s.pod.name}</c>. Bin size scales with the window.
+    /// </summary>
+    IAsyncEnumerable<MetricSample> GetClusterPodCpuAsync(IApplicationInsightsContext context, string node, TimeSpan timeSpan, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Per-pod memory usage in <b>MB</b> for the pods scheduled on <paramref name="node"/>
+    /// (<c>k8s.node.name</c>) over <paramref name="timeSpan"/>. Source: kubeletstats
+    /// <c>k8s.pod.memory.usage</c> (absolute bytes — pods have no consistent capacity to render a
+    /// percentage against, unlike nodes). This is the node→pod drill-down for
+    /// <see cref="GetClusterNodeMemoryAsync"/>. <see cref="MetricSample.Series"/> is
+    /// <c>{k8s.namespace.name}/{k8s.pod.name}</c>. Bin size scales with the window.
+    /// </summary>
+    IAsyncEnumerable<MetricSample> GetClusterPodMemoryAsync(IApplicationInsightsContext context, string node, TimeSpan timeSpan, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Kubernetes node filesystem-used <b>percentage</b> per node (<c>k8s.node.name</c>) over
+    /// <paramref name="timeSpan"/>. Computed as <c>100 * usage / capacity</c> from kubeletstats
+    /// <c>k8s.node.filesystem.usage</c> and <c>k8s.node.filesystem.capacity</c> — answers "is a
+    /// node running out of disk". <see cref="MetricSample.Series"/> is the node name. Bin size
+    /// scales with the window. (Host disk I/O is intentionally not surfaced: the cluster Linux
+    /// nodes' <c>system.disk.*</c> rows carry no host identity, so it cannot be attributed.)
+    /// </summary>
+    IAsyncEnumerable<MetricSample> GetClusterNodeFilesystemAsync(IApplicationInsightsContext context, TimeSpan timeSpan, CancellationToken cancellationToken = default);
+
+    /// <summary>
     /// Counts log entries per (service × severity × environment × source) across <c>AppTraces</c>,
     /// <c>AppExceptions</c> and <c>AppRequests</c> over <paramref name="timeSpan"/>. Severity is
     /// unified across sources: traces use their own <c>SeverityLevel</c>; exceptions are always

--- a/Quilt4Net.Toolkit/Features/ApplicationInsights/IApplicationInsightsService.cs
+++ b/Quilt4Net.Toolkit/Features/ApplicationInsights/IApplicationInsightsService.cs
@@ -84,11 +84,11 @@ public interface IApplicationInsightsService
     IAsyncEnumerable<MetricSample> GetNetworkThroughputAsync(IApplicationInsightsContext context, TimeSpan timeSpan, CancellationToken cancellationToken = default);
 
     /// <summary>
-    /// Kubernetes node CPU usage in <b>cores</b> per node (<c>k8s.node.name</c>) over
-    /// <paramref name="timeSpan"/>. Source: kubeletstats <c>k8s.node.cpu.usage</c> (a gauge in
-    /// cores, e.g. 1.3 = 1.3 cores busy). There is no node CPU-capacity metric in the workspace,
-    /// so this is reported as absolute cores, not a percentage. <see cref="MetricSample.Series"/>
-    /// is the node name. Bin size scales with the window (see <see cref="MetricsBinSelector"/>).
+    /// Kubernetes node CPU-used <b>percentage</b> per node (<c>k8s.node.name</c>) over
+    /// <paramref name="timeSpan"/>. Computed as <c>100 * k8s.node.cpu.usage / k8s.node.allocatable_cpu</c>
+    /// (cores used / total schedulable cores; on k3s allocatable == physical cores). Only bins where
+    /// <c>allocatable_cpu</c> is present render, so coverage starts when the collector began emitting
+    /// it. <see cref="MetricSample.Series"/> is the node name. Bin size scales with the window.
     /// </summary>
     IAsyncEnumerable<MetricSample> GetClusterNodeCpuAsync(IApplicationInsightsContext context, TimeSpan timeSpan, CancellationToken cancellationToken = default);
 
@@ -131,11 +131,10 @@ public interface IApplicationInsightsService
     IAsyncEnumerable<MetricSample> GetClusterNodeFilesystemAsync(IApplicationInsightsContext context, TimeSpan timeSpan, CancellationToken cancellationToken = default);
 
     /// <summary>
-    /// Whole-cluster total CPU in <b>cores</b> over <paramref name="timeSpan"/> — the sum of every
-    /// node's <c>k8s.node.cpu.usage</c> per bin (each node averaged first, then summed), so a
-    /// 12-core node contributes proportionally more than a 2-core node. <see cref="MetricSample.Series"/>
-    /// is <c>"Cluster"</c>. Reported as cores, not %, because the workspace has no node
-    /// CPU-capacity metric (enable <c>k8s.node.allocatable_cpu</c> on the collector to get a %).
+    /// Whole-cluster CPU-used <b>percentage</b> over <paramref name="timeSpan"/>, capacity-weighted:
+    /// <c>100 * Σ usage / Σ allocatable_cpu</c> across all nodes per bin (a 12-core node contributes
+    /// proportionally more than a 2-core node). Source: <c>k8s.node.cpu.usage</c> /
+    /// <c>k8s.node.allocatable_cpu</c>. <see cref="MetricSample.Series"/> is <c>"Cluster"</c>.
     /// </summary>
     IAsyncEnumerable<MetricSample> GetClusterTotalCpuAsync(IApplicationInsightsContext context, TimeSpan timeSpan, CancellationToken cancellationToken = default);
 

--- a/Quilt4Net.Toolkit/Features/ApplicationInsights/LogCountByServiceCell.cs
+++ b/Quilt4Net.Toolkit/Features/ApplicationInsights/LogCountByServiceCell.cs
@@ -15,8 +15,15 @@ namespace Quilt4Net.Toolkit.Features.ApplicationInsights;
 /// (<c>deployment.environment</c> → <c>AspNetCoreEnvironment</c> fallback). Empty when neither tag
 /// was logged.</param>
 /// <param name="Source">Which AI table the row came from — Trace / Exception / Request.</param>
-/// <param name="Count">Row count in the lookback window for that (service, severity, environment,
-/// source) cell.</param>
+/// <param name="Count">Retained row count in the lookback window for that (service, severity,
+/// environment, source) cell — the number of records actually kept after ingestion sampling.</param>
+/// <param name="Bytes">Retained billed bytes (<c>sum(_BilledSize)</c>) for the cell.</param>
+/// <param name="Machine">Source host / role instance the rows came from.</param>
+/// <param name="TrueCount">Sampling-corrected ("true") count: <c>sum(ItemCount)</c> — what the count
+/// would have been with no ingestion sampling. Equals <see cref="Count"/> when the cell is unsampled
+/// (every retained row represents itself, <c>ItemCount == 1</c>).</param>
+/// <param name="TrueBytes">Sampling-corrected ("true") billed bytes: <c>sum(_BilledSize * ItemCount)</c>
+/// — the estimated volume had nothing been sampled out. Equals <see cref="Bytes"/> when unsampled.</param>
 public record LogCountByServiceCell(
     string Service,
     SeverityLevel Severity,
@@ -24,4 +31,6 @@ public record LogCountByServiceCell(
     LogSource Source,
     long Count,
     long Bytes = 0,
-    string Machine = "");
+    string Machine = "",
+    long TrueCount = 0,
+    long TrueBytes = 0);

--- a/Quilt4Net.Toolkit/Features/ApplicationInsights/LogCountByServiceCell.cs
+++ b/Quilt4Net.Toolkit/Features/ApplicationInsights/LogCountByServiceCell.cs
@@ -23,4 +23,5 @@ public record LogCountByServiceCell(
     string Environment,
     LogSource Source,
     long Count,
+    long Bytes = 0,
     string Machine = "");

--- a/Quilt4Net.Toolkit/Features/ApplicationInsights/LogCubeDayCache.cs
+++ b/Quilt4Net.Toolkit/Features/ApplicationInsights/LogCubeDayCache.cs
@@ -1,0 +1,97 @@
+using System.Collections.Concurrent;
+using System.Globalization;
+
+namespace Quilt4Net.Toolkit.Features.ApplicationInsights;
+
+/// <summary>
+/// Process-wide cache of the log-count cube (<see cref="LogCountByServiceCell"/>), sliced one UTC day
+/// at a time. A finished UTC day is immutable — its telemetry never changes — so past-day chunks are
+/// cached indefinitely; the current day is refreshed on a short TTL. Multi-day views compose their
+/// window from these per-day chunks, so widening the range (or revisiting it after the TTL lapses)
+/// re-queries only the live "today" chunk instead of rescanning the whole window in Log Analytics.
+///
+/// <para>Registered as a singleton so the chunks survive across requests/circuits — that's the point;
+/// the scoped <c>LogCountCellCache</c> in the Blazor layer caches the *composed* result per circuit,
+/// this caches the *day slices* under it, process-wide.</para>
+///
+/// <para>Sub-day ranges (1h / 24h) don't use this — a rolling sub-day window can't be assembled from
+/// whole-day chunks, so those stay on the live single-query path.</para>
+/// </summary>
+internal sealed class LogCubeDayCache
+{
+    private readonly record struct DayEntry(LogCountByServiceCell[] Cells, DateTimeOffset LoadedAt);
+
+    private readonly ConcurrentDictionary<string, DayEntry> _days = new();
+    private readonly TimeSpan _todayTtl;
+    private readonly Func<DateTimeOffset> _utcNow;
+
+    // Bound memory: a day chunk older than this is dropped on the next access. Comfortably wider than
+    // the widest range the UI offers (90 days) so nothing in active use is ever evicted.
+    private const int RetentionDays = 100;
+
+    public LogCubeDayCache(TimeSpan todayTtl, Func<DateTimeOffset> utcNow)
+    {
+        _todayTtl = todayTtl;
+        _utcNow = utcNow;
+    }
+
+    /// <summary>
+    /// Return the cube for a single UTC day, fetching+caching it on a miss. Past days are served from
+    /// cache forever once loaded; the current (or, under clock skew, a future) day re-fetches once its
+    /// chunk is older than the configured today-TTL. <paramref name="fetch"/> supplies the day from
+    /// source — the cache stays agnostic of how the day is queried.
+    /// </summary>
+    public async Task<LogCountByServiceCell[]> GetDayAsync(string workspaceKey, DateOnly dateUtc, Func<DateOnly, Task<LogCountByServiceCell[]>> fetch)
+    {
+        var now = _utcNow();
+        var today = DateOnly.FromDateTime(now.UtcDateTime);
+        var key = $"{workspaceKey}|{dateUtc:yyyy-MM-dd}";
+        var mutable = dateUtc >= today; // today (or a future date from clock skew) can still change
+
+        if (_days.TryGetValue(key, out var entry))
+        {
+            if (!mutable) return entry.Cells;
+            if (now - entry.LoadedAt < _todayTtl) return entry.Cells;
+        }
+
+        var cells = await fetch(dateUtc);
+        _days[key] = new DayEntry(cells, now);
+        Evict(today);
+        return cells;
+    }
+
+    private void Evict(DateOnly today)
+    {
+        foreach (var k in _days.Keys)
+        {
+            var bar = k.LastIndexOf('|');
+            if (bar < 0) continue;
+            if (DateOnly.TryParse(k.AsSpan(bar + 1), CultureInfo.InvariantCulture, out var d)
+                && today.DayNumber - d.DayNumber > RetentionDays)
+            {
+                _days.TryRemove(k, out _);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Sum the cells that share a (Service, Severity, Environment, Source, Machine) key across the
+    /// supplied per-day chunks into one cell each — the retained and sampling-corrected figures all
+    /// add. Used to fold a composed multi-day window back into the flat cube shape the views expect.
+    /// </summary>
+    public static LogCountByServiceCell[] Merge(IEnumerable<LogCountByServiceCell> cells)
+    {
+        var acc = new Dictionary<(string Service, SeverityLevel Severity, string Environment, LogSource Source, string Machine), (long Count, long Bytes, long TrueCount, long TrueBytes)>();
+        foreach (var c in cells)
+        {
+            var key = (c.Service, c.Severity, c.Environment, c.Source, c.Machine);
+            var cur = acc.GetValueOrDefault(key);
+            acc[key] = (cur.Count + c.Count, cur.Bytes + c.Bytes, cur.TrueCount + c.TrueCount, cur.TrueBytes + c.TrueBytes);
+        }
+        return acc
+            .Select(kv => new LogCountByServiceCell(
+                kv.Key.Service, kv.Key.Severity, kv.Key.Environment, kv.Key.Source,
+                kv.Value.Count, kv.Value.Bytes, kv.Key.Machine, kv.Value.TrueCount, kv.Value.TrueBytes))
+            .ToArray();
+    }
+}

--- a/Quilt4Net.Toolkit/Features/ApplicationInsights/LogSource.cs
+++ b/Quilt4Net.Toolkit/Features/ApplicationInsights/LogSource.cs
@@ -4,5 +4,9 @@ public enum LogSource
 {
     Exception,
     Trace,
-    Request
+    Request,
+    Dependency,
+    Event,
+    PageView,
+    Availability
 }

--- a/Quilt4Net.Toolkit/Features/ApplicationInsights/LogSource.cs
+++ b/Quilt4Net.Toolkit/Features/ApplicationInsights/LogSource.cs
@@ -7,6 +7,5 @@ public enum LogSource
     Request,
     Dependency,
     Event,
-    PageView,
-    Availability
+    PageView
 }

--- a/Quilt4Net.Toolkit/Features/ApplicationInsights/VolumeBySource.cs
+++ b/Quilt4Net.Toolkit/Features/ApplicationInsights/VolumeBySource.cs
@@ -1,0 +1,15 @@
+namespace Quilt4Net.Toolkit.Features.ApplicationInsights;
+
+/// <summary>
+/// Billed ingestion volume for a single source table (Log Analytics <c>DataType</c>, e.g.
+/// <c>AppMetrics</c>, <c>AppTraces</c>) over a window — the cost breakdown that drives the logging
+/// cost dashboard's source pie. Sourced from the workspace <c>Usage</c> table (billing-grade).
+/// </summary>
+public record VolumeBySource
+{
+    /// <summary>Source table / data type (the Log Analytics <c>DataType</c>).</summary>
+    public required string Source { get; init; }
+
+    /// <summary>Billed ingestion volume in megabytes over the window.</summary>
+    public required double Mb { get; init; }
+}

--- a/Quilt4Net.Toolkit/Features/Content/RemoteContentCallService.cs
+++ b/Quilt4Net.Toolkit/Features/Content/RemoteContentCallService.cs
@@ -58,9 +58,12 @@ internal class RemoteContentCallService : IRemoteContentCallService
             _localCache.TryGetValue(cacheKey, out var cached);
             var needRefresh = cached == null || DateTime.UtcNow > cached.ValidTo;
 
+            // Per-resolution result lines are Debug — they fire on every content read (typically a
+            // 0ms cache hit) and flooded Information traces in production. Errors/warnings still log
+            // at their original levels. Matches RemoteConfigCallService.
             if (!needRefresh)
             {
-                _logger.LogInformation("Content '{Key}' resolved in {Elapsed}ms. Source: Cache, Stale: false.",
+                _logger.LogDebug("Content '{Key}' resolved in {Elapsed}ms. Source: Cache, Stale: false.",
                     key, sw.ElapsedMilliseconds);
                 return (cached.Value ?? defaultValue, true);
             }
@@ -70,7 +73,7 @@ internal class RemoteContentCallService : IRemoteContentCallService
             if (cached != null && _contentOptions.StaleWhileRevalidate)
             {
                 StartBackgroundRefresh(key, cacheKey, defaultValue, languageKey, contentType, effectiveApplication);
-                _logger.LogInformation("Content '{Key}' resolved in {Elapsed}ms. Source: StaleCache, Stale: true.",
+                _logger.LogDebug("Content '{Key}' resolved in {Elapsed}ms. Source: StaleCache, Stale: true.",
                     key, sw.ElapsedMilliseconds);
                 return (cached.Value ?? defaultValue, true);
             }
@@ -85,7 +88,7 @@ internal class RemoteContentCallService : IRemoteContentCallService
             var staleValue = stale?.Value ?? defaultValue;
             _logger.LogError(e, "{Message} Using stale cache or fallback for key {Key}.", e.Message, key);
             CacheFailure(cacheKey, staleValue);
-            _logger.LogInformation("Content '{Key}' resolved in {Elapsed}ms. Source: {Source}, Stale: true.",
+            _logger.LogDebug("Content '{Key}' resolved in {Elapsed}ms. Source: {Source}, Stale: true.",
                 key, sw.ElapsedMilliseconds, stale != null ? "StaleCache" : "Default");
             return (staleValue, false);
         }
@@ -255,7 +258,7 @@ internal class RemoteContentCallService : IRemoteContentCallService
                 _logger.LogError("Unable to get content for key '{Key}'. Response was {StatusCode} {ReasonPhrase}.",
                     key, response.StatusCode, response.ReasonPhrase);
                 CacheFailure(cacheKey, defaultValue);
-                _logger.LogInformation("Content '{Key}' resolved in {Elapsed}ms. Source: Default, Stale: true.",
+                _logger.LogDebug("Content '{Key}' resolved in {Elapsed}ms. Source: Default, Stale: true.",
                     key, sw.ElapsedMilliseconds);
                 return (defaultValue, false);
             }
@@ -268,7 +271,7 @@ internal class RemoteContentCallService : IRemoteContentCallService
 
             _localCache.AddOrUpdate(cacheKey, result, (_, _) => result);
 
-            _logger.LogInformation("Content '{Key}' resolved in {Elapsed}ms. Source: Server, Stale: false.",
+            _logger.LogDebug("Content '{Key}' resolved in {Elapsed}ms. Source: Server, Stale: false.",
                 key, sw.ElapsedMilliseconds);
             return (result.Value ?? defaultValue, true);
         }
@@ -277,7 +280,7 @@ internal class RemoteContentCallService : IRemoteContentCallService
             _logger.LogWarning("HTTP request timed out for content '{Key}' after {Timeout}ms. Using default value.",
                 key, _contentOptions.HttpTimeout.TotalMilliseconds);
             CacheFailure(cacheKey, defaultValue);
-            _logger.LogInformation("Content '{Key}' resolved in {Elapsed}ms. Source: Default, Stale: true.",
+            _logger.LogDebug("Content '{Key}' resolved in {Elapsed}ms. Source: Default, Stale: true.",
                 key, sw.ElapsedMilliseconds);
             return (defaultValue, false);
         }
@@ -285,7 +288,7 @@ internal class RemoteContentCallService : IRemoteContentCallService
         {
             _logger.LogError(e, "{Message} Using default for content key {Key}.", e.Message, key);
             CacheFailure(cacheKey, defaultValue);
-            _logger.LogInformation("Content '{Key}' resolved in {Elapsed}ms. Source: Default, Stale: true.",
+            _logger.LogDebug("Content '{Key}' resolved in {Elapsed}ms. Source: Default, Stale: true.",
                 key, sw.ElapsedMilliseconds);
             return (defaultValue, false);
         }

--- a/docs/articles/log-views.md
+++ b/docs/articles/log-views.md
@@ -147,6 +147,10 @@ Cascading `LogNavigationOptions` is honoured for detail drill-downs — when a h
 
 A pivot of log counts grouped by service across the Verbose / Information / Warning / Error / Critical severity columns, with multi-select filters for Configuration, Environment and Source, plus a "Per machine" toggle that splits each service row by machine. Every filter except Range is a local regroup over the cached cell cube — only Range changes hit AI. Same component Quilt4Net Server's `/developer/log-count` page uses.
 
+A **Show: Count / Volume** toggle flips every cell, total and pie between record count and billed ingestion volume (`_BilledSize`, auto-scaled GB/MB/KB) — a pure local recompute, since both ride on every cached cell. Two marginal pies sit below the grid: **By severity** (the table's bottom totals) and **By service** (its right totals), both following the active metric and filters.
+
+A **Sampling** section reports what the current selection would have ingested with no [ingestion sampling](https://learn.microsoft.com/azure/azure-monitor/app/sampling). Each cell carries a sampling-corrected `TrueCount = sum(ItemCount)` and `TrueBytes = sum(_BilledSize * ItemCount)` beside the retained figures; the section shows the overall effective rate ("X% of records retained, showing A of an estimated B without sampling") and a per-source table (Retained / Est. true / Retained %). When `ItemCount` is 1 everywhere — i.e. nothing is sampled — it says so plainly, which is itself the answer to "are we sampling?". `AppMetrics` is excluded (its `ItemCount` is an aggregation count, not a sampling weight).
+
 ```razor
 @using Quilt4Net.Toolkit.Blazor.Features.Log
 
@@ -164,6 +168,48 @@ Ranges (1h / 24h / 7d) and the Refresh button work the same way as in [`MetricsV
 ### Remote vs local mode
 
 The same `Context` precedence applies to `LogView` / `VersionMatrixDisplay` / `MetricsView` / `LogCountByServiceView`. Hosts that already resolved a `Context` from local options *and* registered the remote selector can pick one explicitly — see [Metrics → Remote vs local mode](metrics.md#remote-vs-local-mode).
+
+## Cost & volume
+
+Two components turn the same workspace into a cost picture — what you ingest, and how close it runs to the daily cap. Both read billing-grade data from the `Usage` table (and, for the cap, the `Operation` table), so the numbers reconcile with the Azure bill rather than with sampled telemetry counts.
+
+### `LogVolumeView` — billed ingestion by source
+
+A pie of billed ingestion volume grouped by source table (`DataType`), a total for the window, and a sortable table (Source / Size / Share). Size auto-scales to GB/MB/KB; the column sorts on the raw value so ordering is correct regardless of the unit shown.
+
+```razor
+@using Quilt4Net.Toolkit.Blazor.Features.Log
+
+<LogVolumeView Context="@ApplicationInsightsContextExtensions.Current"
+               Range="TimeSpan.FromDays(7)" />
+```
+
+| Parameter | Type | Default | Notes |
+|---|---|---|---|
+| `Context` | `IApplicationInsightsContext` | `null` | Workspace to query. When null, resolved via the DI selector / configured options. |
+| `Range` | `TimeSpan` | `7 days` | Initial lookback; the in-view **1h / 24h / 7d** selector changes it. |
+
+When the `Usage` table can't be read (or is empty for the range) the view shows an informational alert instead of an empty chart.
+
+### `CapTimelineView` — daily ingestion-cap graph
+
+A per-UTC-day view of billed volume against the configured daily cap: one column per day, a dashed reference line at the cap, and diamond markers for the **estimated uncapped** volume on days the cap was hit (`cap × 24 / hours-to-hit` — what the day would have ingested unthrottled). The grid below gives the precise first-hit time per day.
+
+```razor
+@using Quilt4Net.Toolkit.Blazor.Features.Log
+
+<CapTimelineView Context="@ApplicationInsightsContextExtensions.Current"
+                 Days="30" />
+```
+
+| Parameter | Type | Default | Notes |
+|---|---|---|---|
+| `Context` | `IApplicationInsightsContext` | `null` | Workspace to query. When null, resolved via the DI selector / configured options. |
+| `Days` | `int` | `30` | Initial range; the in-view **14 / 30 / 90 days** selector changes it. |
+
+The cap value comes from the latest `"Daily quota changed to N"` config event in the `Operation` table; first-hit times from the `"stopped due to daily limit"` events. With no cap configured the view drops the reference line and just charts daily volume; when neither table is readable it shows an informational alert. The daily cap is a *soft* limit — ingestion isn't hard-stopped at the cap, so days can finish above it, which is exactly why the est.-uncapped overlay is worth showing.
+
+Both components honour the same remote/local `Context` precedence as the other views — pass an explicit `Context`, or let the DI selector drive them. On Quilt4Net Server they appear as the **Logging volume** and **Daily cap** tabs on `/monitor/metrics` and `/developer/metrics`.
 
 ## Where next
 


### PR DESCRIPTION
Integration branch → master. Ships two feature sets that were developed on this branch, plus a few fixes. On merge, CI publishes the next release (0.9.1).

## 1. Cluster / host metrics (metrics-cluster-pods)
- Cluster node CPU / memory / filesystem charts with node → pod drill-down.
- Physical vs Cluster split into tabs; capacity-weighted cluster-total toggle.
- Node CPU and cluster-total CPU rendered as % (allocatable_cpu).
- Fixes: date-aware axis labels on multi-day charts; drop host-less rows from Hosts charts; derive the node list from the union of node series.

## 2. Logging cost & volume dashboard (log-cost-insights, PR #116)
- **`LogVolumeView`** — billed ingestion by source table (pie + total + sortable Size/Share, auto-unit), 1h/24h/7d.
- **`CapTimelineView`** — daily billed volume vs the ingestion cap (cap line, est-uncapped markers, first-hit times), 14/30/90-day.
- **`LogCountByServiceView`** — count↔volume toggle, severity/service pies, data-driven source filter, alias folding, and **sampling correction** (retained vs `sum(ItemCount)` true count/volume + per-source rate).
- **Day-chunk cache (`LogCubeDayCache`)** — multi-day log-count windows compose from immutable per-UTC-day chunks (live "today" on a short TTL). Note: 7d is now calendar-aligned, consistent with the cap graph.
- Docs: `docs/articles/log-views.md` "Cost & volume" + Blazor README.

## Validation
Builds clean; **174 Core + 121 Blazor tests** green. All cost/volume/cap KQL validated read-only against a real prod workspace; billing-grade data from `Usage` + `Operation`, not sampled telemetry counts.
