### PR TITLE
fix: health dependency probe degrades on non-success instead of crashing (#119)

### DIFF
--- a/Quilt4Net.Toolkit.Api.Sample/Quilt4Net.Toolkit.Api.Sample.csproj
+++ b/Quilt4Net.Toolkit.Api.Sample/Quilt4Net.Toolkit.Api.Sample.csproj
@@ -12,7 +12,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="10.2.1" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="10.2.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Quilt4Net.Toolkit.Blazor/Quilt4Net.Toolkit.Blazor.csproj
+++ b/Quilt4Net.Toolkit.Blazor/Quilt4Net.Toolkit.Blazor.csproj
@@ -26,7 +26,7 @@
        consumers can fetch _content/Quilt4Net.Toolkit.Blazor/<asset> at runtime. -->
   <ItemGroup>
     <PackageReference Include="Microsoft.Authentication.WebAssembly.Msal" Version="10.0.9" />
-    <PackageReference Include="Microsoft.Identity.Client" Version="4.84.2" />
+    <PackageReference Include="Microsoft.Identity.Client" Version="4.85.0" />
     <PackageReference Include="Tharga.Blazor" Version="2.2.0" />
   </ItemGroup>
   <ItemGroup>

--- a/Quilt4Net.Toolkit.Health.Tests/DefaultDependencyProbeTests.cs
+++ b/Quilt4Net.Toolkit.Health.Tests/DefaultDependencyProbeTests.cs
@@ -1,0 +1,123 @@
+using System.Net;
+using System.Text;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Quilt4Net.Toolkit.Features.Api;
+using Quilt4Net.Toolkit.Features.Health;
+using Quilt4Net.Toolkit.Features.Health.Dependency;
+using Xunit;
+
+namespace Quilt4Net.Toolkit.Health.Tests;
+
+public class DefaultDependencyProbeTests
+{
+    private static readonly Dependency Dependency = new() { Name = "dep", Uri = new Uri("https://dependency.test/"), Essential = false };
+
+    [Fact]
+    public async Task NonSuccessResponse_ReturnsUnhealthyWithStatusCode_DoesNotThrow()
+    {
+        //Arrange
+        var logger = new CapturingLogger<DefaultDependencyProbe>();
+        var probe = new DefaultDependencyProbe(new Quilt4NetHealthApiOptions(), logger)
+        {
+            HandlerFactory = () => new StubHandler(HttpStatusCode.TooManyRequests, "Too Many Requests", "text/plain")
+        };
+
+        //Act
+        var content = await probe.ProbeAsync(Dependency, CancellationToken.None);
+
+        //Assert
+        content.Status.Should().Be(HealthStatus.Unhealthy);
+        content.Components.Should().ContainKey("Probe");
+        var component = content.Components["Probe"];
+        component.Status.Should().Be(HealthStatus.Unhealthy);
+        component.Details.Should().ContainKey("StatusCode");
+        component.Details["StatusCode"].Should().Be("429");
+        logger.Entries.Should().Contain(e => e.Level == LogLevel.Warning);
+    }
+
+    [Fact]
+    public async Task SuccessResponse_ReturnsParsedContent_NoWarning()
+    {
+        //Arrange
+        const string json = """{"Status":"Healthy","Components":{"Db":{"Status":"Healthy"}}}""";
+        var options = new Quilt4NetHealthApiOptions { Certificate = new CertificateCheckOptions { DependencyCheckEnabled = false } };
+        var logger = new CapturingLogger<DefaultDependencyProbe>();
+        var probe = new DefaultDependencyProbe(options, logger)
+        {
+            HandlerFactory = () => new StubHandler(HttpStatusCode.OK, json, "application/json")
+        };
+
+        //Act
+        var content = await probe.ProbeAsync(Dependency, CancellationToken.None);
+
+        //Assert
+        content.Status.Should().Be(HealthStatus.Healthy);
+        content.Components.Should().ContainKey("Db");
+        logger.Entries.Should().NotContain(e => e.Level == LogLevel.Warning);
+    }
+
+    [Fact]
+    public async Task TransportFailure_ReturnsUnhealthy_DoesNotThrow()
+    {
+        //Arrange
+        var logger = new CapturingLogger<DefaultDependencyProbe>();
+        var probe = new DefaultDependencyProbe(new Quilt4NetHealthApiOptions(), logger)
+        {
+            HandlerFactory = () => new ThrowingHandler(new HttpRequestException("boom"))
+        };
+
+        //Act
+        var content = await probe.ProbeAsync(Dependency, CancellationToken.None);
+
+        //Assert
+        content.Status.Should().Be(HealthStatus.Unhealthy);
+        content.Components.Should().ContainKey("Probe");
+        logger.Entries.Should().Contain(e => e.Level == LogLevel.Warning);
+    }
+
+    private sealed class StubHandler : HttpMessageHandler
+    {
+        private readonly HttpStatusCode _status;
+        private readonly string _content;
+        private readonly string _mediaType;
+
+        public StubHandler(HttpStatusCode status, string content, string mediaType)
+        {
+            _status = status;
+            _content = content;
+            _mediaType = mediaType;
+        }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            => Task.FromResult(new HttpResponseMessage(_status) { Content = new StringContent(_content, Encoding.UTF8, _mediaType) });
+    }
+
+    private sealed class ThrowingHandler : HttpMessageHandler
+    {
+        private readonly Exception _exception;
+
+        public ThrowingHandler(Exception exception) => _exception = exception;
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            => throw _exception;
+    }
+
+    private sealed class CapturingLogger<T> : ILogger<T>
+    {
+        public readonly List<(LogLevel Level, string Message)> Entries = new();
+
+        public IDisposable BeginScope<TState>(TState state) where TState : notnull => NullScope.Instance;
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter)
+            => Entries.Add((logLevel, formatter(state, exception)));
+
+        private sealed class NullScope : IDisposable
+        {
+            public static readonly NullScope Instance = new();
+            public void Dispose() { }
+        }
+    }
+}

--- a/Quilt4Net.Toolkit.Health.Tests/DefaultDependencyProbeTests.cs
+++ b/Quilt4Net.Toolkit.Health.Tests/DefaultDependencyProbeTests.cs
@@ -24,7 +24,7 @@ public class DefaultDependencyProbeTests
         };
 
         //Act
-        var content = await probe.ProbeAsync(Dependency, CancellationToken.None);
+        var content = await probe.ProbeAsync(Dependency, TestContext.Current.CancellationToken);
 
         //Assert
         content.Status.Should().Be(HealthStatus.Unhealthy);
@@ -49,7 +49,7 @@ public class DefaultDependencyProbeTests
         };
 
         //Act
-        var content = await probe.ProbeAsync(Dependency, CancellationToken.None);
+        var content = await probe.ProbeAsync(Dependency, TestContext.Current.CancellationToken);
 
         //Assert
         content.Status.Should().Be(HealthStatus.Healthy);
@@ -68,7 +68,7 @@ public class DefaultDependencyProbeTests
         };
 
         //Act
-        var content = await probe.ProbeAsync(Dependency, CancellationToken.None);
+        var content = await probe.ProbeAsync(Dependency, TestContext.Current.CancellationToken);
 
         //Assert
         content.Status.Should().Be(HealthStatus.Unhealthy);

--- a/Quilt4Net.Toolkit.Health.Tests/DependencyServiceTests.cs
+++ b/Quilt4Net.Toolkit.Health.Tests/DependencyServiceTests.cs
@@ -23,7 +23,7 @@ public class DependencyServiceTests
         var sut = new DependencyService(probe, OptionsWith(essential), new ManualTimeProvider());
 
         //Act
-        var result = await sut.GetStatusAsync(CancellationToken.None).ToArrayAsync();
+        var result = await sut.GetStatusAsync(TestContext.Current.CancellationToken).ToArrayAsync(TestContext.Current.CancellationToken);
 
         //Assert
         var component = result.Single();
@@ -42,7 +42,7 @@ public class DependencyServiceTests
         //Act
         for (var i = 0; i < 5; i++)
         {
-            _ = await sut.GetStatusAsync(CancellationToken.None).ToArrayAsync();
+            _ = await sut.GetStatusAsync(TestContext.Current.CancellationToken).ToArrayAsync(TestContext.Current.CancellationToken);
         }
 
         //Assert
@@ -60,9 +60,9 @@ public class DependencyServiceTests
         var sut = new DependencyService(probe, options, time);
 
         //Act
-        _ = await sut.GetStatusAsync(CancellationToken.None).ToArrayAsync();
+        _ = await sut.GetStatusAsync(TestContext.Current.CancellationToken).ToArrayAsync(TestContext.Current.CancellationToken);
         time.Advance(TimeSpan.FromSeconds(11));
-        _ = await sut.GetStatusAsync(CancellationToken.None).ToArrayAsync();
+        _ = await sut.GetStatusAsync(TestContext.Current.CancellationToken).ToArrayAsync(TestContext.Current.CancellationToken);
 
         //Assert
         probe.CallCount.Should().Be(2);
@@ -80,7 +80,7 @@ public class DependencyServiceTests
         //Act
         for (var i = 0; i < 3; i++)
         {
-            _ = await sut.GetStatusAsync(CancellationToken.None).ToArrayAsync();
+            _ = await sut.GetStatusAsync(TestContext.Current.CancellationToken).ToArrayAsync(TestContext.Current.CancellationToken);
         }
 
         //Assert
@@ -97,9 +97,9 @@ public class DependencyServiceTests
 
         //Act
         var calls = Enumerable.Range(0, 10)
-            .Select(_ => sut.GetStatusAsync(CancellationToken.None).ToArrayAsync().AsTask())
+            .Select(_ => sut.GetStatusAsync(TestContext.Current.CancellationToken).ToArrayAsync(TestContext.Current.CancellationToken).AsTask())
             .ToArray();
-        await Task.Delay(100);
+        await Task.Delay(100, TestContext.Current.CancellationToken);
         gate.SetResult();
         await Task.WhenAll(calls);
 

--- a/Quilt4Net.Toolkit.Health.Tests/DependencyServiceTests.cs
+++ b/Quilt4Net.Toolkit.Health.Tests/DependencyServiceTests.cs
@@ -1,0 +1,172 @@
+using FluentAssertions;
+using Quilt4Net.Toolkit.Features.Api;
+using Quilt4Net.Toolkit.Features.Health;
+using Quilt4Net.Toolkit.Features.Health.Dependency;
+using Xunit;
+
+namespace Quilt4Net.Toolkit.Health.Tests;
+
+public class DependencyServiceTests
+{
+    private static readonly Uri DependencyUri = new("https://dependency.test/");
+
+    [Theory]
+    [InlineData(true, HealthStatus.Healthy, HealthStatus.Healthy)]
+    [InlineData(false, HealthStatus.Healthy, HealthStatus.Healthy)]
+    [InlineData(true, HealthStatus.Unhealthy, HealthStatus.Unhealthy)]
+    [InlineData(false, HealthStatus.Unhealthy, HealthStatus.Degraded)]
+    [InlineData(true, HealthStatus.Degraded, HealthStatus.Degraded)]
+    public async Task MapsProbeStatusToComponentStatus(bool essential, HealthStatus probeStatus, HealthStatus expected)
+    {
+        //Arrange
+        var probe = new FakeProbe(_ => Response(probeStatus));
+        var sut = new DependencyService(probe, OptionsWith(essential), new ManualTimeProvider());
+
+        //Act
+        var result = await sut.GetStatusAsync(CancellationToken.None).ToArrayAsync();
+
+        //Assert
+        var component = result.Single();
+        component.Key.Should().Be("dep");
+        component.Value.Status.Should().Be(expected);
+        component.Value.Uri.Should().Be(DependencyUri);
+    }
+
+    [Fact]
+    public async Task RepeatedCallsWithinCacheWindow_ProbeOnce()
+    {
+        //Arrange
+        var probe = new FakeProbe(_ => Response(HealthStatus.Healthy));
+        var sut = new DependencyService(probe, OptionsWith(essential: true), new ManualTimeProvider());
+
+        //Act
+        for (var i = 0; i < 5; i++)
+        {
+            _ = await sut.GetStatusAsync(CancellationToken.None).ToArrayAsync();
+        }
+
+        //Assert
+        probe.CallCount.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task AfterCacheWindowExpires_ProbesAgain()
+    {
+        //Arrange
+        var probe = new FakeProbe(_ => Response(HealthStatus.Healthy));
+        var options = OptionsWith(essential: true);
+        options.DependencyProbeCacheTime = TimeSpan.FromSeconds(10);
+        var time = new ManualTimeProvider();
+        var sut = new DependencyService(probe, options, time);
+
+        //Act
+        _ = await sut.GetStatusAsync(CancellationToken.None).ToArrayAsync();
+        time.Advance(TimeSpan.FromSeconds(11));
+        _ = await sut.GetStatusAsync(CancellationToken.None).ToArrayAsync();
+
+        //Assert
+        probe.CallCount.Should().Be(2);
+    }
+
+    [Fact]
+    public async Task CacheDisabled_ProbesEveryCall()
+    {
+        //Arrange
+        var probe = new FakeProbe(_ => Response(HealthStatus.Healthy));
+        var options = OptionsWith(essential: true);
+        options.DependencyProbeCacheTime = TimeSpan.Zero;
+        var sut = new DependencyService(probe, options, new ManualTimeProvider());
+
+        //Act
+        for (var i = 0; i < 3; i++)
+        {
+            _ = await sut.GetStatusAsync(CancellationToken.None).ToArrayAsync();
+        }
+
+        //Assert
+        probe.CallCount.Should().Be(3);
+    }
+
+    [Fact]
+    public async Task ConcurrentCalls_AreCoalescedToOneProbe()
+    {
+        //Arrange
+        var gate = new TaskCompletionSource();
+        var probe = new GatedProbe(gate.Task, () => Response(HealthStatus.Healthy));
+        var sut = new DependencyService(probe, OptionsWith(essential: true), new ManualTimeProvider());
+
+        //Act
+        var calls = Enumerable.Range(0, 10)
+            .Select(_ => sut.GetStatusAsync(CancellationToken.None).ToArrayAsync().AsTask())
+            .ToArray();
+        await Task.Delay(100);
+        gate.SetResult();
+        await Task.WhenAll(calls);
+
+        //Assert
+        probe.CallCount.Should().Be(1);
+    }
+
+    private static Quilt4NetHealthApiOptions OptionsWith(bool essential)
+    {
+        var options = new Quilt4NetHealthApiOptions();
+        options.AddDependency(new Dependency { Name = "dep", Uri = DependencyUri, Essential = essential });
+        return options;
+    }
+
+    private static HealthResponse Response(HealthStatus status) => new()
+    {
+        Status = status,
+        Components = new Dictionary<string, HealthComponent>
+        {
+            ["Probe"] = new HealthComponent { Status = status }
+        }
+    };
+
+    private sealed class FakeProbe : IDependencyProbe
+    {
+        private readonly Func<Dependency, HealthResponse> _factory;
+        private int _callCount;
+
+        public FakeProbe(Func<Dependency, HealthResponse> factory) => _factory = factory;
+
+        public int CallCount => _callCount;
+
+        public Task<HealthResponse> ProbeAsync(Dependency dependency, CancellationToken cancellationToken)
+        {
+            Interlocked.Increment(ref _callCount);
+            return Task.FromResult(_factory(dependency));
+        }
+    }
+
+    private sealed class GatedProbe : IDependencyProbe
+    {
+        private readonly Task _gate;
+        private readonly Func<HealthResponse> _factory;
+        private int _callCount;
+
+        public GatedProbe(Task gate, Func<HealthResponse> factory)
+        {
+            _gate = gate;
+            _factory = factory;
+        }
+
+        public int CallCount => _callCount;
+
+        public async Task<HealthResponse> ProbeAsync(Dependency dependency, CancellationToken cancellationToken)
+        {
+            Interlocked.Increment(ref _callCount);
+            await _gate;
+            return _factory();
+        }
+    }
+
+    private sealed class ManualTimeProvider : TimeProvider
+    {
+        private DateTimeOffset _now = new(2026, 1, 1, 0, 0, 0, TimeSpan.Zero);
+
+        public override DateTimeOffset GetUtcNow() => _now;
+
+        public void Advance(TimeSpan delta) => _now += delta;
+    }
+}

--- a/Quilt4Net.Toolkit.Health/HealthRegistration.cs
+++ b/Quilt4Net.Toolkit.Health/HealthRegistration.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Mvc.Abstractions;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Options;
 using Quilt4Net.Toolkit.Features.Api;
 using Quilt4Net.Toolkit.Features.Health;
@@ -61,10 +62,13 @@ public static class HealthRegistration
         services.AddSingleton<IActionDescriptorProvider, CustomRouteDescriptorProvider>();
         services.AddSingleton<IHostedServiceProbeRegistry, HostedServiceProbeRegistry>();
 
+        services.TryAddSingleton(TimeProvider.System);
+
         services.AddTransient<ILiveService, LiveService>();
         services.AddTransient<IReadyService, ReadyService>();
         services.AddTransient<IHealthService, HealthService>();
-        services.AddTransient<IDependencyService, DependencyService>();
+        services.AddSingleton<IDependencyProbe, DefaultDependencyProbe>();
+        services.AddSingleton<IDependencyService, DependencyService>();
         services.AddTransient<IVersionService, VersionService>();
         services.AddTransient<IMachineMetricsService, MachineMetricsService>();
         services.AddTransient<IMetricsService, MetricsService>();

--- a/Quilt4Net.Toolkit.Health/README.md
+++ b/Quilt4Net.Toolkit.Health/README.md
@@ -292,6 +292,34 @@ builder.AddQuilt4NetHealth(o =>
 });
 ```
 
+### Behaviour on a failing dependency
+
+A dependency probe never throws. If a dependency returns a non-success status code (e.g. `429 Too Many Requests`), an error page, or is unreachable, it is reported as:
+
+- **`Unhealthy`** when the dependency is `Essential = true`
+- **`Degraded`** when the dependency is `Essential = false`
+
+The HTTP status code (or error message) is included in the component's `Details`, and a single `Warning` is logged — never an `Error`. A rate-limited or temporarily-unavailable non-essential dependency therefore degrades the report instead of crashing the health check or flooding telemetry with exceptions.
+
+### Throttling dependency probes
+
+By default each dependency is probed at most once per `DependencyProbeCacheTime` (10 seconds). Repeated `/api/Health` requests within that window reuse the cached probe result, and concurrent requests are coalesced into a single probe — so frequent health checks don't hammer (and get rate-limited by) the dependency.
+
+```csharp
+builder.AddQuilt4NetHealth(o =>
+{
+    // Cache each dependency probe for 30s (default is 10s).
+    o.DependencyProbeCacheTime = TimeSpan.FromSeconds(30);
+
+    // Or disable caching to probe on every request:
+    // o.DependencyProbeCacheTime = TimeSpan.Zero;
+});
+```
+
+| Property | Default | Description |
+|----------|---------|-------------|
+| `DependencyProbeCacheTime` | 10 seconds | How long a dependency probe result is cached before the dependency is re-probed. Concurrent requests are coalesced into one probe. Set to `TimeSpan.Zero` (or negative) to probe on every request. |
+
 ## Heartbeat
 
 The heartbeat feature sends periodic availability telemetry to Application Insights.

--- a/Quilt4Net.Toolkit/Features/Api/Quilt4NetHealthApiOptions.cs
+++ b/Quilt4Net.Toolkit/Features/Api/Quilt4NetHealthApiOptions.cs
@@ -123,6 +123,16 @@ public record Quilt4NetHealthApiOptions
     /// </summary>
     public CertificateCheckOptions Certificate { get; set; } = new();
 
+    /// <summary>
+    /// How long a dependency health-probe result is cached before the dependency is probed again.
+    /// Repeated requests within this window reuse the cached result instead of re-probing on every
+    /// request, and concurrent requests are coalesced into a single probe. This protects dependencies
+    /// from being hammered (and rate-limited) by frequent health checks.
+    /// Set to <see cref="TimeSpan.Zero"/> (or a negative value) to disable caching and probe every time.
+    /// Default is 10 seconds.
+    /// </summary>
+    public TimeSpan DependencyProbeCacheTime { get; set; } = TimeSpan.FromSeconds(10);
+
     internal IEnumerable<Component> Components => _components.Values;
     internal IEnumerable<Type> ComponentServices => _componentServices.Keys;
     internal IEnumerable<Dependency> DependencyRegistrations => _dependencies.Values;

--- a/Quilt4Net.Toolkit/Features/Health/Dependency/DefaultDependencyProbe.cs
+++ b/Quilt4Net.Toolkit/Features/Health/Dependency/DefaultDependencyProbe.cs
@@ -1,0 +1,123 @@
+using System.Net.Http.Json;
+using System.Net.Security;
+using Microsoft.Extensions.Logging;
+using Quilt4Net.Toolkit.Features.Api;
+using Quilt4Net.Toolkit.Framework;
+
+namespace Quilt4Net.Toolkit.Features.Health.Dependency;
+
+internal class DefaultDependencyProbe : IDependencyProbe
+{
+    private const string ProbeComponentName = "Probe";
+    private const string Parameters = "Health?noDependencies=true&noCertSelfCheck=true";
+
+    private readonly Quilt4NetHealthApiOptions _apiOptions;
+    private readonly ILogger<DefaultDependencyProbe> _logger;
+
+    /// <summary>
+    /// Test seam to override the HTTP transport. When null the real <see cref="HttpClientHandler"/>
+    /// (with the certificate-observing validation callback) is used.
+    /// </summary>
+    internal Func<HttpMessageHandler> HandlerFactory { get; set; }
+
+    public DefaultDependencyProbe(Quilt4NetHealthApiOptions apiOptions, ILogger<DefaultDependencyProbe> logger)
+    {
+        _apiOptions = apiOptions;
+        _logger = logger;
+    }
+
+    public async Task<HealthResponse> ProbeAsync(Dependency dependency, CancellationToken cancellationToken)
+    {
+        if (!Uri.TryCreate(dependency.Uri, Parameters, out var uri))
+        {
+            _logger.LogWarning("Dependency '{DependencyName}' has an invalid uri '{Uri}'.", dependency.Name, dependency.Uri);
+            return BuildFailed(HealthStatus.Unhealthy, new Dictionary<string, string> { { "Message", $"Cannot build uri from '{dependency.Uri}' and '{Parameters}'." } });
+        }
+
+        var certificateStatus = HealthStatus.Healthy;
+        string certificateMessage = null;
+
+        try
+        {
+            HttpMessageHandler handler;
+            if (HandlerFactory != null)
+            {
+                handler = HandlerFactory();
+            }
+            else
+            {
+                var httpClientHandler = new HttpClientHandler();
+                httpClientHandler.ServerCertificateCustomValidationCallback = (_, _, _, errors) =>
+                {
+                    if (errors != SslPolicyErrors.None)
+                    {
+                        certificateStatus = HealthStatus.Degraded;
+                        certificateMessage = $"{errors}";
+                    }
+
+                    return true;
+                };
+                handler = httpClientHandler;
+            }
+
+            using var httpClient = new HttpClient(handler);
+            using var response = await httpClient.GetAsync(uri, cancellationToken);
+
+            if (!response.IsSuccessStatusCode)
+            {
+                _logger.LogWarning("Dependency '{DependencyName}' probe to '{Uri}' returned non-success status {StatusCode} ({ReasonPhrase}).", dependency.Name, uri, (int)response.StatusCode, response.ReasonPhrase);
+                return BuildFailed(HealthStatus.Unhealthy, new Dictionary<string, string>
+                {
+                    { "StatusCode", $"{(int)response.StatusCode}" },
+                    { "Reason", response.ReasonPhrase ?? $"{response.StatusCode}" }
+                });
+            }
+
+            var content = await response.Content.ReadFromJsonAsync<HealthResponse>(cancellationToken);
+            if (content == null)
+            {
+                _logger.LogWarning("Dependency '{DependencyName}' probe to '{Uri}' returned an empty body.", dependency.Name, uri);
+                return BuildFailed(HealthStatus.Degraded, new Dictionary<string, string> { { "Message", "Dependency returned an empty body." } });
+            }
+
+            return await CheckCertificateAsync(dependency, certificateStatus, certificateMessage, content);
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception e)
+        {
+            _logger.LogWarning(e, "Dependency '{DependencyName}' probe to '{Uri}' failed.", dependency.Name, uri);
+            return BuildFailed(HealthStatus.Unhealthy, new Dictionary<string, string> { { "Message", e.Message } });
+        }
+    }
+
+    private static HealthResponse BuildFailed(HealthStatus status, Dictionary<string, string> details) => new()
+    {
+        Status = status,
+        Components = new Dictionary<string, HealthComponent>
+        {
+            { ProbeComponentName, new HealthComponent { Status = status, Details = details } }
+        }
+    };
+
+    private async Task<HealthResponse> CheckCertificateAsync(Dependency x, HealthStatus certificateStatus, string message, HealthResponse content)
+    {
+        if (!(_apiOptions.Certificate?.DependencyCheckEnabled ?? false)) return content;
+
+        var certificateHealth = await Certificatehelper.GetCertificateHealthAsync(x.Uri, _apiOptions.Certificate, certificateStatus, message);
+
+        content = content with
+        {
+            Status = EnumExtensions.MaxEnum<HealthStatus>(certificateStatus, content.Status),
+            Components = content.Components
+                .Concat(new Dictionary<string, HealthComponent> { { "Certificate", certificateHealth } })
+                .ToUniqueDictionary()
+        };
+
+        content.Components.Remove("CertificateSelf");
+
+        return content;
+    }
+}

--- a/Quilt4Net.Toolkit/Features/Health/Dependency/DependencyService.cs
+++ b/Quilt4Net.Toolkit/Features/Health/Dependency/DependencyService.cs
@@ -1,92 +1,112 @@
-using System.Net.Http.Json;
-using System.Net.Security;
+using System.Collections.Concurrent;
 using System.Runtime.CompilerServices;
 using Quilt4Net.Toolkit.Features.Api;
-using Quilt4Net.Toolkit.Framework;
 
 namespace Quilt4Net.Toolkit.Features.Health.Dependency;
 
 internal class DependencyService : IDependencyService
 {
+    private readonly IDependencyProbe _probe;
     private readonly Quilt4NetHealthApiOptions _apiOptions;
+    private readonly TimeProvider _timeProvider;
+    private readonly ConcurrentDictionary<string, CacheSlot> _cache = new();
 
-    public DependencyService(Quilt4NetHealthApiOptions apiOptions)
+    public DependencyService(IDependencyProbe probe, Quilt4NetHealthApiOptions apiOptions, TimeProvider timeProvider)
     {
+        _probe = probe;
         _apiOptions = apiOptions;
+        _timeProvider = timeProvider;
     }
 
     public async IAsyncEnumerable<KeyValuePair<string, DependencyComponent>> GetStatusAsync([EnumeratorCancellation] CancellationToken cancellationToken)
     {
-        var tasks = _apiOptions.DependencyRegistrations.Select(x => Task.Run(async () =>
-        {
-            var handler = new HttpClientHandler();
+        var tasks = _apiOptions.DependencyRegistrations
+            .Select(x => GetComponentAsync(x, cancellationToken))
+            .ToList();
 
-            var certificateStatus = HealthStatus.Healthy;
-            string message = null;
-            handler.ServerCertificateCustomValidationCallback = (_, _, _, errors) =>
-            {
-                if (errors != SslPolicyErrors.None)
-                {
-                    certificateStatus = HealthStatus.Degraded;
-                    message = $"{errors}";
-                }
-
-                return true;
-            };
-
-            using var httpClient = new HttpClient(handler);
-            var parameters = "Health?noDependencies=true&noCertSelfCheck=true";
-            if (!Uri.TryCreate(x.Uri, parameters, out var uri)) throw new InvalidOperationException($"Cannot build uri from '{x.Uri}' and '{parameters}'.");
-            using var response = await httpClient.GetAsync(uri, cancellationToken);
-            var content = await response.Content.ReadFromJsonAsync<HealthResponse>(cancellationToken);
-
-            content = await CheckCertificateAsync(x, certificateStatus, message, content);
-
-            return (x.Name, x.Essential, content.Components, x.Uri);
-        }, cancellationToken)).ToList();
-
-        while (tasks.Any())
+        while (tasks.Count > 0)
         {
             var task = await Task.WhenAny(tasks);
-
-            var dependencyComponent = new DependencyComponent
-            {
-                Status = BuildStatus(task),
-                Uri = task.Result.Uri,
-                DependencyComponents = task.Result.Components
-            };
-            yield return new KeyValuePair<string, DependencyComponent>(task.Result.Name, dependencyComponent);
             tasks.Remove(task);
+            yield return await task;
         }
     }
 
-    private async Task<HealthResponse> CheckCertificateAsync(Dependency x, HealthStatus certificateStatus, string message, HealthResponse content)
+    private async Task<KeyValuePair<string, DependencyComponent>> GetComponentAsync(Dependency dependency, CancellationToken cancellationToken)
     {
-        if (!(_apiOptions.Certificate?.DependencyCheckEnabled ?? false)) return content;
+        var content = await GetContentAsync(dependency, cancellationToken);
 
-        var certificateHealth = await Certificatehelper.GetCertificateHealthAsync(x.Uri, _apiOptions.Certificate, certificateStatus, message);
-
-        content = content with
+        var component = new DependencyComponent
         {
-            Status = EnumExtensions.MaxEnum<HealthStatus>(certificateStatus, content.Status),
-            Components = content.Components
-                .Concat(new Dictionary<string, HealthComponent> { { "Certificate", certificateHealth } })
-                .ToUniqueDictionary()
+            Status = BuildStatus(dependency.Essential, content.Components),
+            Uri = dependency.Uri,
+            DependencyComponents = content.Components
         };
 
-        content.Components.Remove("CertificateSelf");
-
-        return content;
+        return new KeyValuePair<string, DependencyComponent>(dependency.Name, component);
     }
 
-    private static HealthStatus BuildStatus(Task<(string Name, bool Essential, Dictionary<string, HealthComponent> Components, Uri _)> task)
+    private async Task<HealthResponse> GetContentAsync(Dependency dependency, CancellationToken cancellationToken)
     {
-        var status = task.Result.Components.Max(x => x.Value.Status);
-        if (!task.Result.Essential && status == HealthStatus.Unhealthy)
+        var cacheTime = _apiOptions.DependencyProbeCacheTime;
+        if (cacheTime <= TimeSpan.Zero)
+        {
+            return await _probe.ProbeAsync(dependency, cancellationToken);
+        }
+
+        var slot = _cache.GetOrAdd(dependency.Name, _ => new CacheSlot());
+
+        if (TryGetFresh(slot, cacheTime, out var cached))
+        {
+            return cached;
+        }
+
+        await slot.Gate.WaitAsync(cancellationToken);
+        try
+        {
+            if (TryGetFresh(slot, cacheTime, out cached))
+            {
+                return cached;
+            }
+
+            var content = await _probe.ProbeAsync(dependency, cancellationToken);
+            slot.Content = content;
+            slot.FetchedAt = _timeProvider.GetUtcNow();
+            return content;
+        }
+        finally
+        {
+            slot.Gate.Release();
+        }
+    }
+
+    private bool TryGetFresh(CacheSlot slot, TimeSpan cacheTime, out HealthResponse content)
+    {
+        if (slot.Content != null && _timeProvider.GetUtcNow() - slot.FetchedAt < cacheTime)
+        {
+            content = slot.Content;
+            return true;
+        }
+
+        content = null;
+        return false;
+    }
+
+    private static HealthStatus BuildStatus(bool essential, Dictionary<string, HealthComponent> components)
+    {
+        var status = components.Count == 0 ? HealthStatus.Healthy : components.Max(x => x.Value.Status);
+        if (!essential && status == HealthStatus.Unhealthy)
         {
             status = HealthStatus.Degraded;
         }
 
         return status;
+    }
+
+    private sealed class CacheSlot
+    {
+        public SemaphoreSlim Gate { get; } = new(1, 1);
+        public HealthResponse Content { get; set; }
+        public DateTimeOffset FetchedAt { get; set; }
     }
 }

--- a/Quilt4Net.Toolkit/Features/Health/Dependency/IDependencyProbe.cs
+++ b/Quilt4Net.Toolkit/Features/Health/Dependency/IDependencyProbe.cs
@@ -1,0 +1,11 @@
+namespace Quilt4Net.Toolkit.Features.Health.Dependency;
+
+internal interface IDependencyProbe
+{
+    /// <summary>
+    /// Probes a single dependency's health endpoint. Never throws for a non-success response or a
+    /// transport/parse failure — those are reported as an unhealthy/degraded <see cref="HealthResponse"/>.
+    /// Only cancellation propagates.
+    /// </summary>
+    Task<HealthResponse> ProbeAsync(Dependency dependency, CancellationToken cancellationToken);
+}

--- a/Quilt4Net.Toolkit/Features/Health/HealthClient.cs
+++ b/Quilt4Net.Toolkit/Features/Health/HealthClient.cs
@@ -21,6 +21,7 @@ internal class HealthClient : IHealthClient
         using var client = new HttpClient();
         client.BaseAddress = new Uri(_clientOptions.HealthAddress);
         using var result = await client.GetAsync("live", cancellationToken);
+        result.EnsureSuccessStatusCode();
         var content = await result.Content.ReadFromJsonAsync<LiveResponse>(new JsonSerializerOptions { PropertyNameCaseInsensitive = true }, cancellationToken);
         return content;
     }
@@ -32,6 +33,7 @@ internal class HealthClient : IHealthClient
         using var client = new HttpClient();
         client.BaseAddress = new Uri(_clientOptions.HealthAddress);
         using var result = await client.GetAsync("ready", cancellationToken);
+        result.EnsureSuccessStatusCode();
         var content = await result.Content.ReadFromJsonAsync<ReadyResponse>(new JsonSerializerOptions { PropertyNameCaseInsensitive = true }, cancellationToken);
         return content;
     }
@@ -43,6 +45,7 @@ internal class HealthClient : IHealthClient
         using var client = new HttpClient();
         client.BaseAddress = new Uri(_clientOptions.HealthAddress);
         using var result = await client.GetAsync("health", cancellationToken);
+        result.EnsureSuccessStatusCode();
         var content = await result.Content.ReadFromJsonAsync<HealthResponse>(new JsonSerializerOptions { PropertyNameCaseInsensitive = true }, cancellationToken);
         return content;
     }
@@ -54,6 +57,7 @@ internal class HealthClient : IHealthClient
         using var client = new HttpClient();
         client.BaseAddress = new Uri(_clientOptions.HealthAddress);
         using var result = await client.GetAsync("metrics", cancellationToken);
+        result.EnsureSuccessStatusCode();
         var content = await result.Content.ReadFromJsonAsync<MetricsResponse>(new JsonSerializerOptions { PropertyNameCaseInsensitive = true }, cancellationToken);
         return content;
     }
@@ -65,6 +69,7 @@ internal class HealthClient : IHealthClient
         using var client = new HttpClient();
         client.BaseAddress = new Uri(_clientOptions.HealthAddress);
         using var result = await client.GetAsync("version", cancellationToken);
+        result.EnsureSuccessStatusCode();
         var content = await result.Content.ReadFromJsonAsync<VersionResponse>(new JsonSerializerOptions { PropertyNameCaseInsensitive = true }, cancellationToken);
         return content;
     }

--- a/Quilt4Net.Toolkit/README.md
+++ b/Quilt4Net.Toolkit/README.md
@@ -141,6 +141,8 @@ var metrics = await _healthClient.GetMetricsAsync(cancellationToken);
 var version = await _healthClient.GetVersionAsync(cancellationToken);
 ```
 
+If the remote endpoint replies with a non-success status code, these methods throw `HttpRequestException` (carrying the status code) rather than a JSON parse error — wrap calls in try/catch when the remote service may be unavailable.
+
 ### HealthClientOptions
 
 | Property | Default | Description |


### PR DESCRIPTION
Fixes #119.

## Problem
`DependencyService.GetStatusAsync` probed each registered dependency's `/api/Health` and called `ReadFromJsonAsync<HealthResponse>` **without** checking `IsSuccessStatusCode`. A non-2xx response (e.g. HTTP 429 rate-limit, or an HTML/text error page) threw `JsonReaderException`, faulted the probe task, and surfaced as an **error** in the consumer's telemetry — bypassing the non-essential handling. The reporting consumer saw ~4,800 such errors over 7 days from a single non-essential, rate-limited dependency (~456k probes).

## Fix
- **Guard + never throw.** Extracted the per-dependency HTTP probe into an `IDependencyProbe` seam (`DefaultDependencyProbe`): checks `IsSuccessStatusCode`, wraps transport/parse/cert in try/catch, and on failure returns a synthetic `Unhealthy` `Probe` component carrying the status code in `Details` instead of throwing. `BuildStatus` still downgrades non-essential `Unhealthy → Degraded` (so a rate-limited non-essential dependency now reports **Degraded**) and now guards an empty component set.
- **Warning, not error.** Non-success / failed probes log at `Warning`.
- **Probe throttle (root cause of the 429 storm).** `DependencyService` is now a singleton with a per-dependency TTL cache + concurrent-probe coalescing. New option `Quilt4NetHealthApiOptions.DependencyProbeCacheTime` (default **10s**; set `TimeSpan.Zero` to disable). Repeated `/api/Health` requests within the window reuse a single probe; concurrent requests are coalesced.
- **HealthClient.** `EnsureSuccessStatusCode()` before parsing in all 5 methods (`Live`/`Ready`/`Health`/`Metrics`/`Version`) → clear `HttpRequestException` instead of cryptic `JsonReaderException`.

## Behavior change
Dependency probe results are cached for **10s by default**. For typical health polling (≥10s) this is invisible; an essential dependency going down would show healthy for up to the cache window. Disable with `o.DependencyProbeCacheTime = TimeSpan.Zero` or tune as needed.

## Tests
+12 tests (`DependencyServiceTests` + `DefaultDependencyProbeTests`); Health.Tests 48 → 60; full solution suite green (393).

## Follow-up (not yet in this PR)
- README docs for `DependencyProbeCacheTime` + the non-success behavior.
- Bundled the up-front dependency refresh (Swashbuckle 10.2.2, Microsoft.Identity.Client 4.85.0).
