### PR TITLE
Monitoring: Infrastructure/Log-volume restructure + cap & volume improvements

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@ on:
     branches: [master]
 
 env:
-  MAJOR_MINOR: '0.9'
+  MAJOR_MINOR: '0.10'
 
 permissions:
   contents: write

--- a/Quilt4Net.Toolkit.Api.Sample/Quilt4Net.Toolkit.Api.Sample.csproj
+++ b/Quilt4Net.Toolkit.Api.Sample/Quilt4Net.Toolkit.Api.Sample.csproj
@@ -12,7 +12,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="10.2.2" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="10.2.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Quilt4Net.Toolkit.Api.Tests/Quilt4Net.Toolkit.Api.Tests.csproj
+++ b/Quilt4Net.Toolkit.Api.Tests/Quilt4Net.Toolkit.Api.Tests.csproj
@@ -9,7 +9,7 @@
 		<PackageReference Include="AutoFixture" Version="4.18.1" />
 		<PackageReference Include="FluentAssertions" Version="8.10.0" />
 		<PackageReference Include="JetBrains.Annotations" Version="2026.2.0" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
 		<PackageReference Include="Moq" Version="4.20.72" />
 		<PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.9" />
 		<PackageReference Include="OneOf" Version="3.0.271" />

--- a/Quilt4Net.Toolkit.Blazor.Tests/CapTimelineBuilderTests.cs
+++ b/Quilt4Net.Toolkit.Blazor.Tests/CapTimelineBuilderTests.cs
@@ -38,6 +38,43 @@ public class CapTimelineBuilderTests
     }
 
     [Fact]
+    public void Build_Cycles_OneRowPerResetCycle_WithCleanCappedSpan()
+    {
+        var stops = new List<DateTime> { Day1.AddHours(22), Day1.AddDays(1).AddHours(20) };
+        var resets = new List<DateTime> { Day1.AddHours(12), Day1.AddDays(1).AddHours(12), Day1.AddDays(2).AddHours(12) };
+        var cycleGb = new Dictionary<DateTime, double> { [Day1.AddHours(12)] = 10.5, [Day1.AddDays(1).AddHours(12)] = 10.4 };
+
+        var timeline = CapTimelineBuilder.Build([.. stops], [.. resets], new Dictionary<DateTime, double>(),
+            measuredCapGb: 10, configuredCapGb: null, windowStartUtc: Day1, windowEndUtc: Day1.AddDays(2).AddHours(12),
+            cycleGbByStart: cycleGb);
+
+        timeline.Cycles.Should().HaveCount(2);
+
+        var firstCycle = timeline.Cycles.Single(c => c.StartUtc == Day1.AddHours(12));
+        firstCycle.CapHitUtc.Should().Be(Day1.AddHours(22));
+        firstCycle.CappedDuration.Should().Be(TimeSpan.FromHours(14));   // 22:00 → next reset 12:00
+        firstCycle.IngestedGb.Should().Be(10.5);                          // looked up from cycleGbByStart
+        firstCycle.EndUtc.Should().Be(Day1.AddDays(1).AddHours(12));
+    }
+
+    [Fact]
+    public void Build_RecapAfterReset_DayHasTwoCappedIntervals()
+    {
+        // Carry-over cap until 12:00, then a fresh cap at 22:00 the same day.
+        var stops = new List<DateTime> { Day1.AddDays(-1).AddHours(20), Day1.AddHours(22) };
+        var resets = new List<DateTime> { Day1.AddHours(12), Day1.AddDays(1).AddHours(12) };
+
+        var timeline = CapTimelineBuilder.Build([.. stops], [.. resets],
+            new Dictionary<DateTime, double> { [Day1.Date] = 9 },
+            measuredCapGb: 10, configuredCapGb: null, windowStartUtc: Day1.AddDays(-1), windowEndUtc: Day1.AddDays(2));
+
+        var day = timeline.Days.Single(d => d.DateUtc == Day1.Date);
+        day.CappedIntervals.Should().HaveCount(2);                        // 00:00–12:00 and 22:00–24:00
+        day.CappedIntervals[0].EndUtc.Should().Be(Day1.AddHours(12));     // resumed at 12:00
+        day.CappedIntervals[1].StartUtc.Should().Be(Day1.AddHours(22));   // re-capped at 22:00
+    }
+
+    [Fact]
     public void Build_OpenTrailingCap_ClosesAtWindowEnd()
     {
         // A stop with no following reset is still capped until the window end.

--- a/Quilt4Net.Toolkit.Blazor.Tests/CapTimelineBuilderTests.cs
+++ b/Quilt4Net.Toolkit.Blazor.Tests/CapTimelineBuilderTests.cs
@@ -1,0 +1,75 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using FluentAssertions;
+using Quilt4Net.Toolkit.Features.ApplicationInsights;
+using Xunit;
+
+namespace Quilt4Net.Toolkit.Blazor.Tests;
+
+public class CapTimelineBuilderTests
+{
+    private static readonly DateTime Day1 = new(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+
+    // Three UTC days at 1 MB/hour, with two caps that each run 23:00 → 05:00 the next day
+    // (reset at 05:00). The middle day is thus capped 00:00–05:00 (carry-over) AND 23:00–24:00 = 6h.
+    private static List<HourVolume> BuildScenario()
+    {
+        var hours = new List<HourVolume>();
+        for (var i = 0; i < 72; i++)
+            hours.Add(new HourVolume { HourUtc = Day1.AddHours(i), Mb = 1.0 });
+
+        void Cap(DateTime from, int count)
+        {
+            for (var i = 0; i < count; i++)
+            {
+                var at = from.AddHours(i);
+                var idx = hours.FindIndex(h => h.HourUtc == at);
+                hours[idx] = hours[idx] with { Mb = 0 };
+            }
+        }
+
+        Cap(Day1.AddHours(23), 6);           // 23:00 day1 → 04:59 day2  (resume 05:00 day2)
+        Cap(Day1.AddDays(1).AddHours(23), 6); // 23:00 day2 → 04:59 day3  (resume 05:00 day3)
+        return hours;
+    }
+
+    [Fact]
+    public void Build_DetectsResetTime_PerDayGap_AndDerivedCapSize()
+    {
+        var timeline = CapTimelineBuilder.Build(BuildScenario(), configuredCapGb: null);
+
+        // Reset detected from where data resumes after a cap.
+        timeline.CapResetUtc.Should().Be(TimeSpan.FromHours(5));
+
+        var day2 = timeline.Days.Single(d => d.DateUtc == Day1.Date.AddDays(1));
+        day2.GapDuration.Should().Be(TimeSpan.FromHours(6));               // 5h carry-over + 1h new cap
+        day2.ResumeUtc.Should().Be(Day1.AddDays(1).AddHours(5));           // resumed at 05:00
+
+        timeline.Days.Single(d => d.DateUtc == Day1.Date).GapDuration.Should().Be(TimeSpan.FromHours(1));
+        timeline.Days.Single(d => d.DateUtc == Day1.Date.AddDays(2)).GapDuration.Should().Be(TimeSpan.FromHours(5));
+
+        // Cap size = volume in a complete reset→next-cap cycle: 05:00→23:00 = 18h × 1 MB = 18 MB.
+        timeline.DerivedCapGb.Should().BeApproximately(18.0 / 1024.0, 1e-9);
+    }
+
+    [Fact]
+    public void Build_NoData_ReturnsEmpty()
+    {
+        var timeline = CapTimelineBuilder.Build(new List<HourVolume>(), configuredCapGb: 5);
+        timeline.Days.Should().BeEmpty();
+        timeline.CapResetUtc.Should().BeNull();
+        timeline.CapGb.Should().Be(5);
+    }
+
+    [Fact]
+    public void Build_NoGaps_NoCapReported()
+    {
+        var hours = Enumerable.Range(0, 48).Select(i => new HourVolume { HourUtc = Day1.AddHours(i), Mb = 2.0 }).ToList();
+        var timeline = CapTimelineBuilder.Build(hours, configuredCapGb: null);
+
+        timeline.Days.Should().OnlyContain(d => d.GapDuration == null);
+        timeline.CapResetUtc.Should().BeNull();
+        timeline.DerivedCapGb.Should().BeNull();
+    }
+}

--- a/Quilt4Net.Toolkit.Blazor.Tests/CapTimelineBuilderTests.cs
+++ b/Quilt4Net.Toolkit.Blazor.Tests/CapTimelineBuilderTests.cs
@@ -11,65 +11,68 @@ public class CapTimelineBuilderTests
 {
     private static readonly DateTime Day1 = new(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc);
 
-    // Three UTC days at 1 MB/hour, with two caps that each run 23:00 → 05:00 the next day
-    // (reset at 05:00). The middle day is thus capped 00:00–05:00 (carry-over) AND 23:00–24:00 = 6h.
-    private static List<HourVolume> BuildScenario()
-    {
-        var hours = new List<HourVolume>();
-        for (var i = 0; i < 72; i++)
-            hours.Add(new HourVolume { HourUtc = Day1.AddHours(i), Mb = 1.0 });
-
-        void Cap(DateTime from, int count)
-        {
-            for (var i = 0; i < count; i++)
-            {
-                var at = from.AddHours(i);
-                var idx = hours.FindIndex(h => h.HourUtc == at);
-                hours[idx] = hours[idx] with { Mb = 0 };
-            }
-        }
-
-        Cap(Day1.AddHours(23), 6);           // 23:00 day1 → 04:59 day2  (resume 05:00 day2)
-        Cap(Day1.AddDays(1).AddHours(23), 6); // 23:00 day2 → 04:59 day3  (resume 05:00 day3)
-        return hours;
-    }
-
     [Fact]
-    public void Build_DetectsResetTime_PerDayGap_AndDerivedCapSize()
+    public void Build_FromCapEvents_DetectsReset_PerDayCappedDuration_AndCapSize()
     {
-        var timeline = CapTimelineBuilder.Build(BuildScenario(), configuredCapGb: null);
+        // Reset at 12:00 each day; a cap hit at 22:00 day1 (off until 12:00 day2) and 20:00 day2
+        // (off until 12:00 day3). So day2 is capped 00:00–12:00 (carry-over) + 20:00–24:00 = 16h.
+        var stops = new List<DateTime> { Day1.AddHours(22), Day1.AddDays(1).AddHours(20) };
+        var resets = new List<DateTime> { Day1.AddHours(12), Day1.AddDays(1).AddHours(12), Day1.AddDays(2).AddHours(12) };
+        var dailyGb = new Dictionary<DateTime, double>
+        {
+            [Day1.Date] = 8, [Day1.Date.AddDays(1)] = 9, [Day1.Date.AddDays(2)] = 3,
+        };
 
-        // Reset detected from where data resumes after a cap.
-        timeline.CapResetUtc.Should().Be(TimeSpan.FromHours(5));
+        var timeline = CapTimelineBuilder.Build(stops, resets, dailyGb,
+            measuredCapGb: 10, configuredCapGb: null, windowStartUtc: Day1, windowEndUtc: Day1.AddDays(3));
+
+        timeline.CapResetUtc.Should().Be(TimeSpan.FromHours(12));
+        timeline.DerivedCapGb.Should().Be(10);
 
         var day2 = timeline.Days.Single(d => d.DateUtc == Day1.Date.AddDays(1));
-        day2.GapDuration.Should().Be(TimeSpan.FromHours(6));               // 5h carry-over + 1h new cap
-        day2.ResumeUtc.Should().Be(Day1.AddDays(1).AddHours(5));           // resumed at 05:00
+        day2.GapDuration.Should().Be(TimeSpan.FromHours(16));            // 12h carry-over + 4h new cap
+        day2.ResumeUtc.Should().Be(Day1.AddDays(1).AddHours(12));        // resumed at 12:00
 
-        timeline.Days.Single(d => d.DateUtc == Day1.Date).GapDuration.Should().Be(TimeSpan.FromHours(1));
-        timeline.Days.Single(d => d.DateUtc == Day1.Date.AddDays(2)).GapDuration.Should().Be(TimeSpan.FromHours(5));
-
-        // Cap size = volume in a complete reset→next-cap cycle: 05:00→23:00 = 18h × 1 MB = 18 MB.
-        timeline.DerivedCapGb.Should().BeApproximately(18.0 / 1024.0, 1e-9);
+        timeline.Days.Single(d => d.DateUtc == Day1.Date).GapDuration.Should().Be(TimeSpan.FromHours(2));
+        timeline.Days.Single(d => d.DateUtc == Day1.Date.AddDays(2)).GapDuration.Should().Be(TimeSpan.FromHours(12));
     }
 
     [Fact]
-    public void Build_NoData_ReturnsEmpty()
+    public void Build_OpenTrailingCap_ClosesAtWindowEnd()
     {
-        var timeline = CapTimelineBuilder.Build(new List<HourVolume>(), configuredCapGb: 5);
+        // A stop with no following reset is still capped until the window end.
+        var stops = new List<DateTime> { Day1.AddHours(20) };
+        var resets = new List<DateTime> { Day1.AddHours(12) };
+        var dailyGb = new Dictionary<DateTime, double> { [Day1.Date] = 10 };
+
+        var timeline = CapTimelineBuilder.Build(stops, resets, dailyGb,
+            measuredCapGb: 10, configuredCapGb: null, windowStartUtc: Day1, windowEndUtc: Day1.AddHours(23));
+
+        timeline.Days.Single(d => d.DateUtc == Day1.Date).GapDuration.Should().Be(TimeSpan.FromHours(3)); // 20:00→23:00
+    }
+
+    [Fact]
+    public void Build_NoStops_NoCapButResetStillDetected()
+    {
+        var resets = new List<DateTime> { Day1.AddHours(12), Day1.AddDays(1).AddHours(12) };
+        var dailyGb = new Dictionary<DateTime, double> { [Day1.Date] = 4, [Day1.Date.AddDays(1)] = 5 };
+
+        var timeline = CapTimelineBuilder.Build(stops: [], resets: resets, dailyGb: dailyGb,
+            measuredCapGb: null, configuredCapGb: null, windowStartUtc: Day1, windowEndUtc: Day1.AddDays(2));
+
+        timeline.CapResetUtc.Should().Be(TimeSpan.FromHours(12));
+        timeline.Days.Should().OnlyContain(d => d.GapDuration == null);
+        timeline.DerivedCapGb.Should().BeNull();
+    }
+
+    [Fact]
+    public void Build_Empty_ReturnsEmpty()
+    {
+        var timeline = CapTimelineBuilder.Build([], [], new Dictionary<DateTime, double>(),
+            measuredCapGb: null, configuredCapGb: 5, windowStartUtc: Day1, windowEndUtc: Day1.AddDays(1));
+
         timeline.Days.Should().BeEmpty();
         timeline.CapResetUtc.Should().BeNull();
         timeline.CapGb.Should().Be(5);
-    }
-
-    [Fact]
-    public void Build_NoGaps_NoCapReported()
-    {
-        var hours = Enumerable.Range(0, 48).Select(i => new HourVolume { HourUtc = Day1.AddHours(i), Mb = 2.0 }).ToList();
-        var timeline = CapTimelineBuilder.Build(hours, configuredCapGb: null);
-
-        timeline.Days.Should().OnlyContain(d => d.GapDuration == null);
-        timeline.CapResetUtc.Should().BeNull();
-        timeline.DerivedCapGb.Should().BeNull();
     }
 }

--- a/Quilt4Net.Toolkit.Blazor.Tests/CapTimelineBuilderTests.cs
+++ b/Quilt4Net.Toolkit.Blazor.Tests/CapTimelineBuilderTests.cs
@@ -38,23 +38,32 @@ public class CapTimelineBuilderTests
     }
 
     [Fact]
-    public void Build_Cycles_OneRowPerResetCycle_WithCleanCappedSpan()
+    public void Build_Cycles_OneRowPerDay_IncludingUncappedDays()
     {
-        var stops = new List<DateTime> { Day1.AddHours(22), Day1.AddDays(1).AddHours(20) };
-        var resets = new List<DateTime> { Day1.AddHours(12), Day1.AddDays(1).AddHours(12), Day1.AddDays(2).AddHours(12) };
-        var cycleGb = new Dictionary<DateTime, double> { [Day1.AddHours(12)] = 10.5, [Day1.AddDays(1).AddHours(12)] = 10.4 };
+        // Cap hit only on day1. Resets fire only after a cap (day1 + day2), but every day has volume.
+        var stops = new List<DateTime> { Day1.AddHours(22) };
+        var resets = new List<DateTime> { Day1.AddHours(12), Day1.AddDays(1).AddHours(12) };
+        var cycleGb = new Dictionary<DateTime, double>
+        {
+            [Day1.AddHours(12)] = 10.5, [Day1.AddDays(1).AddHours(12)] = 10.4, [Day1.AddDays(2).AddHours(12)] = 3,
+        };
 
         var timeline = CapTimelineBuilder.Build([.. stops], [.. resets], new Dictionary<DateTime, double>(),
-            measuredCapGb: 10, configuredCapGb: null, windowStartUtc: Day1, windowEndUtc: Day1.AddDays(2).AddHours(12),
+            measuredCapGb: 10, configuredCapGb: null, windowStartUtc: Day1, windowEndUtc: Day1.AddDays(3).AddHours(12),
             cycleGbByStart: cycleGb);
 
-        timeline.Cycles.Should().HaveCount(2);
+        // Every day with volume gets a cycle, capped or not.
+        timeline.Cycles.Should().HaveCount(3);
 
-        var firstCycle = timeline.Cycles.Single(c => c.StartUtc == Day1.AddHours(12));
-        firstCycle.CapHitUtc.Should().Be(Day1.AddHours(22));
-        firstCycle.CappedDuration.Should().Be(TimeSpan.FromHours(14));   // 22:00 → next reset 12:00
-        firstCycle.IngestedGb.Should().Be(10.5);                          // looked up from cycleGbByStart
-        firstCycle.EndUtc.Should().Be(Day1.AddDays(1).AddHours(12));
+        var capped = timeline.Cycles.Single(c => c.StartUtc == Day1.AddHours(12));
+        capped.CapHitUtc.Should().Be(Day1.AddHours(22));
+        capped.CappedDuration.Should().Be(TimeSpan.FromHours(14));        // 22:00 → next reset 12:00
+        capped.IngestedGb.Should().Be(10.5);
+
+        var uncapped = timeline.Cycles.Single(c => c.StartUtc == Day1.AddDays(2).AddHours(12));
+        uncapped.CapHitUtc.Should().BeNull();
+        uncapped.CappedDuration.Should().BeNull();
+        uncapped.IngestedGb.Should().Be(3);
     }
 
     [Fact]

--- a/Quilt4Net.Toolkit.Blazor.Tests/LogEnvironmentSelectorIncidentTests.cs
+++ b/Quilt4Net.Toolkit.Blazor.Tests/LogEnvironmentSelectorIncidentTests.cs
@@ -36,6 +36,8 @@ public class LogEnvironmentSelectorIncidentTests : BunitContext
         public Task<bool> CanConnectAsync(IApplicationInsightsContext context) => Task.FromResult(false);
 
         public IAsyncEnumerable<VolumeBySource> GetVolumeBySourceAsync(IApplicationInsightsContext context, TimeSpan timeSpan, CancellationToken cancellationToken = default) => Throw<VolumeBySource>();
+        public IAsyncEnumerable<VolumeBySource> GetVolumeBySourceAsync(IApplicationInsightsContext context, DateTimeOffset fromUtc, DateTimeOffset toUtc, CancellationToken cancellationToken = default) => Throw<VolumeBySource>();
+        public IAsyncEnumerable<VolumeTimelinePoint> GetVolumeTimelineAsync(IApplicationInsightsContext context, DateTimeOffset fromUtc, DateTimeOffset toUtc, CancellationToken cancellationToken = default) => Throw<VolumeTimelinePoint>();
         public Task<CapTimeline> GetCapTimelineAsync(IApplicationInsightsContext context, int days, CancellationToken cancellationToken = default) => Task.FromException<CapTimeline>(_ex);
         public IAsyncEnumerable<EnvironmentOption> GetEnvironments(IApplicationInsightsContext context) => Throw<EnvironmentOption>();
         public IAsyncEnumerable<LogItem> SearchAsync(IApplicationInsightsContext context, string environment, string text, TimeSpan timeSpan, SeverityLevel minSeverityLevel = SeverityLevel.Verbose, CancellationToken cancellationToken = default) => Throw<LogItem>();

--- a/Quilt4Net.Toolkit.Blazor.Tests/LogViewConfigTests.cs
+++ b/Quilt4Net.Toolkit.Blazor.Tests/LogViewConfigTests.cs
@@ -55,6 +55,8 @@ public class LogViewConfigTests : BunitContext
     {
         public Task<bool> CanConnectAsync(IApplicationInsightsContext context) => Task.FromResult(false);
         public IAsyncEnumerable<VolumeBySource> GetVolumeBySourceAsync(IApplicationInsightsContext context, TimeSpan timeSpan, CancellationToken cancellationToken = default) => Empty<VolumeBySource>();
+        public IAsyncEnumerable<VolumeBySource> GetVolumeBySourceAsync(IApplicationInsightsContext context, DateTimeOffset fromUtc, DateTimeOffset toUtc, CancellationToken cancellationToken = default) => Empty<VolumeBySource>();
+        public IAsyncEnumerable<VolumeTimelinePoint> GetVolumeTimelineAsync(IApplicationInsightsContext context, DateTimeOffset fromUtc, DateTimeOffset toUtc, CancellationToken cancellationToken = default) => Empty<VolumeTimelinePoint>();
         public Task<CapTimeline> GetCapTimelineAsync(IApplicationInsightsContext context, int days, CancellationToken cancellationToken = default) => Task.FromResult(new CapTimeline { Days = [] });
         public IAsyncEnumerable<EnvironmentOption> GetEnvironments(IApplicationInsightsContext context) => Empty<EnvironmentOption>();
         public IAsyncEnumerable<LogItem> SearchAsync(IApplicationInsightsContext context, string environment, string text, TimeSpan timeSpan, SeverityLevel minSeverityLevel = SeverityLevel.Verbose, CancellationToken cancellationToken = default) => Empty<LogItem>();

--- a/Quilt4Net.Toolkit.Blazor.Tests/MetricsViewClusterTests.cs
+++ b/Quilt4Net.Toolkit.Blazor.Tests/MetricsViewClusterTests.cs
@@ -111,6 +111,8 @@ public class MetricsViewClusterTests : BunitContext
         // Everything else returns empty — the view only needs the metric methods to render.
         public Task<bool> CanConnectAsync(IApplicationInsightsContext context) => Task.FromResult(true);
         public IAsyncEnumerable<VolumeBySource> GetVolumeBySourceAsync(IApplicationInsightsContext context, TimeSpan timeSpan, CancellationToken cancellationToken = default) => Empty<VolumeBySource>();
+        public IAsyncEnumerable<VolumeBySource> GetVolumeBySourceAsync(IApplicationInsightsContext context, DateTimeOffset fromUtc, DateTimeOffset toUtc, CancellationToken cancellationToken = default) => Empty<VolumeBySource>();
+        public IAsyncEnumerable<VolumeTimelinePoint> GetVolumeTimelineAsync(IApplicationInsightsContext context, DateTimeOffset fromUtc, DateTimeOffset toUtc, CancellationToken cancellationToken = default) => Empty<VolumeTimelinePoint>();
         public Task<CapTimeline> GetCapTimelineAsync(IApplicationInsightsContext context, int days, CancellationToken cancellationToken = default) => Task.FromResult(new CapTimeline { Days = [] });
         public IAsyncEnumerable<EnvironmentOption> GetEnvironments(IApplicationInsightsContext context) => Empty<EnvironmentOption>();
         public IAsyncEnumerable<LogItem> SearchAsync(IApplicationInsightsContext context, string environment, string text, TimeSpan timeSpan, SeverityLevel minSeverityLevel = SeverityLevel.Verbose, CancellationToken cancellationToken = default) => Empty<LogItem>();

--- a/Quilt4Net.Toolkit.Blazor.Tests/Quilt4Net.Toolkit.Blazor.Tests.csproj
+++ b/Quilt4Net.Toolkit.Blazor.Tests/Quilt4Net.Toolkit.Blazor.Tests.csproj
@@ -13,7 +13,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Quilt4Net.Toolkit.Blazor/Features/Log/CapTimelineView.razor
+++ b/Quilt4Net.Toolkit.Blazor/Features/Log/CapTimelineView.razor
@@ -17,15 +17,27 @@
 }
 else
 {
-    <RadzenStack Orientation="Orientation.Vertical" Gap="0" class="rz-mb-2">
-        <RadzenText TextStyle="TextStyle.Caption" Text="Range" />
-        <RadzenSelectBar @bind-Value="_days" TValue="int" Size="ButtonSize.Small" Change="@(_ => LoadAsync())">
-            <Items>
-                <RadzenSelectBarItem Text="14 days" Value="14" />
-                <RadzenSelectBarItem Text="30 days" Value="30" />
-                <RadzenSelectBarItem Text="90 days" Value="90" />
-            </Items>
-        </RadzenSelectBar>
+    <RadzenStack Orientation="Orientation.Horizontal" Gap="1rem" Wrap="FlexWrap.Wrap" class="rz-mb-2">
+        <RadzenStack Orientation="Orientation.Vertical" Gap="0">
+            <RadzenText TextStyle="TextStyle.Caption" Text="Range" />
+            <RadzenSelectBar @bind-Value="_days" TValue="int" Size="ButtonSize.Small" Change="@(_ => LoadAsync())">
+                <Items>
+                    <RadzenSelectBarItem Text="14 days" Value="14" />
+                    <RadzenSelectBarItem Text="30 days" Value="30" />
+                    <RadzenSelectBarItem Text="90 days" Value="90" />
+                </Items>
+            </RadzenSelectBar>
+        </RadzenStack>
+        @* Break the timeline by calendar UTC day (default) or by quota cycle (reset → next reset). *@
+        <RadzenStack Orientation="Orientation.Vertical" Gap="0">
+            <RadzenText TextStyle="TextStyle.Caption" Text="Break by" />
+            <RadzenSelectBar @bind-Value="_grouping" TValue="Grouping" Size="ButtonSize.Small" Change="@(_ => Rebuild())">
+                <Items>
+                    <RadzenSelectBarItem Text="Calendar day" Value="Grouping.Day" />
+                    <RadzenSelectBarItem Text="Cap cycle" Value="Grouping.Cycle" />
+                </Items>
+            </RadzenSelectBar>
+        </RadzenStack>
     </RadzenStack>
 
     @if (_loading || Model == null)
@@ -54,26 +66,21 @@ else
         }
 
         <RadzenChart>
-            <RadzenColumnSeries Data="@Model" CategoryProperty="DateLabel" ValueProperty="IngestedGb" Title="Ingested" />
+            <RadzenColumnSeries Data="@Model" CategoryProperty="Label" ValueProperty="IngestedGb" Title="Ingested" />
             @if (EffectiveCapGb.HasValue)
             {
-                @* Constant value on every row → renders as a horizontal reference line at the cap.
-                   CapLine is a non-nullable double (the series only renders when a cap exists) so
-                   Radzen's tooltip lambda never dereferences a null. *@
-                <RadzenLineSeries Data="@Model" CategoryProperty="DateLabel" ValueProperty="CapLine" Title="Daily cap" LineType="LineType.Dashed" />
+                @* Constant value on every row → renders as a horizontal reference line at the cap. *@
+                <RadzenLineSeries Data="@Model" CategoryProperty="Label" ValueProperty="CapLine" Title="Daily cap" LineType="LineType.Dashed" />
             }
             @if (_uncappedPoints.Length > 0)
             {
-                @* Bound to a *filtered* set (hit days only) with a non-nullable value — feeding the
-                   full Model here would put nulls on non-hit days and Radzen's tooltip lambda would
-                   throw "Nullable object must have a value". Markers mark how much each capped day
-                   would have ingested unthrottled. *@
-                <RadzenLineSeries Data="@_uncappedPoints" CategoryProperty="DateLabel" ValueProperty="EstUncappedGb" Title="Est. uncapped" Smooth="false">
+                @* Filtered to capped rows with a non-nullable value so the chart tooltip never sees a null. *@
+                <RadzenLineSeries Data="@_uncappedPoints" CategoryProperty="Label" ValueProperty="EstUncappedGb" Title="Est. uncapped" Smooth="false">
                     <RadzenMarkers MarkerType="MarkerType.Diamond" />
                 </RadzenLineSeries>
             }
             <RadzenCategoryAxis>
-                <RadzenAxisTitle Text="Day (UTC)" />
+                <RadzenAxisTitle Text="@PeriodTitle" />
             </RadzenCategoryAxis>
             <RadzenValueAxis FormatString="{0:0.#} GB">
                 <RadzenAxisTitle Text="Billed volume" />
@@ -83,8 +90,8 @@ else
 
         <RadzenDataGrid Data="@Model" TItem="Row" AllowSorting="true" AllowPaging="true" PageSize="15" class="rz-mt-2">
             <Columns>
-                <RadzenDataGridColumn Title="Day (UTC)" Property="@nameof(Row.DateUtc)" SortOrder="SortOrder.Descending">
-                    <Template>@context.DateUtc.ToString("yyyy-MM-dd")</Template>
+                <RadzenDataGridColumn Title="@PeriodTitle" Property="@nameof(Row.SortKey)" SortOrder="SortOrder.Descending">
+                    <Template>@context.Period</Template>
                 </RadzenDataGridColumn>
                 <RadzenDataGridColumn Title="Ingested" Property="@nameof(Row.IngestedGb)" TextAlign="TextAlign.Right">
                     <Template>@context.IngestedGb.ToString("N2") GB</Template>
@@ -93,7 +100,7 @@ else
                     <Template>
                         @if (context.GapDuration.HasValue)
                         {
-                            <span title="@(context.ResumeUtc.HasValue ? $"Data resumed at {context.ResumeUtc:HH:mm} UTC" : "Capped (no resume in range)")">
+                            <span title="@context.GapTooltip">
                                 <RadzenBadge BadgeStyle="BadgeStyle.Danger" Text="@FormatGap(context.GapDuration.Value)" />
                             </span>
                         }
@@ -125,6 +132,10 @@ else
     private CancellationTokenSource _cts;
     private bool _loading;
     private int _days = 30;
+    private CapTimeline _timeline;
+    private Grouping _grouping = Grouping.Day;
+
+    public enum Grouping { Day, Cycle }
 
     [Parameter]
     public IApplicationInsightsContext Context { get; set; }
@@ -146,6 +157,8 @@ else
         : _capGb.HasValue ? $"{_capGb.Value:N0} GB (configured)" : "unknown";
 
     private string ResetLabel => _capResetUtc.HasValue ? _capResetUtc.Value.ToString(@"hh\:mm") + " UTC" : "not detected";
+
+    private string PeriodTitle => _grouping == Grouping.Cycle ? "Cap cycle (UTC)" : "Day (UTC)";
 
     private static string FormatGap(TimeSpan gap) => $"{(int)gap.TotalHours:D2}:{gap.Minutes:D2}";
 
@@ -200,35 +213,13 @@ else
 
         try
         {
-            var timeline = await _ais.GetCapTimelineAsync(ctx, _days, token);
+            _timeline = await _ais.GetCapTimelineAsync(ctx, _days, token);
             if (token.IsCancellationRequested) return;
 
-            _capGb = timeline.CapGb;
-            _derivedCapGb = timeline.DerivedCapGb;
-            _capResetUtc = timeline.CapResetUtc;
-            Model = timeline.Days
-                .OrderBy(d => d.DateUtc)
-                .Select(d => new Row(
-                    d.DateUtc,
-                    d.DateUtc.ToString("MM-dd"),
-                    d.IngestedGb,
-                    (_derivedCapGb ?? timeline.CapGb) ?? 0,
-                    d.ResumeUtc,
-                    d.GapDuration,
-                    d.EstimatedUncappedGb))
-                .ToArray();
-
-            // Filtered, non-nullable points for the est-uncapped marker series — keeps nulls out of
-            // the Radzen series (the chart tooltip lambda can't handle a null value).
-            _uncappedPoints = Model
-                .Where(r => r.EstUncappedGb.HasValue)
-                .Select(r => new UncappedPoint(r.DateLabel, r.EstUncappedGb.Value))
-                .ToArray();
-
-            _hitDays = Model.Count(r => r.GapDuration.HasValue);
-            _estLostGb = Model
-                .Where(r => r.EstUncappedGb.HasValue)
-                .Sum(r => Math.Max(0, r.EstUncappedGb.Value - r.IngestedGb));
+            _capGb = _timeline.CapGb;
+            _derivedCapGb = _timeline.DerivedCapGb;
+            _capResetUtc = _timeline.CapResetUtc;
+            Rebuild();
         }
         catch (OperationCanceledException) when (token.IsCancellationRequested)
         {
@@ -243,6 +234,63 @@ else
         }
     }
 
+    // Map the cached timeline into chart/grid rows for the selected grouping — no re-query needed when
+    // the user toggles "Break by".
+    private void Rebuild()
+    {
+        if (_timeline == null) { Model = []; _uncappedPoints = []; return; }
+
+        var capLine = (_derivedCapGb ?? _capGb) ?? 0;
+
+        Model = _grouping == Grouping.Cycle
+            ? _timeline.Cycles
+                .OrderBy(c => c.StartUtc)
+                .Select(c => new Row(
+                    c.StartUtc.ToString("MM-dd"),
+                    c.StartUtc.ToString("yyyy-MM-dd HH:mm"),
+                    c.StartUtc,
+                    c.IngestedGb,
+                    capLine,
+                    c.CappedDuration,
+                    c.EstimatedUncappedGb,
+                    c.CapHitUtc.HasValue ? $"Cap hit at {c.CapHitUtc:HH:mm} UTC; quota resets {c.EndUtc:HH:mm} ({c.EndUtc:MM-dd})" : null))
+                .ToArray()
+            : _timeline.Days
+                .OrderBy(d => d.DateUtc)
+                .Select(d => new Row(
+                    d.DateUtc.ToString("MM-dd"),
+                    d.DateUtc.ToString("yyyy-MM-dd"),
+                    d.DateUtc,
+                    d.IngestedGb,
+                    capLine,
+                    d.GapDuration,
+                    d.EstimatedUncappedGb,
+                    DayGapTooltip(d)))
+                .ToArray();
+
+        _uncappedPoints = Model
+            .Where(r => r.EstUncappedGb.HasValue)
+            .Select(r => new UncappedPoint(r.Label, r.EstUncappedGb.Value))
+            .ToArray();
+
+        _hitDays = Model.Count(r => r.GapDuration.HasValue);
+        _estLostGb = Model
+            .Where(r => r.EstUncappedGb.HasValue)
+            .Sum(r => Math.Max(0, r.EstUncappedGb.Value - r.IngestedGb));
+
+        StateHasChanged();
+    }
+
+    // "Capped 00:00–12:00, 22:24–24:00 UTC" — shows the resume (end of a carry-over gap) and any re-cap.
+    private static string DayGapTooltip(CapDay d)
+    {
+        if (d.CappedIntervals.Count == 0) return null;
+        var dayEnd = d.DateUtc.AddDays(1);
+        var parts = d.CappedIntervals.Select(iv =>
+            $"{iv.StartUtc:HH:mm}–{(iv.EndUtc >= dayEnd ? "24:00" : iv.EndUtc.ToString("HH:mm"))}");
+        return "Capped " + string.Join(", ", parts) + " UTC";
+    }
+
     public void Dispose()
     {
         if (_selector != null) _selector.OnChanged -= OnSelectorChanged;
@@ -250,17 +298,14 @@ else
         _cts?.Dispose();
     }
 
-    // HitSortKey lets the "Cap hit" column sort chronologically (DateTime.MaxValue floats no-hit days
-    // to the end) while the cell itself renders just the HH:mm badge. CapLine is the (non-nullable)
-    // cap value repeated on every row so the reference-line series never sees a null; EstUncappedGb
-    // stays nullable for the grid ("—" on non-hit days) but is fed to the chart only via the filtered
-    // _uncappedPoints set.
-    private sealed record Row(DateTime DateUtc, string DateLabel, double IngestedGb, double CapLine, DateTime? ResumeUtc, TimeSpan? GapDuration, double? EstUncappedGb)
+    // Label = short chart x-label; Period = full grid display; SortKey = chronological sort. CapLine is the
+    // (non-nullable) cap value repeated on every row so the reference-line series never sees a null.
+    private sealed record Row(string Label, string Period, DateTime SortKey, double IngestedGb, double CapLine, TimeSpan? GapDuration, double? EstUncappedGb, string GapTooltip)
     {
         public double GapHours => GapDuration?.TotalHours ?? 0;
     }
 
-    /// <summary>Hit-day-only point for the est-uncapped marker series — non-nullable value so the
+    /// <summary>Capped-row-only point for the est-uncapped marker series — non-nullable value so the
     /// Radzen chart tooltip never dereferences a null.</summary>
-    private sealed record UncappedPoint(string DateLabel, double EstUncappedGb);
+    private sealed record UncappedPoint(string Label, double EstUncappedGb);
 }

--- a/Quilt4Net.Toolkit.Blazor/Features/Log/CapTimelineView.razor
+++ b/Quilt4Net.Toolkit.Blazor/Features/Log/CapTimelineView.razor
@@ -42,20 +42,20 @@ else
     else
     {
         <RadzenText TextStyle="TextStyle.H6" Text="@HeaderText" />
-        @if (_capGb.HasValue)
+        @if (EffectiveCapGb.HasValue || _hitDays > 0)
         {
             <RadzenText TextStyle="TextStyle.Body2" class="rz-mb-1"
-                        Text="@($"Cap size: {_capGb.Value:N0} GB · resets at {ResetLabel} UTC")" />
+                        Text="@($"Cap size: {CapSizeLabel} · resets at {ResetLabel}")" />
         }
-        @if (_capGb.HasValue && _hitDays > 0)
+        @if (EffectiveCapGb.HasValue && _hitDays > 0)
         {
             <RadzenText TextStyle="TextStyle.Caption" class="rz-mb-2"
-                        Text="@($"Estimated volume lost to the cap over this range: {_estLostGb:N1} GB (sum of est. uncapped − ingested on hit days).")" />
+                        Text="@($"Estimated volume lost to the cap over this range: {_estLostGb:N1} GB (sum of est. uncapped − ingested on capped days).")" />
         }
 
         <RadzenChart>
             <RadzenColumnSeries Data="@Model" CategoryProperty="DateLabel" ValueProperty="IngestedGb" Title="Ingested" />
-            @if (_capGb.HasValue)
+            @if (EffectiveCapGb.HasValue)
             {
                 @* Constant value on every row → renders as a horizontal reference line at the cap.
                    CapLine is a non-nullable double (the series only renders when a cap exists) so
@@ -89,11 +89,11 @@ else
                 <RadzenDataGridColumn Title="Ingested" Property="@nameof(Row.IngestedGb)" TextAlign="TextAlign.Right">
                     <Template>@context.IngestedGb.ToString("N2") GB</Template>
                 </RadzenDataGridColumn>
-                <RadzenDataGridColumn Title="Capped for" Property="@nameof(Row.HitSortKey)" TextAlign="TextAlign.Right">
+                <RadzenDataGridColumn Title="Capped for" Property="@nameof(Row.GapHours)" TextAlign="TextAlign.Right">
                     <Template>
                         @if (context.GapDuration.HasValue)
                         {
-                            <span title="@($"Cap hit at {context.CapHitUtc:HH:mm} UTC")">
+                            <span title="@(context.ResumeUtc.HasValue ? $"Data resumed at {context.ResumeUtc:HH:mm} UTC" : "Capped (no resume in range)")">
                                 <RadzenBadge BadgeStyle="BadgeStyle.Danger" Text="@FormatGap(context.GapDuration.Value)" />
                             </span>
                         }
@@ -115,6 +115,7 @@ else
     private Row[] Model { get; set; }
     private UncappedPoint[] _uncappedPoints = [];
     private double? _capGb;
+    private double? _derivedCapGb;
     private TimeSpan? _capResetUtc;
     private int _hitDays;
     private double _estLostGb;
@@ -134,11 +135,17 @@ else
 
     private IApplicationInsightsContext EffectiveContext => Context ?? _selector?.Selected;
 
-    private string HeaderText => _capGb.HasValue
-        ? $"Daily cap: {_capGb.Value:N0} GB · hit on {_hitDays} of {Model.Length} days"
-        : $"No daily cap configured · {Model.Length} days of billed volume";
+    private double? EffectiveCapGb => _derivedCapGb ?? _capGb;
 
-    private string ResetLabel => (_capResetUtc ?? TimeSpan.Zero).ToString(@"hh\:mm");
+    private string HeaderText => EffectiveCapGb.HasValue
+        ? $"Daily cap ≈ {EffectiveCapGb.Value:N0} GB · capped on {_hitDays} of {Model.Length} days"
+        : $"No cap detected · {Model.Length} days of billed volume";
+
+    private string CapSizeLabel => _derivedCapGb.HasValue
+        ? $"{_derivedCapGb.Value:N0} GB (measured)"
+        : _capGb.HasValue ? $"{_capGb.Value:N0} GB (configured)" : "unknown";
+
+    private string ResetLabel => _capResetUtc.HasValue ? _capResetUtc.Value.ToString(@"hh\:mm") + " UTC" : "not detected";
 
     private static string FormatGap(TimeSpan gap) => $"{(int)gap.TotalHours:D2}:{gap.Minutes:D2}";
 
@@ -197,6 +204,7 @@ else
             if (token.IsCancellationRequested) return;
 
             _capGb = timeline.CapGb;
+            _derivedCapGb = timeline.DerivedCapGb;
             _capResetUtc = timeline.CapResetUtc;
             Model = timeline.Days
                 .OrderBy(d => d.DateUtc)
@@ -204,8 +212,8 @@ else
                     d.DateUtc,
                     d.DateUtc.ToString("MM-dd"),
                     d.IngestedGb,
-                    timeline.CapGb ?? 0,
-                    d.CapHitUtc,
+                    (_derivedCapGb ?? timeline.CapGb) ?? 0,
+                    d.ResumeUtc,
                     d.GapDuration,
                     d.EstimatedUncappedGb))
                 .ToArray();
@@ -217,7 +225,7 @@ else
                 .Select(r => new UncappedPoint(r.DateLabel, r.EstUncappedGb.Value))
                 .ToArray();
 
-            _hitDays = Model.Count(r => r.CapHitUtc.HasValue);
+            _hitDays = Model.Count(r => r.GapDuration.HasValue);
             _estLostGb = Model
                 .Where(r => r.EstUncappedGb.HasValue)
                 .Sum(r => Math.Max(0, r.EstUncappedGb.Value - r.IngestedGb));
@@ -247,9 +255,9 @@ else
     // cap value repeated on every row so the reference-line series never sees a null; EstUncappedGb
     // stays nullable for the grid ("—" on non-hit days) but is fed to the chart only via the filtered
     // _uncappedPoints set.
-    private sealed record Row(DateTime DateUtc, string DateLabel, double IngestedGb, double CapLine, DateTime? CapHitUtc, TimeSpan? GapDuration, double? EstUncappedGb)
+    private sealed record Row(DateTime DateUtc, string DateLabel, double IngestedGb, double CapLine, DateTime? ResumeUtc, TimeSpan? GapDuration, double? EstUncappedGb)
     {
-        public DateTime HitSortKey => CapHitUtc ?? DateTime.MaxValue;
+        public double GapHours => GapDuration?.TotalHours ?? 0;
     }
 
     /// <summary>Hit-day-only point for the est-uncapped marker series — non-nullable value so the

--- a/Quilt4Net.Toolkit.Blazor/Features/Log/CapTimelineView.razor
+++ b/Quilt4Net.Toolkit.Blazor/Features/Log/CapTimelineView.razor
@@ -65,19 +65,15 @@ else
                         Text="@($"Estimated volume lost to the cap over this range: {_estLostGb:N1} GB (sum of est. uncapped − ingested on capped days).")" />
         }
 
+        @* Ingested (bottom) + the estimated capped-away volume (top) stacked, so the full bar height is
+           the estimated uncapped volume. The capped-away segment is 0 (invisible) on uncapped rows. *@
         <RadzenChart>
-            <RadzenColumnSeries Data="@Model" CategoryProperty="Label" ValueProperty="IngestedGb" Title="Ingested" />
+            <RadzenStackedColumnSeries Data="@Model" CategoryProperty="Label" ValueProperty="IngestedGb" Title="Ingested" />
+            <RadzenStackedColumnSeries Data="@Model" CategoryProperty="Label" ValueProperty="ExtraGb" Title="Capped away (est.)" />
             @if (EffectiveCapGb.HasValue)
             {
                 @* Constant value on every row → renders as a horizontal reference line at the cap. *@
                 <RadzenLineSeries Data="@Model" CategoryProperty="Label" ValueProperty="CapLine" Title="Daily cap" LineType="LineType.Dashed" />
-            }
-            @if (_uncappedPoints.Length > 0)
-            {
-                @* Filtered to capped rows with a non-nullable value so the chart tooltip never sees a null. *@
-                <RadzenLineSeries Data="@_uncappedPoints" CategoryProperty="Label" ValueProperty="EstUncappedGb" Title="Est. uncapped" Smooth="false">
-                    <RadzenMarkers MarkerType="MarkerType.Diamond" />
-                </RadzenLineSeries>
             }
             <RadzenCategoryAxis>
                 <RadzenAxisTitle Text="@PeriodTitle" />
@@ -120,7 +116,6 @@ else
 
 @code {
     private Row[] Model { get; set; }
-    private UncappedPoint[] _uncappedPoints = [];
     private double? _capGb;
     private double? _derivedCapGb;
     private TimeSpan? _capResetUtc;
@@ -208,7 +203,6 @@ else
 
         _loading = true;
         Model = null;
-        _uncappedPoints = [];
         StateHasChanged();
 
         try
@@ -238,7 +232,7 @@ else
     // the user toggles "Break by".
     private void Rebuild()
     {
-        if (_timeline == null) { Model = []; _uncappedPoints = []; return; }
+        if (_timeline == null) { Model = []; return; }
 
         var capLine = (_derivedCapGb ?? _capGb) ?? 0;
 
@@ -268,11 +262,6 @@ else
                     DayGapTooltip(d)))
                 .ToArray();
 
-        _uncappedPoints = Model
-            .Where(r => r.EstUncappedGb.HasValue)
-            .Select(r => new UncappedPoint(r.Label, r.EstUncappedGb.Value))
-            .ToArray();
-
         _hitDays = Model.Count(r => r.GapDuration.HasValue);
         _estLostGb = Model
             .Where(r => r.EstUncappedGb.HasValue)
@@ -300,12 +289,11 @@ else
 
     // Label = short chart x-label; Period = full grid display; SortKey = chronological sort. CapLine is the
     // (non-nullable) cap value repeated on every row so the reference-line series never sees a null.
+    // ExtraGb is the est. capped-away volume (uncapped − ingested), stacked on top of the Ingested bar;
+    // 0 on uncapped rows so its column segment is invisible.
     private sealed record Row(string Label, string Period, DateTime SortKey, double IngestedGb, double CapLine, TimeSpan? GapDuration, double? EstUncappedGb, string GapTooltip)
     {
         public double GapHours => GapDuration?.TotalHours ?? 0;
+        public double ExtraGb => EstUncappedGb.HasValue ? Math.Max(0, EstUncappedGb.Value - IngestedGb) : 0;
     }
-
-    /// <summary>Capped-row-only point for the est-uncapped marker series — non-nullable value so the
-    /// Radzen chart tooltip never dereferences a null.</summary>
-    private sealed record UncappedPoint(string Label, double EstUncappedGb);
 }

--- a/Quilt4Net.Toolkit.Blazor/Features/Log/CapTimelineView.razor
+++ b/Quilt4Net.Toolkit.Blazor/Features/Log/CapTimelineView.razor
@@ -42,6 +42,11 @@ else
     else
     {
         <RadzenText TextStyle="TextStyle.H6" Text="@HeaderText" />
+        @if (_capGb.HasValue)
+        {
+            <RadzenText TextStyle="TextStyle.Body2" class="rz-mb-1"
+                        Text="@($"Cap size: {_capGb.Value:N0} GB · resets at {ResetLabel} UTC")" />
+        }
         @if (_capGb.HasValue && _hitDays > 0)
         {
             <RadzenText TextStyle="TextStyle.Caption" class="rz-mb-2"
@@ -84,11 +89,13 @@ else
                 <RadzenDataGridColumn Title="Ingested" Property="@nameof(Row.IngestedGb)" TextAlign="TextAlign.Right">
                     <Template>@context.IngestedGb.ToString("N2") GB</Template>
                 </RadzenDataGridColumn>
-                <RadzenDataGridColumn Title="Cap hit (UTC)" Property="@nameof(Row.HitSortKey)" TextAlign="TextAlign.Right">
+                <RadzenDataGridColumn Title="Capped for" Property="@nameof(Row.HitSortKey)" TextAlign="TextAlign.Right">
                     <Template>
-                        @if (context.CapHitUtc.HasValue)
+                        @if (context.GapDuration.HasValue)
                         {
-                            <RadzenBadge BadgeStyle="BadgeStyle.Danger" Text="@context.CapHitUtc.Value.ToString("HH:mm")" />
+                            <span title="@($"Cap hit at {context.CapHitUtc:HH:mm} UTC")">
+                                <RadzenBadge BadgeStyle="BadgeStyle.Danger" Text="@FormatGap(context.GapDuration.Value)" />
+                            </span>
                         }
                         else
                         {
@@ -108,6 +115,7 @@ else
     private Row[] Model { get; set; }
     private UncappedPoint[] _uncappedPoints = [];
     private double? _capGb;
+    private TimeSpan? _capResetUtc;
     private int _hitDays;
     private double _estLostGb;
     private string _configError;
@@ -129,6 +137,10 @@ else
     private string HeaderText => _capGb.HasValue
         ? $"Daily cap: {_capGb.Value:N0} GB · hit on {_hitDays} of {Model.Length} days"
         : $"No daily cap configured · {Model.Length} days of billed volume";
+
+    private string ResetLabel => (_capResetUtc ?? TimeSpan.Zero).ToString(@"hh\:mm");
+
+    private static string FormatGap(TimeSpan gap) => $"{(int)gap.TotalHours:D2}:{gap.Minutes:D2}";
 
     protected override async Task OnInitializedAsync()
     {
@@ -185,6 +197,7 @@ else
             if (token.IsCancellationRequested) return;
 
             _capGb = timeline.CapGb;
+            _capResetUtc = timeline.CapResetUtc;
             Model = timeline.Days
                 .OrderBy(d => d.DateUtc)
                 .Select(d => new Row(
@@ -193,6 +206,7 @@ else
                     d.IngestedGb,
                     timeline.CapGb ?? 0,
                     d.CapHitUtc,
+                    d.GapDuration,
                     d.EstimatedUncappedGb))
                 .ToArray();
 
@@ -233,7 +247,7 @@ else
     // cap value repeated on every row so the reference-line series never sees a null; EstUncappedGb
     // stays nullable for the grid ("—" on non-hit days) but is fed to the chart only via the filtered
     // _uncappedPoints set.
-    private sealed record Row(DateTime DateUtc, string DateLabel, double IngestedGb, double CapLine, DateTime? CapHitUtc, double? EstUncappedGb)
+    private sealed record Row(DateTime DateUtc, string DateLabel, double IngestedGb, double CapLine, DateTime? CapHitUtc, TimeSpan? GapDuration, double? EstUncappedGb)
     {
         public DateTime HitSortKey => CapHitUtc ?? DateTime.MaxValue;
     }

--- a/Quilt4Net.Toolkit.Blazor/Features/Log/LogVolumeView.razor
+++ b/Quilt4Net.Toolkit.Blazor/Features/Log/LogVolumeView.razor
@@ -11,11 +11,13 @@ else
 {
     <RadzenStack Orientation="Orientation.Vertical" Gap="0" class="rz-mb-2">
         <RadzenText TextStyle="TextStyle.Caption" Text="Range" />
-        <RadzenSelectBar @bind-Value="_range" TValue="TimeSpan" Size="ButtonSize.Small" Change="@(_ => LoadAsync())">
+        <RadzenSelectBar @bind-Value="_range" TValue="VolumeRange" Size="ButtonSize.Small" Change="@(_ => LoadAsync())">
             <Items>
-                <RadzenSelectBarItem Text="1h" Value="@TimeSpan.FromHours(1)" />
-                <RadzenSelectBarItem Text="24h" Value="@TimeSpan.FromHours(24)" />
-                <RadzenSelectBarItem Text="7d" Value="@TimeSpan.FromDays(7)" />
+                <RadzenSelectBarItem Text="1h" Value="VolumeRange.Hour1" />
+                <RadzenSelectBarItem Text="24h" Value="VolumeRange.Hours24" />
+                <RadzenSelectBarItem Text="Today" Value="VolumeRange.Today" />
+                <RadzenSelectBarItem Text="Yesterday" Value="VolumeRange.Yesterday" />
+                <RadzenSelectBarItem Text="7d" Value="VolumeRange.Days7" />
             </Items>
         </RadzenSelectBar>
     </RadzenStack>
@@ -32,10 +34,31 @@ else
     }
     else
     {
-        <RadzenText TextStyle="TextStyle.H6" Text="@($"Total ingested: {FormatSize(_totalMb)} over the last {RangeLabel(_range)}")" />
-        <RadzenChart>
-            <RadzenPieSeries Data="@Model" CategoryProperty="Source" ValueProperty="Mb" Title="Size" />
-        </RadzenChart>
+        <RadzenText TextStyle="TextStyle.H6" Text="@($"Total ingested: {FormatSize(_totalMb)} over {RangeLabel(_range)}")" />
+        @if (_range == VolumeRange.Days7)
+        {
+            <RadzenChart>
+                @foreach (var series in _series)
+                {
+                    <RadzenLineSeries Data="@series.Points" CategoryProperty="DayLabel" ValueProperty="Mb" Title="@series.Source" Smooth="true">
+                        <RadzenMarkers MarkerType="MarkerType.Circle" />
+                    </RadzenLineSeries>
+                }
+                <RadzenCategoryAxis>
+                    <RadzenAxisTitle Text="Day (UTC)" />
+                </RadzenCategoryAxis>
+                <RadzenValueAxis FormatString="{0:0.#} MB" Min="0">
+                    <RadzenAxisTitle Text="Billed volume" />
+                </RadzenValueAxis>
+                <RadzenLegend Position="LegendPosition.Bottom" />
+            </RadzenChart>
+        }
+        else
+        {
+            <RadzenChart>
+                <RadzenPieSeries Data="@Model" CategoryProperty="Source" ValueProperty="Mb" Title="Size" />
+            </RadzenChart>
+        }
         <RadzenDataGrid Data="@Model" TItem="Row" AllowSorting="true" AllowPaging="true" PageSize="10">
             <Columns>
                 <RadzenDataGridColumn Title="Source" Property="@nameof(Row.Source)" />
@@ -48,6 +71,8 @@ else
                 </RadzenDataGridColumn>
             </Columns>
         </RadzenDataGrid>
+        <RadzenText TextStyle="TextStyle.Caption" Style="color: gray;"
+                    Text="Billing-grade (Usage table). Short ranges can lag behind real-time by Azure's billing-aggregation delay — Log count reads raw telemetry and may show more recent data." />
     }
 }
 
@@ -61,20 +86,25 @@ else
     private IApplicationInsightsConfigurationSelector _selector;
     private CancellationTokenSource _cts;
     private bool _loading;
-    private TimeSpan _range = TimeSpan.FromDays(7);
+    private VolumeRange _range = VolumeRange.Days7;
+    private List<Series> _series = [];
 
     [Parameter]
     public IApplicationInsightsContext Context { get; set; }
 
-    /// <summary>Initial range; the user can change it with the in-view 1h/24h/7d selector.</summary>
+    /// <summary>Initial range; the user can change it with the in-view selector. Days >= 7 starts on the 7d line chart.</summary>
     [Parameter]
     public TimeSpan Range { get; set; } = TimeSpan.FromDays(7);
 
     private IApplicationInsightsContext EffectiveContext => Context ?? _selector?.Selected;
 
+    public enum VolumeRange { Hour1, Hours24, Today, Yesterday, Days7 }
+
     protected override async Task OnInitializedAsync()
     {
-        _range = Range;
+        _range = Range >= TimeSpan.FromDays(7) ? VolumeRange.Days7
+            : Range >= TimeSpan.FromHours(24) ? VolumeRange.Hours24
+            : VolumeRange.Hour1;
 
         _ais = LogConfigurationGuard.TryResolve(ServiceProvider);
         if (_ais == null)
@@ -118,17 +148,46 @@ else
 
         _loading = true;
         Model = null;
+        _series = [];
         StateHasChanged();
 
         try
         {
-            var loaded = await _ais.GetVolumeBySourceAsync(ctx, _range, token).ToArrayAsync(token);
-            if (token.IsCancellationRequested) return;
+            if (_range == VolumeRange.Days7)
+            {
+                var todayUtc = DateTime.UtcNow.Date;
+                var fromUtc = new DateTimeOffset(todayUtc.AddDays(-6), TimeSpan.Zero);
+                var toUtc = DateTimeOffset.UtcNow;
 
-            _totalMb = loaded.Sum(x => x.Mb);
-            Model = loaded
-                .Select(x => new Row(x.Source, x.Mb, _totalMb > 0 ? x.Mb / _totalMb : 0))
-                .ToArray();
+                var points = await _ais.GetVolumeTimelineAsync(ctx, fromUtc, toUtc, token).ToArrayAsync(token);
+                if (token.IsCancellationRequested) return;
+
+                var days = points.Select(p => p.DayUtc.Date).Distinct().OrderBy(d => d).ToArray();
+                _series = points
+                    .GroupBy(p => p.Source)
+                    .OrderByDescending(g => g.Sum(x => x.Mb))
+                    .Select(g => new Series(g.Key, days
+                        .Select(d => new SeriesPoint(d.ToString("MM-dd"), g.Where(x => x.DayUtc.Date == d).Sum(x => x.Mb)))
+                        .ToArray()))
+                    .ToList();
+
+                _totalMb = points.Sum(p => p.Mb);
+                Model = points
+                    .GroupBy(p => p.Source)
+                    .Select(g => new Row(g.Key, g.Sum(x => x.Mb), _totalMb > 0 ? g.Sum(x => x.Mb) / _totalMb : 0))
+                    .OrderByDescending(r => r.Mb)
+                    .ToArray();
+            }
+            else
+            {
+                var loaded = await LoadBySourceAsync(ctx, token);
+                if (token.IsCancellationRequested) return;
+
+                _totalMb = loaded.Sum(x => x.Mb);
+                Model = loaded
+                    .Select(x => new Row(x.Source, x.Mb, _totalMb > 0 ? x.Mb / _totalMb : 0))
+                    .ToArray();
+            }
         }
         catch (OperationCanceledException) when (token.IsCancellationRequested)
         {
@@ -143,6 +202,29 @@ else
         }
     }
 
+    private async Task<VolumeBySource[]> LoadBySourceAsync(IApplicationInsightsContext ctx, CancellationToken token)
+    {
+        switch (_range)
+        {
+            case VolumeRange.Hour1:
+                return await _ais.GetVolumeBySourceAsync(ctx, TimeSpan.FromHours(1), token).ToArrayAsync(token);
+            case VolumeRange.Hours24:
+                return await _ais.GetVolumeBySourceAsync(ctx, TimeSpan.FromHours(24), token).ToArrayAsync(token);
+            case VolumeRange.Today:
+            {
+                var from = new DateTimeOffset(DateTime.UtcNow.Date, TimeSpan.Zero);
+                return await _ais.GetVolumeBySourceAsync(ctx, from, DateTimeOffset.UtcNow, token).ToArrayAsync(token);
+            }
+            case VolumeRange.Yesterday:
+            {
+                var start = DateTime.UtcNow.Date.AddDays(-1);
+                return await _ais.GetVolumeBySourceAsync(ctx, new DateTimeOffset(start, TimeSpan.Zero), new DateTimeOffset(start.AddDays(1), TimeSpan.Zero), token).ToArrayAsync(token);
+            }
+            default:
+                return Array.Empty<VolumeBySource>();
+        }
+    }
+
     // Auto-scaled display from a megabyte value. Sorting uses the raw MB (always MB), so the unit
     // shown per row (GB/MB/KB) never affects ordering.
     private static string FormatSize(double mb)
@@ -152,10 +234,14 @@ else
         return $"{mb * 1024.0:N0} KB";
     }
 
-    private static string RangeLabel(TimeSpan range)
-        => range >= TimeSpan.FromDays(7) ? "7 days"
-            : range >= TimeSpan.FromHours(24) ? "24 hours"
-            : "1 hour";
+    private static string RangeLabel(VolumeRange range) => range switch
+    {
+        VolumeRange.Hour1 => "the last 1 hour",
+        VolumeRange.Hours24 => "the last 24 hours",
+        VolumeRange.Today => "today (UTC)",
+        VolumeRange.Yesterday => "yesterday (UTC)",
+        _ => "the last 7 days",
+    };
 
     public void Dispose()
     {
@@ -165,4 +251,6 @@ else
     }
 
     private sealed record Row(string Source, double Mb, double Share);
+    private sealed record Series(string Source, SeriesPoint[] Points);
+    private sealed record SeriesPoint(string DayLabel, double Mb);
 }

--- a/Quilt4Net.Toolkit.Blazor/Features/Metrics/MetricsView.razor
+++ b/Quilt4Net.Toolkit.Blazor/Features/Metrics/MetricsView.razor
@@ -1,4 +1,5 @@
 @using Microsoft.Extensions.DependencyInjection
+@using Blazored.LocalStorage
 @using Quilt4Net.Toolkit.Blazor.Features.ApplicationInsights
 @using Quilt4Net.Toolkit.Blazor.Framework
 @using Quilt4Net.Toolkit.Features.ApplicationInsights
@@ -26,7 +27,7 @@
             <RadzenStack Orientation="Orientation.Vertical" Gap="0">
                 <RadzenText TextStyle="TextStyle.Caption" Text="Configuration" />
                 <RadzenDropDown Data="@Configs" @bind-Value="_selectedConfig" TValue="ApplicationInsightsConfigurationResponse"
-                                TextProperty="Name" Change="@(_ => ReloadAsync(force: false))" />
+                                TextProperty="Name" Change="@(_ => OnConfigChangedAsync())" />
             </RadzenStack>
         }
         <RadzenStack Orientation="Orientation.Vertical" Gap="0">
@@ -186,6 +187,16 @@
     [Parameter]
     public IReadOnlyList<ApplicationInsightsConfigurationResponse> Configs { get; set; }
 
+    /// <summary>
+    /// Optional scope for remembering the selected configuration across sessions (e.g. the team key).
+    /// When set and a <see cref="Configs"/> dropdown is shown, the choice is persisted to local storage.
+    /// </summary>
+    [Parameter]
+    public string StorageScope { get; set; }
+
+    private ILocalStorageService _localStorage;
+    private string ConfigStorageKey => string.IsNullOrEmpty(StorageScope) ? null : $"Quilt4Net.Metrics.{StorageScope}.config";
+
     private IApplicationInsightsContext EffectiveContext
         => Context ?? _selectedConfig ?? _selector?.Selected;
 
@@ -196,6 +207,7 @@
         // still work, they just lose cross-page persistence.
         _scopedCache = ServiceProvider.GetService<MetricsSeriesCache>();
         _browserTime = ServiceProvider.GetService<IBrowserTimeZoneAccessor>();
+        _localStorage = ServiceProvider.GetService<ILocalStorageService>();
 
         // Explicit Context / Configs bypass the DI selector entirely.
         if (Context == null && Configs is not { Count: > 0 })
@@ -214,6 +226,7 @@
         if (Configs is { Count: > 0 } && _selectedConfig == null)
         {
             _selectedConfig = Configs[0];
+            await RestoreSelectedConfigAsync();
         }
 
         if (EffectiveContext == null)
@@ -228,6 +241,31 @@
     private async void OnSelectorChanged()
     {
         await InvokeAsync(() => ReloadAsync(force: false));
+    }
+
+    // Persist + reload when the user picks a configuration from the Configs dropdown.
+    private async Task OnConfigChangedAsync()
+    {
+        if (ConfigStorageKey != null && _localStorage != null && _selectedConfig != null)
+        {
+            try { await _localStorage.SetItemAsStringAsync(ConfigStorageKey, _selectedConfig.Name); }
+            catch { /* localStorage failures shouldn't break the view */ }
+        }
+        await ReloadAsync(force: false);
+    }
+
+    // Restore the previously-selected configuration (by name) from local storage, if any.
+    private async Task RestoreSelectedConfigAsync()
+    {
+        if (ConfigStorageKey == null || _localStorage == null || Configs is not { Count: > 0 }) return;
+        try
+        {
+            var savedName = await _localStorage.GetItemAsStringAsync(ConfigStorageKey);
+            if (string.IsNullOrEmpty(savedName)) return;
+            var match = Configs.FirstOrDefault(c => c.Name == savedName);
+            if (match != null) _selectedConfig = match;
+        }
+        catch { /* prerender (no JS interop) or corrupt entry — keep the default */ }
     }
 
     private async Task ReloadAsync(bool force)

--- a/Quilt4Net.Toolkit.Blazor/Quilt4Net.Toolkit.Blazor.csproj
+++ b/Quilt4Net.Toolkit.Blazor/Quilt4Net.Toolkit.Blazor.csproj
@@ -26,7 +26,7 @@
        consumers can fetch _content/Quilt4Net.Toolkit.Blazor/<asset> at runtime. -->
   <ItemGroup>
     <PackageReference Include="Microsoft.Authentication.WebAssembly.Msal" Version="10.0.9" />
-    <PackageReference Include="Microsoft.Identity.Client" Version="4.85.0" />
+    <PackageReference Include="Microsoft.Identity.Client" Version="4.85.1" />
     <PackageReference Include="Tharga.Blazor" Version="2.2.0" />
   </ItemGroup>
   <ItemGroup>

--- a/Quilt4Net.Toolkit.Blazor/README.md
+++ b/Quilt4Net.Toolkit.Blazor/README.md
@@ -787,11 +787,11 @@ Two components turn the workspace into a cost picture using billing-grade data f
 ```razor
 @using Quilt4Net.Toolkit.Blazor.Features.Log
 
-<LogVolumeView Range="TimeSpan.FromDays(7)" />   @* pie of billed volume by source table + size table; 1h/24h/7d selector *@
-<CapTimelineView Days="30" />                     @* billed GB/day vs the daily cap, first-hit times, est. uncapped; 14/30/90d selector *@
+<LogVolumeView Range="TimeSpan.FromDays(7)" />   @* billed volume by source: pie for 1h/24h/Today/Yesterday, per-source line for 7d *@
+<CapTimelineView Days="30" />                     @* billed GB vs the daily cap (Operation-event detection); Break by day or cap cycle; ingested + est-capped-away stacked bars; 14/30/90d *@
 ```
 
-`LogCountByServiceView` also gains a **Show: Count / Volume** toggle (record count ↔ billed volume, a local recompute), two marginal pies (by severity / by service), and a **Sampling** section that reports retained vs sampling-corrected (`sum(ItemCount)`) figures and the effective sampling rate per source — stating plainly when sampling is not in effect. On Quilt4Net Server these surface as the **Logging volume** and **Daily cap** tabs on `/monitor/metrics` and `/developer/metrics`. Full reference: [Log views → Cost & volume](https://quilt4net.com/articles/log-views.html).
+`LogCountByServiceView` also gains a **Show: Count / Volume** toggle (record count ↔ billed volume, a local recompute), two marginal pies (by severity / by service), and a **Sampling** section that reports retained vs sampling-corrected (`sum(ItemCount)`) figures and the effective sampling rate per source — stating plainly when sampling is not in effect. On Quilt4Net Server these surface as the **Volume** and **Daily cap** tabs of the **Log volume** page (`/monitor/volume`, `/developer/volume`). Full reference: [Log views → Cost & volume](https://quilt4net.com/articles/log-views.html).
 
 ## Version matrix
 

--- a/Quilt4Net.Toolkit.Health.Tests/Quilt4Net.Toolkit.Health.Tests.csproj
+++ b/Quilt4Net.Toolkit.Health.Tests/Quilt4Net.Toolkit.Health.Tests.csproj
@@ -9,7 +9,7 @@
 		<PackageReference Include="AutoBogus" Version="2.13.1" />
 		<PackageReference Include="FluentAssertions" Version="8.10.0" />
 		<PackageReference Include="JetBrains.Annotations" Version="2026.2.0" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
 		<PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.9" />
 		<PackageReference Include="Moq" Version="4.20.72" />
 		<PackageReference Include="OneOf" Version="3.0.271" />

--- a/Quilt4Net.Toolkit.Mcp.Tests/Quilt4Net.Toolkit.Mcp.Tests.csproj
+++ b/Quilt4Net.Toolkit.Mcp.Tests/Quilt4Net.Toolkit.Mcp.Tests.csproj
@@ -7,7 +7,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="FluentAssertions" Version="8.10.0" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
 		<PackageReference Include="Moq" Version="4.20.72" />
 		<PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
 			<PrivateAssets>all</PrivateAssets>

--- a/Quilt4Net.Toolkit.Tests/CapTimelineBuilderTests.cs
+++ b/Quilt4Net.Toolkit.Tests/CapTimelineBuilderTests.cs
@@ -5,7 +5,7 @@ using FluentAssertions;
 using Quilt4Net.Toolkit.Features.ApplicationInsights;
 using Xunit;
 
-namespace Quilt4Net.Toolkit.Blazor.Tests;
+namespace Quilt4Net.Toolkit.Tests;
 
 public class CapTimelineBuilderTests
 {

--- a/Quilt4Net.Toolkit.Tests/Quilt4Net.Toolkit.Tests.csproj
+++ b/Quilt4Net.Toolkit.Tests/Quilt4Net.Toolkit.Tests.csproj
@@ -9,7 +9,7 @@
 		<PackageReference Include="AutoFixture" Version="4.18.1" />
 		<PackageReference Include="FluentAssertions" Version="8.10.0" />
 		<PackageReference Include="JetBrains.Annotations" Version="2026.2.0" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
 		<PackageReference Include="Moq" Version="4.20.72" />
 		<PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.9" />
 		<PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">

--- a/Quilt4Net.Toolkit/ApplicationInsightsRegistration.cs
+++ b/Quilt4Net.Toolkit/ApplicationInsightsRegistration.cs
@@ -108,6 +108,11 @@ public static class ApplicationInsightsRegistration
             {
                 x.DefaultFreshSpan = TimeSpan.FromMinutes(10);
             });
+            // Per-day billed volume timeline (Usage table) for the 7d volume line chart.
+            s.RegisterType<VolumeTimelinePoint[], IMemory>(x =>
+            {
+                x.DefaultFreshSpan = TimeSpan.FromMinutes(10);
+            });
             // Daily ingestion-cap timeline (Operation + Usage). Daily-grained; 10 minutes is plenty.
             s.RegisterType<CapTimeline, IMemory>(x =>
             {
@@ -180,6 +185,7 @@ public static class ApplicationInsightsRegistration
             s.RegisterType<DiskCapacity[], IMemory>(x => { x.DefaultFreshSpan = TimeSpan.FromMinutes(10); });
             s.RegisterType<LogCountByServiceCell[], IMemory>(x => { x.DefaultFreshSpan = TimeSpan.FromMinutes(10); });
             s.RegisterType<VolumeBySource[], IMemory>(x => { x.DefaultFreshSpan = TimeSpan.FromMinutes(10); });
+            s.RegisterType<VolumeTimelinePoint[], IMemory>(x => { x.DefaultFreshSpan = TimeSpan.FromMinutes(10); });
             s.RegisterType<CapTimeline, IMemory>(x => { x.DefaultFreshSpan = TimeSpan.FromMinutes(10); });
         });
     }

--- a/Quilt4Net.Toolkit/Features/ApplicationInsights/ApplicationInsightsService.cs
+++ b/Quilt4Net.Toolkit/Features/ApplicationInsights/ApplicationInsightsService.cs
@@ -267,62 +267,37 @@ Usage
 
                 var window = new LogsQueryTimeRange(TimeSpan.FromDays(days));
 
-                // First cap-hit per day, from the workspace "data collection stopped" operation events.
-                var hits = new Dictionary<DateTime, DateTime>();
-                var hitResp = await client.QueryWorkspaceAsync(workspaceId,
-                    "Operation | where OperationCategory == 'Data Collection Status' | where Detail has 'stopped due to daily limit' | summarize HitUtc = min(TimeGenerated) by Day = startofday(TimeGenerated)",
-                    window);
-                foreach (var table in hitResp.Value.AllTables)
-                {
-                    var dayIdx = GetColumnIndex(table, "Day");
-                    var hitIdx = GetColumnIndex(table, "HitUtc");
-                    foreach (var row in table.Rows) hits[GetDateTime(row, dayIdx)] = GetDateTime(row, hitIdx);
-                }
-
-                // Billed volume per day (GB).
-                var volume = new Dictionary<DateTime, double>();
+                // Hourly billable volume. A daily cap stops ingestion until the workspace's (variable)
+                // reset time, so capped periods show up as hours with no billable volume; CapTimelineBuilder
+                // detects the gaps, the resume (reset) time, the per-day capped duration and the cap size.
+                var hourly = new Dictionary<DateTime, double>();
                 var volResp = await client.QueryWorkspaceAsync(workspaceId,
-                    "Usage | where IsBillable == true | summarize Gb = sum(Quantity) / 1024.0 by Day = startofday(TimeGenerated)",
+                    "Usage | where IsBillable == true | summarize Mb = sum(Quantity) by Hour = bin(TimeGenerated, 1h) | order by Hour asc",
                     window);
                 foreach (var table in volResp.Value.AllTables)
                 {
-                    var dayIdx = GetColumnIndex(table, "Day");
-                    var gbIdx = GetColumnIndex(table, "Gb");
+                    var hourIdx = GetColumnIndex(table, "Hour");
+                    var mbIdx = GetColumnIndex(table, "Mb");
                     foreach (var row in table.Rows)
                     {
-                        var raw = row[gbIdx];
+                        var raw = row[mbIdx];
                         if (raw is null) continue;
-                        volume[GetDateTime(row, dayIdx)] = System.Convert.ToDouble(raw, System.Globalization.CultureInfo.InvariantCulture);
+                        hourly[GetDateTime(row, hourIdx)] = System.Convert.ToDouble(raw, System.Globalization.CultureInfo.InvariantCulture);
                     }
                 }
 
-                var capDays = volume.Keys.Union(hits.Keys)
-                    .Distinct()
-                    .OrderByDescending(d => d)
-                    .Select(day =>
-                    {
-                        var gb = volume.GetValueOrDefault(day);
-                        DateTime? hit = hits.TryGetValue(day, out var h) ? h : null;
-                        double? est = null;
-                        TimeSpan? gap = null;
-                        if (hit.HasValue)
-                        {
-                            // Volume-at-hit ≈ the cap; extrapolate to a full day by the elapsed fraction.
-                            var hours = (hit.Value - day).TotalHours;
-                            var baseGb = capGb ?? gb;
-                            if (hours > 0) est = baseGb * 24.0 / hours;
+                // Fill a continuous hourly series from the first to the last hour that had data, so
+                // capped (zero-volume) hours between them are visible as gaps.
+                var hourSeries = new List<HourVolume>();
+                if (hourly.Count > 0)
+                {
+                    var start = hourly.Keys.Min();
+                    var end = hourly.Keys.Max();
+                    for (var h = start; h <= end; h = h.AddHours(1))
+                        hourSeries.Add(new HourVolume { HourUtc = h, Mb = hourly.GetValueOrDefault(h) });
+                }
 
-                            // Capped until the next daily reset. Azure's default reset is 00:00 UTC, i.e.
-                            // the start of the next day, so the gap is the time from the hit to next midnight.
-                            gap = day.AddDays(1) - hit.Value;
-                        }
-                        return new CapDay { DateUtc = day, IngestedGb = gb, CapHitUtc = hit, GapDuration = gap, EstimatedUncappedGb = est };
-                    })
-                    .ToArray();
-
-                // Reset time-of-day: the Azure daily-cap default is 00:00 UTC. Surfaced only when a cap is configured.
-                var resetUtc = capGb.HasValue ? (TimeSpan?)TimeSpan.Zero : null;
-                return new CapTimeline { CapGb = capGb, CapResetUtc = resetUtc, Days = capDays };
+                return CapTimelineBuilder.Build(hourSeries, capGb);
             }
             catch (Exception e)
             {

--- a/Quilt4Net.Toolkit/Features/ApplicationInsights/ApplicationInsightsService.cs
+++ b/Quilt4Net.Toolkit/Features/ApplicationInsights/ApplicationInsightsService.cs
@@ -267,37 +267,65 @@ Usage
 
                 var window = new LogsQueryTimeRange(TimeSpan.FromDays(days));
 
-                // Hourly billable volume. A daily cap stops ingestion until the workspace's (variable)
-                // reset time, so capped periods show up as hours with no billable volume; CapTimelineBuilder
-                // detects the gaps, the resume (reset) time, the per-day capped duration and the cap size.
-                var hourly = new Dictionary<DateTime, double>();
+                // Authoritative cap timing from the workspace's daily-cap Operation events: when collection
+                // stopped (cap hit) and when it resumed (daily-limit reset). Far more precise than the
+                // ~1h-lagged Usage table.
+                var stops = await QueryEventTimesAsync(client, workspaceId,
+                    "Operation | where OperationCategory == 'Data Collection Status' | where Detail has 'stopped due to daily limit' | project TimeGenerated | order by TimeGenerated asc",
+                    window);
+                var resets = await QueryEventTimesAsync(client, workspaceId,
+                    "Operation | where OperationCategory == 'Data Collection Status' | where Detail has 'daily limit reset' | project TimeGenerated | order by TimeGenerated asc",
+                    window);
+
+                // Billed volume per UTC day (GB) for the bars.
+                var dailyGb = new Dictionary<DateTime, double>();
                 var volResp = await client.QueryWorkspaceAsync(workspaceId,
-                    "Usage | where IsBillable == true | summarize Mb = sum(Quantity) by Hour = bin(TimeGenerated, 1h) | order by Hour asc",
+                    "Usage | where IsBillable == true | summarize Gb = sum(Quantity) / 1024.0 by Day = startofday(TimeGenerated)",
                     window);
                 foreach (var table in volResp.Value.AllTables)
                 {
-                    var hourIdx = GetColumnIndex(table, "Hour");
-                    var mbIdx = GetColumnIndex(table, "Mb");
+                    var dayIdx = GetColumnIndex(table, "Day");
+                    var gbIdx = GetColumnIndex(table, "Gb");
                     foreach (var row in table.Rows)
                     {
-                        var raw = row[mbIdx];
+                        var raw = row[gbIdx];
                         if (raw is null) continue;
-                        hourly[GetDateTime(row, hourIdx)] = System.Convert.ToDouble(raw, System.Globalization.CultureInfo.InvariantCulture);
+                        dailyGb[GetDateTime(row, dayIdx)] = System.Convert.ToDouble(raw, System.Globalization.CultureInfo.InvariantCulture);
                     }
                 }
 
-                // Fill a continuous hourly series from the first to the last hour that had data, so
-                // capped (zero-volume) hours between them are visible as gaps.
-                var hourSeries = new List<HourVolume>();
-                if (hourly.Count > 0)
+                // Cap size = largest billable volume in a single reset cycle (the quota the cap allows).
+                // Cycles are aligned to the reset hour; the Usage table reports ~1h late, so shift the bin
+                // by (resetHour + 1h). Rounded to the nearest GB to read as the configured cap.
+                double? measuredCapGb = null;
+                if (resets.Count > 0)
                 {
-                    var start = hourly.Keys.Min();
-                    var end = hourly.Keys.Max();
-                    for (var h = start; h <= end; h = h.AddHours(1))
-                        hourSeries.Add(new HourVolume { HourUtc = h, Mb = hourly.GetValueOrDefault(h) });
+                    var resetHour = resets
+                        .GroupBy(r => (int)Math.Round(r.TimeOfDay.TotalHours) % 24)
+                        .OrderByDescending(g => g.Count()).First().Key;
+                    var offset = (resetHour + 1) % 24; // +1h for Usage reporting lag
+                    var cycleResp = await client.QueryWorkspaceAsync(workspaceId,
+                        $"Usage | where IsBillable == true | summarize Gb = sum(Quantity) / 1024.0 by Cycle = bin(TimeGenerated - {offset}h, 1d)",
+                        window);
+                    var maxCycleGb = 0.0;
+                    foreach (var table in cycleResp.Value.AllTables)
+                    {
+                        var gbIdx = GetColumnIndex(table, "Gb");
+                        foreach (var row in table.Rows)
+                        {
+                            var raw = row[gbIdx];
+                            if (raw is null) continue;
+                            maxCycleGb = Math.Max(maxCycleGb, System.Convert.ToDouble(raw, System.Globalization.CultureInfo.InvariantCulture));
+                        }
+                    }
+                    // Floor, not round: Azure stops collection once you *exceed* the cap, so the measured
+                    // cycle volume slightly overshoots (e.g. ~10.5 GB for a 10 GB cap). Flooring recovers
+                    // the configured whole-GB cap.
+                    if (maxCycleGb > 0) measuredCapGb = Math.Floor(maxCycleGb);
                 }
 
-                return CapTimelineBuilder.Build(hourSeries, capGb);
+                return CapTimelineBuilder.Build(stops, resets, dailyGb, measuredCapGb, capGb,
+                    DateTime.UtcNow - TimeSpan.FromDays(days), DateTime.UtcNow);
             }
             catch (Exception e)
             {
@@ -305,6 +333,20 @@ Usage
                 return new CapTimeline { CapGb = null, Days = [] };
             }
         });
+    }
+
+    private static async Task<List<DateTime>> QueryEventTimesAsync(LogsQueryClient client, string workspaceId, string query, LogsQueryTimeRange range)
+    {
+        var list = new List<DateTime>();
+        var resp = await client.QueryWorkspaceAsync(workspaceId, query, range);
+        foreach (var table in resp.Value.AllTables)
+        {
+            var idx = GetColumnIndex(table, "TimeGenerated");
+            if (idx < 0) continue;
+            foreach (var row in table.Rows)
+                list.Add(GetDateTime(row, idx));
+        }
+        return list;
     }
 
     public async Task<bool> CanConnectAsync(IApplicationInsightsContext context)

--- a/Quilt4Net.Toolkit/Features/ApplicationInsights/ApplicationInsightsService.cs
+++ b/Quilt4Net.Toolkit/Features/ApplicationInsights/ApplicationInsightsService.cs
@@ -110,8 +110,31 @@ union startup_pick, (log_pick | join kind=leftanti startup_pick on ApplicationNa
         TimeSpan timeSpan,
         [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
-        var cacheKey = $"volbysource|{context.ToKey()}|{timeSpan}";
-        var items = await _timeToLiveCache.GetAsync(cacheKey, async () =>
+        var items = await FetchVolumeBySourceAsync(context, $"volbysource|{context.ToKey()}|{timeSpan}", new LogsQueryTimeRange(timeSpan));
+        foreach (var item in items)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            yield return item;
+        }
+    }
+
+    public async IAsyncEnumerable<VolumeBySource> GetVolumeBySourceAsync(
+        IApplicationInsightsContext context,
+        DateTimeOffset fromUtc,
+        DateTimeOffset toUtc,
+        [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        var items = await FetchVolumeBySourceAsync(context, $"volbysource|{context.ToKey()}|{fromUtc:O}|{toUtc:O}", new LogsQueryTimeRange(fromUtc, toUtc));
+        foreach (var item in items)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            yield return item;
+        }
+    }
+
+    private Task<VolumeBySource[]> FetchVolumeBySourceAsync(IApplicationInsightsContext context, string cacheKey, LogsQueryTimeRange range)
+    {
+        return _timeToLiveCache.GetAsync(cacheKey, async () =>
         {
             // Billing-grade volume straight from the Usage table — cheap, no telemetry scan.
             const string query = @"
@@ -124,7 +147,7 @@ Usage
             {
                 var client = GetClient(context);
                 var workspaceId = context?.WorkspaceId ?? _options.WorkspaceId;
-                var response = await client.QueryWorkspaceAsync(workspaceId, query, new LogsQueryTimeRange(timeSpan));
+                var response = await client.QueryWorkspaceAsync(workspaceId, query, range);
 
                 var list = new List<VolumeBySource>();
                 foreach (var table in response.Value.AllTables)
@@ -152,6 +175,62 @@ Usage
                 // empty so the cost view shows "unavailable" rather than failing the whole page.
                 _logger.LogWarning(e, "Unable to read the Usage table for volume-by-source. Returning empty.");
                 return Array.Empty<VolumeBySource>();
+            }
+        });
+    }
+
+    public async IAsyncEnumerable<VolumeTimelinePoint> GetVolumeTimelineAsync(
+        IApplicationInsightsContext context,
+        DateTimeOffset fromUtc,
+        DateTimeOffset toUtc,
+        [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        var cacheKey = $"voltimeline|{context.ToKey()}|{fromUtc:O}|{toUtc:O}";
+        var items = await _timeToLiveCache.GetAsync(cacheKey, async () =>
+        {
+            // Per-UTC-day billed volume by source, for the multi-day line chart.
+            const string query = @"
+Usage
+| where IsBillable == true
+| summarize Mb = sum(Quantity) by Day = bin(TimeGenerated, 1d), Source = DataType
+| where Mb > 0
+| order by Day asc";
+            try
+            {
+                var client = GetClient(context);
+                var workspaceId = context?.WorkspaceId ?? _options.WorkspaceId;
+                var response = await client.QueryWorkspaceAsync(workspaceId, query, new LogsQueryTimeRange(fromUtc, toUtc));
+
+                var list = new List<VolumeTimelinePoint>();
+                foreach (var table in response.Value.AllTables)
+                {
+                    var dayIdx = GetColumnIndex(table, "Day");
+                    var sourceIdx = GetColumnIndex(table, "Source");
+                    var mbIdx = GetColumnIndex(table, "Mb");
+                    foreach (var row in table.Rows)
+                    {
+                        var source = row[sourceIdx]?.ToString();
+                        if (string.IsNullOrEmpty(source)) continue;
+                        var rawDay = row[dayIdx];
+                        var rawMb = row[mbIdx];
+                        if (rawDay is null || rawMb is null) continue;
+                        var dayUtc = rawDay is DateTimeOffset dto
+                            ? dto.UtcDateTime
+                            : System.Convert.ToDateTime(rawDay, System.Globalization.CultureInfo.InvariantCulture);
+                        list.Add(new VolumeTimelinePoint
+                        {
+                            DayUtc = dayUtc,
+                            Source = source,
+                            Mb = System.Convert.ToDouble(rawMb, System.Globalization.CultureInfo.InvariantCulture)
+                        });
+                    }
+                }
+                return list.ToArray();
+            }
+            catch (Exception e)
+            {
+                _logger.LogWarning(e, "Unable to read the Usage table for volume timeline. Returning empty.");
+                return Array.Empty<VolumeTimelinePoint>();
             }
         });
         foreach (var item in items)
@@ -225,18 +304,25 @@ Usage
                         var gb = volume.GetValueOrDefault(day);
                         DateTime? hit = hits.TryGetValue(day, out var h) ? h : null;
                         double? est = null;
+                        TimeSpan? gap = null;
                         if (hit.HasValue)
                         {
                             // Volume-at-hit ≈ the cap; extrapolate to a full day by the elapsed fraction.
                             var hours = (hit.Value - day).TotalHours;
                             var baseGb = capGb ?? gb;
                             if (hours > 0) est = baseGb * 24.0 / hours;
+
+                            // Capped until the next daily reset. Azure's default reset is 00:00 UTC, i.e.
+                            // the start of the next day, so the gap is the time from the hit to next midnight.
+                            gap = day.AddDays(1) - hit.Value;
                         }
-                        return new CapDay { DateUtc = day, IngestedGb = gb, CapHitUtc = hit, EstimatedUncappedGb = est };
+                        return new CapDay { DateUtc = day, IngestedGb = gb, CapHitUtc = hit, GapDuration = gap, EstimatedUncappedGb = est };
                     })
                     .ToArray();
 
-                return new CapTimeline { CapGb = capGb, Days = capDays };
+                // Reset time-of-day: the Azure daily-cap default is 00:00 UTC. Surfaced only when a cap is configured.
+                var resetUtc = capGb.HasValue ? (TimeSpan?)TimeSpan.Zero : null;
+                return new CapTimeline { CapGb = capGb, CapResetUtc = resetUtc, Days = capDays };
             }
             catch (Exception e)
             {

--- a/Quilt4Net.Toolkit/Features/ApplicationInsights/ApplicationInsightsService.cs
+++ b/Quilt4Net.Toolkit/Features/ApplicationInsights/ApplicationInsightsService.cs
@@ -294,10 +294,11 @@ Usage
                     }
                 }
 
-                // Cap size = largest billable volume in a single reset cycle (the quota the cap allows).
-                // Cycles are aligned to the reset hour; the Usage table reports ~1h late, so shift the bin
-                // by (resetHour + 1h). Rounded to the nearest GB to read as the configured cap.
+                // Per-reset-cycle billable volume → cap size (max cycle) + the per-cycle bars for the
+                // cap-cycle view. Cycles are aligned to the reset hour; the Usage table reports ~1h late,
+                // so shift the bin by (resetHour + 1h) and map the bin back to the reset boundary.
                 double? measuredCapGb = null;
+                var cycleGbByStart = new Dictionary<DateTime, double>();
                 if (resets.Count > 0)
                 {
                     var resetHour = resets
@@ -310,12 +311,17 @@ Usage
                     var maxCycleGb = 0.0;
                     foreach (var table in cycleResp.Value.AllTables)
                     {
+                        var cycleIdx = GetColumnIndex(table, "Cycle");
                         var gbIdx = GetColumnIndex(table, "Gb");
                         foreach (var row in table.Rows)
                         {
                             var raw = row[gbIdx];
                             if (raw is null) continue;
-                            maxCycleGb = Math.Max(maxCycleGb, System.Convert.ToDouble(raw, System.Globalization.CultureInfo.InvariantCulture));
+                            var gb = System.Convert.ToDouble(raw, System.Globalization.CultureInfo.InvariantCulture);
+                            maxCycleGb = Math.Max(maxCycleGb, gb);
+                            // Bin start (shifted) → actual reset boundary = binStart + resetHour.
+                            var cycleStart = GetDateTime(row, cycleIdx).AddHours(resetHour);
+                            cycleGbByStart[cycleStart] = gb;
                         }
                     }
                     // Floor, not round: Azure stops collection once you *exceed* the cap, so the measured
@@ -325,7 +331,7 @@ Usage
                 }
 
                 return CapTimelineBuilder.Build(stops, resets, dailyGb, measuredCapGb, capGb,
-                    DateTime.UtcNow - TimeSpan.FromDays(days), DateTime.UtcNow);
+                    DateTime.UtcNow - TimeSpan.FromDays(days), DateTime.UtcNow, cycleGbByStart);
             }
             catch (Exception e)
             {

--- a/Quilt4Net.Toolkit/Features/ApplicationInsights/CapTimeline.cs
+++ b/Quilt4Net.Toolkit/Features/ApplicationInsights/CapTimeline.cs
@@ -28,6 +28,42 @@ public record CapDay
     /// ingested over the uncapped hours of the day. <c>null</c> when the day wasn't capped.
     /// </summary>
     public double? EstimatedUncappedGb { get; init; }
+
+    /// <summary>The capped sub-intervals within this UTC day (clipped to the day) — a day can have a
+    /// carry-over gap at the start and a fresh cap later, so there may be more than one.</summary>
+    public IReadOnlyList<CappedInterval> CappedIntervals { get; init; } = [];
+}
+
+/// <summary>A capped (no-collection) interval, in UTC.</summary>
+public record CappedInterval
+{
+    public required DateTime StartUtc { get; init; }
+    public required DateTime EndUtc { get; init; }
+}
+
+/// <summary>
+/// One cap cycle — the quota period from a reset to the next reset. Unlike a calendar day this aligns
+/// to the cap, so a cycle has at most one cap hit and a single clean capped span (hit → next reset).
+/// </summary>
+public record CapCycle
+{
+    /// <summary>When the quota reset and collection resumed (UTC) — the start of the cycle.</summary>
+    public required DateTime StartUtc { get; init; }
+
+    /// <summary>The next reset (UTC) — the end of the cycle.</summary>
+    public required DateTime EndUtc { get; init; }
+
+    /// <summary>Billed volume ingested during the cycle (GB).</summary>
+    public required double IngestedGb { get; init; }
+
+    /// <summary>When the cap was hit in this cycle (UTC), or <c>null</c> if it wasn't.</summary>
+    public DateTime? CapHitUtc { get; init; }
+
+    /// <summary>How long the cycle was capped (hit → next reset). <c>null</c> when not hit.</summary>
+    public TimeSpan? CappedDuration { get; init; }
+
+    /// <summary>Estimated uncapped volume (GB) for the cycle, extrapolated from the uncapped portion.</summary>
+    public double? EstimatedUncappedGb { get; init; }
 }
 
 /// <summary>
@@ -53,6 +89,9 @@ public record CapTimeline
     /// </summary>
     public TimeSpan? CapResetUtc { get; init; }
 
-    /// <summary>Per-day entries, newest first.</summary>
+    /// <summary>Per-calendar-UTC-day entries, newest first.</summary>
     public required IReadOnlyList<CapDay> Days { get; init; }
+
+    /// <summary>Per-cap-cycle entries (reset → next reset), newest first. Empty when no resets were observed.</summary>
+    public IReadOnlyList<CapCycle> Cycles { get; init; } = [];
 }

--- a/Quilt4Net.Toolkit/Features/ApplicationInsights/CapTimeline.cs
+++ b/Quilt4Net.Toolkit/Features/ApplicationInsights/CapTimeline.cs
@@ -16,6 +16,12 @@ public record CapDay
     public DateTime? CapHitUtc { get; init; }
 
     /// <summary>
+    /// How long the workspace stayed capped that day — from <see cref="CapHitUtc"/> until the next daily
+    /// cap reset (when ingestion resumes). <c>null</c> when the cap wasn't hit.
+    /// </summary>
+    public TimeSpan? GapDuration { get; init; }
+
+    /// <summary>
     /// Estimated full-day volume (GB) had the cap not stopped ingestion — extrapolated from the
     /// pre-cap rate (cap ÷ fraction-of-day-elapsed-at-hit). <c>null</c> when the cap wasn't hit, in
     /// which case <see cref="IngestedGb"/> is already the real full-day volume.
@@ -31,6 +37,12 @@ public record CapTimeline
 {
     /// <summary>Configured daily cap in GB, or <c>null</c> if it couldn't be determined.</summary>
     public double? CapGb { get; init; }
+
+    /// <summary>
+    /// The daily cap reset time-of-day (UTC) — when ingestion resumes after a cap. Defaults to the Azure
+    /// daily-cap default of 00:00 UTC. <c>null</c> when no cap is configured.
+    /// </summary>
+    public TimeSpan? CapResetUtc { get; init; }
 
     /// <summary>Per-day entries, newest first.</summary>
     public required IReadOnlyList<CapDay> Days { get; init; }

--- a/Quilt4Net.Toolkit/Features/ApplicationInsights/CapTimeline.cs
+++ b/Quilt4Net.Toolkit/Features/ApplicationInsights/CapTimeline.cs
@@ -1,46 +1,55 @@
 namespace Quilt4Net.Toolkit.Features.ApplicationInsights;
 
 /// <summary>
-/// One day of the ingestion-cap timeline: how much was ingested, whether/when the daily cap was hit,
-/// and an estimate of what the day's volume would have been had the cap not stopped ingestion.
+/// One UTC day of the ingestion-cap timeline: how much was ingested, how long the workspace was capped
+/// (no billable data) that day, when data resumed, and an estimate of the uncapped volume.
 /// </summary>
 public record CapDay
 {
     /// <summary>The UTC day (midnight) this entry covers.</summary>
     public required DateTime DateUtc { get; init; }
 
-    /// <summary>Billed volume ingested that day (GB). On a capped day this is roughly the cap.</summary>
+    /// <summary>Billed volume ingested that day (GB).</summary>
     public required double IngestedGb { get; init; }
 
-    /// <summary>When the daily cap was hit (UTC), or <c>null</c> if it wasn't hit that day.</summary>
-    public DateTime? CapHitUtc { get; init; }
-
     /// <summary>
-    /// How long the workspace stayed capped that day — from <see cref="CapHitUtc"/> until the next daily
-    /// cap reset (when ingestion resumes). <c>null</c> when the cap wasn't hit.
+    /// Total time that day with no billable ingestion attributable to the cap (a bounded no-data gap).
+    /// Includes both a carry-over gap at the start of the day and a new cap later the same day.
+    /// <c>null</c>/zero when the day wasn't capped.
     /// </summary>
     public TimeSpan? GapDuration { get; init; }
 
+    /// <summary>When billable data first resumed that day after a cap (UTC) — i.e. the observed reset.
+    /// <c>null</c> when the day didn't start (or continue) under a cap.</summary>
+    public DateTime? ResumeUtc { get; init; }
+
     /// <summary>
-    /// Estimated full-day volume (GB) had the cap not stopped ingestion — extrapolated from the
-    /// pre-cap rate (cap ÷ fraction-of-day-elapsed-at-hit). <c>null</c> when the cap wasn't hit, in
-    /// which case <see cref="IngestedGb"/> is already the real full-day volume.
+    /// Estimated full-day volume (GB) had the cap not stopped ingestion — extrapolated from the volume
+    /// ingested over the uncapped hours of the day. <c>null</c> when the day wasn't capped.
     /// </summary>
     public double? EstimatedUncappedGb { get; init; }
 }
 
 /// <summary>
-/// Daily ingestion-cap timeline for a workspace: the configured daily cap plus a per-day breakdown of
-/// volume and cap-hit time. Backs the logging dashboard's cap graph.
+/// Daily ingestion-cap timeline for a workspace, derived from gaps in billable ingestion: the per-day
+/// volume + capped duration, the detected daily reset time, and the cap size measured from a full
+/// reset-to-cap cycle. Backs the logging dashboard's cap graph.
 /// </summary>
 public record CapTimeline
 {
-    /// <summary>Configured daily cap in GB, or <c>null</c> if it couldn't be determined.</summary>
+    /// <summary>Configured daily cap in GB from the workspace "Daily quota changed to N" event, or <c>null</c> if unknown.</summary>
     public double? CapGb { get; init; }
 
     /// <summary>
-    /// The daily cap reset time-of-day (UTC) — when ingestion resumes after a cap. Defaults to the Azure
-    /// daily-cap default of 00:00 UTC. <c>null</c> when no cap is configured.
+    /// Cap size measured from observed data — the billable volume in a complete reset→cap cycle (GB).
+    /// <c>null</c> when no complete capped cycle was observed in range. Prefer this over <see cref="CapGb"/>
+    /// for display when available, since it reflects what was actually ingested before the cap hit.
+    /// </summary>
+    public double? DerivedCapGb { get; init; }
+
+    /// <summary>
+    /// The detected daily cap reset time-of-day (UTC) — when ingestion resumes after a cap, taken from the
+    /// most common resume time across the range. <c>null</c> when no cap/reset was observed.
     /// </summary>
     public TimeSpan? CapResetUtc { get; init; }
 

--- a/Quilt4Net.Toolkit/Features/ApplicationInsights/CapTimelineBuilder.cs
+++ b/Quilt4Net.Toolkit/Features/ApplicationInsights/CapTimelineBuilder.cs
@@ -1,0 +1,116 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Quilt4Net.Toolkit.Features.ApplicationInsights;
+
+/// <summary>One hour of billable ingestion volume (MB). Input to <see cref="CapTimelineBuilder"/>.</summary>
+public record HourVolume
+{
+    public required DateTime HourUtc { get; init; }
+    public required double Mb { get; init; }
+}
+
+/// <summary>
+/// Builds a <see cref="CapTimeline"/> from an hourly billable-volume series by detecting gaps (capped
+/// periods) in ingestion. A daily cap stops data until the workspace's (variable) reset time, so a cap
+/// shows up as a run of hours with no billable volume; the hour data resumes is the reset time. Pure and
+/// deterministic — unit-testable without Azure.
+/// </summary>
+public static class CapTimelineBuilder
+{
+    /// <param name="hours">Hourly billable volume (MB), ascending and continuous (missing hours filled with 0).</param>
+    /// <param name="configuredCapGb">Configured daily cap (GB) from the quota event, if known.</param>
+    public static CapTimeline Build(IReadOnlyList<HourVolume> hours, double? configuredCapGb)
+    {
+        var n = hours?.Count ?? 0;
+        var capped = new bool[n];
+
+        if (n == 0)
+            return new CapTimeline { CapGb = configuredCapGb, Days = [] };
+
+        // Only count *bounded* no-data runs (data before and after) as caps — that excludes the
+        // leading edge before the workspace had any data and the trailing edge (billing lag / an
+        // in-progress cap we can't yet measure because data hasn't resumed).
+        var firstData = -1;
+        var lastData = -1;
+        for (var i = 0; i < n; i++)
+        {
+            if (hours[i].Mb > 0)
+            {
+                if (firstData < 0) firstData = i;
+                lastData = i;
+            }
+        }
+
+        if (firstData >= 0)
+            for (var i = firstData; i <= lastData; i++)
+                if (hours[i].Mb <= 0)
+                    capped[i] = true;
+
+        // Resume times = the hour data restarts right after a capped run.
+        var resumeTimes = new List<DateTime>();
+        for (var i = 1; i < n; i++)
+            if (capped[i - 1] && !capped[i])
+                resumeTimes.Add(hours[i].HourUtc);
+
+        // Detected reset = the most common resume time-of-day across the range.
+        TimeSpan? resetUtc = resumeTimes.Count > 0
+            ? resumeTimes.GroupBy(t => t.TimeOfDay).OrderByDescending(g => g.Count()).ThenBy(g => g.Key).First().Key
+            : null;
+
+        // Derived cap size = the largest billable volume across complete reset→next-cap cycles (the quota
+        // the cap permits before it stops ingestion).
+        double? derivedCapGb = null;
+        for (var i = 1; i < n; i++)
+        {
+            if (!(capped[i - 1] && !capped[i])) continue; // resume at i
+            double mb = 0;
+            var j = i;
+            while (j < n && !capped[j]) { mb += hours[j].Mb; j++; }
+            if (j < n && capped[j]) // a complete cycle, ended by a new cap
+            {
+                var gb = mb / 1024.0;
+                derivedCapGb = derivedCapGb.HasValue ? Math.Max(derivedCapGb.Value, gb) : gb;
+            }
+        }
+
+        // Per-UTC-day aggregation.
+        var days = hours
+            .Select((h, i) => (h, i))
+            .GroupBy(x => x.h.HourUtc.Date)
+            .OrderByDescending(g => g.Key)
+            .Select(g =>
+            {
+                var idxs = g.Select(x => x.i).ToArray();
+                var ingestedGb = idxs.Sum(i => hours[i].Mb) / 1024.0;
+                var cappedHours = idxs.Count(i => capped[i]);
+
+                DateTime? resume = null;
+                foreach (var i in idxs)
+                    if (i > 0 && capped[i - 1] && !capped[i]) { resume = hours[i].HourUtc; break; }
+
+                double? est = cappedHours is > 0 and < 24
+                    ? ingestedGb * 24.0 / (24 - cappedHours)
+                    : null;
+
+                return new CapDay
+                {
+                    DateUtc = g.Key,
+                    IngestedGb = ingestedGb,
+                    GapDuration = cappedHours > 0 ? TimeSpan.FromHours(cappedHours) : null,
+                    ResumeUtc = resume,
+                    EstimatedUncappedGb = est,
+                };
+            })
+            .ToArray();
+
+        return new CapTimeline
+        {
+            CapGb = configuredCapGb,
+            DerivedCapGb = derivedCapGb,
+            CapResetUtc = resetUtc,
+            Days = days,
+        };
+    }
+}

--- a/Quilt4Net.Toolkit/Features/ApplicationInsights/CapTimelineBuilder.cs
+++ b/Quilt4Net.Toolkit/Features/ApplicationInsights/CapTimelineBuilder.cs
@@ -27,17 +27,19 @@ public static class CapTimelineBuilder
         double? measuredCapGb,
         double? configuredCapGb,
         DateTime windowStartUtc,
-        DateTime windowEndUtc)
+        DateTime windowEndUtc,
+        IReadOnlyDictionary<DateTime, double> cycleGbByStart = null)
     {
         stops ??= [];
         resets ??= [];
         dailyGb ??= new Dictionary<DateTime, double>();
 
+        var sortedStops = stops.OrderBy(s => s).ToList();
         var sortedResets = resets.OrderBy(r => r).ToList();
 
         // Capped intervals: collection is off from each stop until the next reset (or the window end).
         var intervals = new List<(DateTime Start, DateTime End)>();
-        foreach (var stop in stops.OrderBy(s => s))
+        foreach (var stop in sortedStops)
         {
             var nextReset = sortedResets.FirstOrDefault(r => r > stop);
             var end = nextReset != default ? nextReset : windowEndUtc;
@@ -61,12 +63,15 @@ public static class CapTimelineBuilder
             var dayStart = day;
             var dayEnd = day.AddDays(1);
 
-            var cappedSpan = intervals.Aggregate(TimeSpan.Zero, (acc, iv) =>
+            // Clip each capped interval to the day; a day can hold a carry-over gap and a fresh cap.
+            var clipped = new List<CappedInterval>();
+            foreach (var iv in intervals)
             {
                 var os = iv.Start > dayStart ? iv.Start : dayStart;
                 var oe = iv.End < dayEnd ? iv.End : dayEnd;
-                return oe > os ? acc + (oe - os) : acc;
-            });
+                if (oe > os) clipped.Add(new CappedInterval { StartUtc = os, EndUtc = oe });
+            }
+            var cappedSpan = clipped.Aggregate(TimeSpan.Zero, (acc, c) => acc + (c.EndUtc - c.StartUtc));
 
             var ingested = dailyGb.GetValueOrDefault(day);
             DateTime? resume = sortedResets.Where(r => r >= dayStart && r < dayEnd).Select(r => (DateTime?)r).FirstOrDefault();
@@ -83,6 +88,7 @@ public static class CapTimelineBuilder
                 GapDuration = cappedSpan > TimeSpan.Zero ? cappedSpan : null,
                 ResumeUtc = resume,
                 EstimatedUncappedGb = est,
+                CappedIntervals = clipped,
             };
         }).ToArray();
 
@@ -92,6 +98,60 @@ public static class CapTimelineBuilder
             DerivedCapGb = measuredCapGb,
             CapResetUtc = resetUtc,
             Days = capDays,
+            Cycles = BuildCycles(sortedStops, sortedResets, cycleGbByStart, windowEndUtc),
         };
+    }
+
+    // One row per quota cycle (reset → next reset): at most one cap hit, a single clean capped span.
+    private static IReadOnlyList<CapCycle> BuildCycles(
+        List<DateTime> sortedStops,
+        List<DateTime> sortedResets,
+        IReadOnlyDictionary<DateTime, double> cycleGbByStart,
+        DateTime windowEndUtc)
+    {
+        var cycles = new List<CapCycle>();
+        for (var i = 0; i < sortedResets.Count; i++)
+        {
+            var start = sortedResets[i];
+            var end = i + 1 < sortedResets.Count ? sortedResets[i + 1] : windowEndUtc;
+            if (end <= start) continue;
+
+            var hit = sortedStops.Where(s => s >= start && s < end).Select(s => (DateTime?)s).FirstOrDefault();
+            var ingested = LookupCycleGb(cycleGbByStart, start);
+
+            TimeSpan? cappedDuration = hit.HasValue ? end - hit.Value : null;
+            double? est = null;
+            if (hit.HasValue)
+            {
+                var cycleHours = (end - start).TotalHours;
+                var cappedHours = cappedDuration.Value.TotalHours;
+                if (cycleHours > 0 && cappedHours < cycleHours)
+                    est = ingested * cycleHours / (cycleHours - cappedHours);
+            }
+
+            cycles.Add(new CapCycle
+            {
+                StartUtc = start,
+                EndUtc = end,
+                IngestedGb = ingested,
+                CapHitUtc = hit,
+                CappedDuration = cappedDuration,
+                EstimatedUncappedGb = est,
+            });
+        }
+        return cycles.OrderByDescending(c => c.StartUtc).ToArray();
+    }
+
+    private static double LookupCycleGb(IReadOnlyDictionary<DateTime, double> cycleGbByStart, DateTime start)
+    {
+        if (cycleGbByStart == null || cycleGbByStart.Count == 0) return 0;
+        if (cycleGbByStart.TryGetValue(start, out var exact)) return exact;
+        // Nearest cycle-start within 6h (the binned start may differ from the reset event by minutes/lag).
+        var best = cycleGbByStart
+            .Where(kvp => Math.Abs((kvp.Key - start).TotalHours) <= 6)
+            .OrderBy(kvp => Math.Abs((kvp.Key - start).TotalHours))
+            .Select(kvp => (double?)kvp.Value)
+            .FirstOrDefault();
+        return best ?? 0;
     }
 }

--- a/Quilt4Net.Toolkit/Features/ApplicationInsights/CapTimelineBuilder.cs
+++ b/Quilt4Net.Toolkit/Features/ApplicationInsights/CapTimelineBuilder.cs
@@ -4,113 +4,94 @@ using System.Linq;
 
 namespace Quilt4Net.Toolkit.Features.ApplicationInsights;
 
-/// <summary>One hour of billable ingestion volume (MB). Input to <see cref="CapTimelineBuilder"/>.</summary>
-public record HourVolume
-{
-    public required DateTime HourUtc { get; init; }
-    public required double Mb { get; init; }
-}
-
 /// <summary>
-/// Builds a <see cref="CapTimeline"/> from an hourly billable-volume series by detecting gaps (capped
-/// periods) in ingestion. A daily cap stops data until the workspace's (variable) reset time, so a cap
-/// shows up as a run of hours with no billable volume; the hour data resumes is the reset time. Pure and
-/// deterministic — unit-testable without Azure.
+/// Builds a <see cref="CapTimeline"/> from the workspace's authoritative daily-cap Operation events:
+/// "data collection stopped due to daily limit" (cap hit) and "data collection started … daily limit
+/// reset" (reset/resume). Collection is off between a stop and the next reset; per-UTC-day capped time
+/// is the overlap of those intervals with the day, and the reset time is taken from the reset events
+/// (precise, unlike the ~1h-lagged Usage table). Pure and deterministic — unit-testable without Azure.
 /// </summary>
 public static class CapTimelineBuilder
 {
-    /// <param name="hours">Hourly billable volume (MB), ascending and continuous (missing hours filled with 0).</param>
+    /// <param name="stops">Cap-hit event times (UTC).</param>
+    /// <param name="resets">Daily-reset event times (UTC) — when collection resumed.</param>
+    /// <param name="dailyGb">Billed volume per UTC day (GB).</param>
+    /// <param name="measuredCapGb">Cap size measured from a full reset cycle (GB), already rounded; or null.</param>
     /// <param name="configuredCapGb">Configured daily cap (GB) from the quota event, if known.</param>
-    public static CapTimeline Build(IReadOnlyList<HourVolume> hours, double? configuredCapGb)
+    /// <param name="windowStartUtc">Start of the analysed window (used to close an open trailing cap).</param>
+    /// <param name="windowEndUtc">End of the analysed window (used to close an open trailing cap).</param>
+    public static CapTimeline Build(
+        IReadOnlyList<DateTime> stops,
+        IReadOnlyList<DateTime> resets,
+        IReadOnlyDictionary<DateTime, double> dailyGb,
+        double? measuredCapGb,
+        double? configuredCapGb,
+        DateTime windowStartUtc,
+        DateTime windowEndUtc)
     {
-        var n = hours?.Count ?? 0;
-        var capped = new bool[n];
+        stops ??= [];
+        resets ??= [];
+        dailyGb ??= new Dictionary<DateTime, double>();
 
-        if (n == 0)
-            return new CapTimeline { CapGb = configuredCapGb, Days = [] };
+        var sortedResets = resets.OrderBy(r => r).ToList();
 
-        // Only count *bounded* no-data runs (data before and after) as caps — that excludes the
-        // leading edge before the workspace had any data and the trailing edge (billing lag / an
-        // in-progress cap we can't yet measure because data hasn't resumed).
-        var firstData = -1;
-        var lastData = -1;
-        for (var i = 0; i < n; i++)
+        // Capped intervals: collection is off from each stop until the next reset (or the window end).
+        var intervals = new List<(DateTime Start, DateTime End)>();
+        foreach (var stop in stops.OrderBy(s => s))
         {
-            if (hours[i].Mb > 0)
-            {
-                if (firstData < 0) firstData = i;
-                lastData = i;
-            }
+            var nextReset = sortedResets.FirstOrDefault(r => r > stop);
+            var end = nextReset != default ? nextReset : windowEndUtc;
+            if (end > stop) intervals.Add((stop, end));
         }
 
-        if (firstData >= 0)
-            for (var i = firstData; i <= lastData; i++)
-                if (hours[i].Mb <= 0)
-                    capped[i] = true;
-
-        // Resume times = the hour data restarts right after a capped run.
-        var resumeTimes = new List<DateTime>();
-        for (var i = 1; i < n; i++)
-            if (capped[i - 1] && !capped[i])
-                resumeTimes.Add(hours[i].HourUtc);
-
-        // Detected reset = the most common resume time-of-day across the range.
-        TimeSpan? resetUtc = resumeTimes.Count > 0
-            ? resumeTimes.GroupBy(t => t.TimeOfDay).OrderByDescending(g => g.Count()).ThenBy(g => g.Key).First().Key
+        // Reset time-of-day = the most common reset-event hour.
+        TimeSpan? resetUtc = resets.Count > 0
+            ? resets.GroupBy(r => TimeSpan.FromHours(Math.Round(r.TimeOfDay.TotalHours)))
+                    .OrderByDescending(g => g.Count()).ThenBy(g => g.Key).First().Key
             : null;
 
-        // Derived cap size = the largest billable volume across complete reset→next-cap cycles (the quota
-        // the cap permits before it stops ingestion).
-        double? derivedCapGb = null;
-        for (var i = 1; i < n; i++)
+        // Days to render: union of days with volume and days touched by a capped interval.
+        var days = new HashSet<DateTime>(dailyGb.Keys.Select(d => d.Date));
+        foreach (var (s, e) in intervals)
+            for (var d = s.Date; d <= e.Date; d = d.AddDays(1))
+                days.Add(d);
+
+        var capDays = days.OrderByDescending(d => d).Select(day =>
         {
-            if (!(capped[i - 1] && !capped[i])) continue; // resume at i
-            double mb = 0;
-            var j = i;
-            while (j < n && !capped[j]) { mb += hours[j].Mb; j++; }
-            if (j < n && capped[j]) // a complete cycle, ended by a new cap
+            var dayStart = day;
+            var dayEnd = day.AddDays(1);
+
+            var cappedSpan = intervals.Aggregate(TimeSpan.Zero, (acc, iv) =>
             {
-                var gb = mb / 1024.0;
-                derivedCapGb = derivedCapGb.HasValue ? Math.Max(derivedCapGb.Value, gb) : gb;
-            }
-        }
+                var os = iv.Start > dayStart ? iv.Start : dayStart;
+                var oe = iv.End < dayEnd ? iv.End : dayEnd;
+                return oe > os ? acc + (oe - os) : acc;
+            });
 
-        // Per-UTC-day aggregation.
-        var days = hours
-            .Select((h, i) => (h, i))
-            .GroupBy(x => x.h.HourUtc.Date)
-            .OrderByDescending(g => g.Key)
-            .Select(g =>
+            var ingested = dailyGb.GetValueOrDefault(day);
+            DateTime? resume = sortedResets.Where(r => r >= dayStart && r < dayEnd).Select(r => (DateTime?)r).FirstOrDefault();
+
+            double? est = null;
+            var cappedHours = cappedSpan.TotalHours;
+            if (cappedHours > 0 && cappedHours < 24)
+                est = ingested * 24.0 / (24 - cappedHours);
+
+            return new CapDay
             {
-                var idxs = g.Select(x => x.i).ToArray();
-                var ingestedGb = idxs.Sum(i => hours[i].Mb) / 1024.0;
-                var cappedHours = idxs.Count(i => capped[i]);
-
-                DateTime? resume = null;
-                foreach (var i in idxs)
-                    if (i > 0 && capped[i - 1] && !capped[i]) { resume = hours[i].HourUtc; break; }
-
-                double? est = cappedHours is > 0 and < 24
-                    ? ingestedGb * 24.0 / (24 - cappedHours)
-                    : null;
-
-                return new CapDay
-                {
-                    DateUtc = g.Key,
-                    IngestedGb = ingestedGb,
-                    GapDuration = cappedHours > 0 ? TimeSpan.FromHours(cappedHours) : null,
-                    ResumeUtc = resume,
-                    EstimatedUncappedGb = est,
-                };
-            })
-            .ToArray();
+                DateUtc = day,
+                IngestedGb = ingested,
+                GapDuration = cappedSpan > TimeSpan.Zero ? cappedSpan : null,
+                ResumeUtc = resume,
+                EstimatedUncappedGb = est,
+            };
+        }).ToArray();
 
         return new CapTimeline
         {
             CapGb = configuredCapGb,
-            DerivedCapGb = derivedCapGb,
+            DerivedCapGb = measuredCapGb,
             CapResetUtc = resetUtc,
-            Days = days,
+            Days = capDays,
         };
     }
 }

--- a/Quilt4Net.Toolkit/Features/ApplicationInsights/CapTimelineBuilder.cs
+++ b/Quilt4Net.Toolkit/Features/ApplicationInsights/CapTimelineBuilder.cs
@@ -112,13 +112,19 @@ public static class CapTimelineBuilder
         IReadOnlyDictionary<DateTime, double> cycleGbByStart,
         DateTime windowEndUtc)
     {
-        var starts = new SortedSet<DateTime>();
-        if (cycleGbByStart != null)
-            foreach (var k in cycleGbByStart.Keys) starts.Add(k);
-        foreach (var r in sortedResets) starts.Add(r);
-        if (starts.Count == 0) return [];
-
-        var startList = starts.ToList();
+        // Per-cycle volume keys are already one-per-day at the reset hour; prefer them. Fall back to reset
+        // events only when there's no volume data. Dedupe to one start per calendar day — reset events can
+        // fire at slightly different hours (e.g. 11:00 vs 12:00), which would otherwise create two cycles
+        // for the same day and collide as duplicate chart categories.
+        IEnumerable<DateTime> candidates = cycleGbByStart is { Count: > 0 }
+            ? cycleGbByStart.Keys
+            : sortedResets;
+        var startList = candidates
+            .GroupBy(s => s.Date)
+            .Select(g => g.Min())
+            .OrderBy(s => s)
+            .ToList();
+        if (startList.Count == 0) return [];
         var cycles = new List<CapCycle>();
         for (var i = 0; i < startList.Count; i++)
         {

--- a/Quilt4Net.Toolkit/Features/ApplicationInsights/CapTimelineBuilder.cs
+++ b/Quilt4Net.Toolkit/Features/ApplicationInsights/CapTimelineBuilder.cs
@@ -102,19 +102,32 @@ public static class CapTimelineBuilder
         };
     }
 
-    // One row per quota cycle (reset → next reset): at most one cap hit, a single clean capped span.
+    // One row per quota cycle (reset → next reset) for *every* day with data — not just capped days.
+    // The "daily limit reset" event only fires after a cap, so we anchor cycles to every cycle-start
+    // that has billable volume (plus any reset boundary), giving a continuous timeline. A cycle has at
+    // most one cap hit and a single clean capped span (hit → next reset).
     private static IReadOnlyList<CapCycle> BuildCycles(
         List<DateTime> sortedStops,
         List<DateTime> sortedResets,
         IReadOnlyDictionary<DateTime, double> cycleGbByStart,
         DateTime windowEndUtc)
     {
+        var starts = new SortedSet<DateTime>();
+        if (cycleGbByStart != null)
+            foreach (var k in cycleGbByStart.Keys) starts.Add(k);
+        foreach (var r in sortedResets) starts.Add(r);
+        if (starts.Count == 0) return [];
+
+        var startList = starts.ToList();
         var cycles = new List<CapCycle>();
-        for (var i = 0; i < sortedResets.Count; i++)
+        for (var i = 0; i < startList.Count; i++)
         {
-            var start = sortedResets[i];
-            var end = i + 1 < sortedResets.Count ? sortedResets[i + 1] : windowEndUtc;
-            if (end <= start) continue;
+            var start = startList[i];
+            // Cycle ends at the next cycle start, or one day on (clamped to the window) for the last.
+            var end = i + 1 < startList.Count
+                ? startList[i + 1]
+                : (start.AddDays(1) < windowEndUtc ? start.AddDays(1) : windowEndUtc);
+            if (end <= start) end = start.AddDays(1);
 
             var hit = sortedStops.Where(s => s >= start && s < end).Select(s => (DateTime?)s).FirstOrDefault();
             var ingested = LookupCycleGb(cycleGbByStart, start);

--- a/Quilt4Net.Toolkit/Features/ApplicationInsights/CapTimelineBuilder.cs
+++ b/Quilt4Net.Toolkit/Features/ApplicationInsights/CapTimelineBuilder.cs
@@ -11,7 +11,7 @@ namespace Quilt4Net.Toolkit.Features.ApplicationInsights;
 /// is the overlap of those intervals with the day, and the reset time is taken from the reset events
 /// (precise, unlike the ~1h-lagged Usage table). Pure and deterministic — unit-testable without Azure.
 /// </summary>
-public static class CapTimelineBuilder
+internal static class CapTimelineBuilder
 {
     /// <param name="stops">Cap-hit event times (UTC).</param>
     /// <param name="resets">Daily-reset event times (UTC) — when collection resumed.</param>

--- a/Quilt4Net.Toolkit/Features/ApplicationInsights/IApplicationInsightsService.cs
+++ b/Quilt4Net.Toolkit/Features/ApplicationInsights/IApplicationInsightsService.cs
@@ -13,6 +13,19 @@ public interface IApplicationInsightsService
     IAsyncEnumerable<VolumeBySource> GetVolumeBySourceAsync(IApplicationInsightsContext context, TimeSpan timeSpan, CancellationToken cancellationToken = default);
 
     /// <summary>
+    /// Billed ingestion volume (MB) per source table over an absolute UTC window — used for the
+    /// "Today" / "Yesterday" (UTC) ranges. Same <c>Usage</c>-table source and graceful-degrade behaviour
+    /// as the relative overload.
+    /// </summary>
+    IAsyncEnumerable<VolumeBySource> GetVolumeBySourceAsync(IApplicationInsightsContext context, DateTimeOffset fromUtc, DateTimeOffset toUtc, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Billed ingestion volume (MB) per source table per UTC day over an absolute window — backs the
+    /// multi-day logging-volume line chart. Same <c>Usage</c>-table source and graceful-degrade behaviour.
+    /// </summary>
+    IAsyncEnumerable<VolumeTimelinePoint> GetVolumeTimelineAsync(IApplicationInsightsContext context, DateTimeOffset fromUtc, DateTimeOffset toUtc, CancellationToken cancellationToken = default);
+
+    /// <summary>
     /// Daily ingestion-cap timeline over the last <paramref name="days"/> days: the configured daily
     /// cap (GB) plus, per day, the ingested volume, the cap-hit time (from the workspace
     /// "data collection stopped due to daily limit" operation events), and an estimate of the

--- a/Quilt4Net.Toolkit/Features/ApplicationInsights/VolumeTimelinePoint.cs
+++ b/Quilt4Net.Toolkit/Features/ApplicationInsights/VolumeTimelinePoint.cs
@@ -1,0 +1,19 @@
+using System;
+
+namespace Quilt4Net.Toolkit.Features.ApplicationInsights;
+
+/// <summary>
+/// Billed ingestion volume for a single source table on a single UTC day — the points behind the
+/// multi-day logging-volume line chart. Sourced from the workspace <c>Usage</c> table (billing-grade).
+/// </summary>
+public record VolumeTimelinePoint
+{
+    /// <summary>The UTC day (start-of-day) the volume was billed on.</summary>
+    public required DateTime DayUtc { get; init; }
+
+    /// <summary>Source table / data type (the Log Analytics <c>DataType</c>).</summary>
+    public required string Source { get; init; }
+
+    /// <summary>Billed ingestion volume in megabytes for that source on that day.</summary>
+    public required double Mb { get; init; }
+}

--- a/Quilt4Net.Toolkit/Quilt4Net.Toolkit.csproj
+++ b/Quilt4Net.Toolkit/Quilt4Net.Toolkit.csproj
@@ -52,6 +52,6 @@
     </PackageReference>
     <PackageReference Include="System.Management" Version="10.0.9" />
     <PackageReference Include="System.Linq.Async" Version="7.0.1" />
-    <PackageReference Include="Tharga.Cache" Version="0.4.8" />
+    <PackageReference Include="Tharga.Cache" Version="0.4.9" />
   </ItemGroup>
 </Project>

--- a/docs/articles/log-views.md
+++ b/docs/articles/log-views.md
@@ -175,7 +175,7 @@ Two components turn the same workspace into a cost picture — what you ingest, 
 
 ### `LogVolumeView` — billed ingestion by source
 
-A pie of billed ingestion volume grouped by source table (`DataType`), a total for the window, and a sortable table (Source / Size / Share). Size auto-scales to GB/MB/KB; the column sorts on the raw value so ordering is correct regardless of the unit shown.
+Billed ingestion volume grouped by source table (`DataType`): a pie + sortable table (Source / Size / Share) for the **1h**, **24h**, **Today (UTC)** and **Yesterday (UTC)** ranges, and a **per-source line chart** for the **7d** range. A total for the window is shown above. Size auto-scales to GB/MB/KB; the column sorts on the raw value so ordering is correct regardless of the unit shown.
 
 ```razor
 @using Quilt4Net.Toolkit.Blazor.Features.Log
@@ -187,13 +187,18 @@ A pie of billed ingestion volume grouped by source table (`DataType`), a total f
 | Parameter | Type | Default | Notes |
 |---|---|---|---|
 | `Context` | `IApplicationInsightsContext` | `null` | Workspace to query. When null, resolved via the DI selector / configured options. |
-| `Range` | `TimeSpan` | `7 days` | Initial lookback; the in-view **1h / 24h / 7d** selector changes it. |
+| `Range` | `TimeSpan` | `7 days` | Initial range; the in-view **1h / 24h / Today / Yesterday / 7d** selector changes it. |
 
-When the `Usage` table can't be read (or is empty for the range) the view shows an informational alert instead of an empty chart.
+`Usage` is billing-grade but reported with a delay, so short ranges (1h/Today) can lag behind real-time — a caption notes this. When the `Usage` table can't be read (or is empty for the range) the view shows an informational alert instead of an empty chart.
 
 ### `CapTimelineView` — daily ingestion-cap graph
 
-A per-UTC-day view of billed volume against the configured daily cap: one column per day, a dashed reference line at the cap, and diamond markers for the **estimated uncapped** volume on days the cap was hit (`cap × 24 / hours-to-hit` — what the day would have ingested unthrottled). The grid below gives the precise first-hit time per day.
+Tracks billed volume against the daily cap, detected from the workspace's daily-cap `Operation` events. Two views via the **Break by** toggle:
+
+- **Calendar day** (default) — one column per UTC day. "Capped for" shows the total no-collection time that day (a gap spanning the reset splits across midnight); its tooltip lists the capped sub-intervals, e.g. `Capped 00:00–12:00, 22:24–24:00 UTC`.
+- **Cap cycle** — one row per quota cycle (reset → next reset), so a cap is a single clean span (hit → next reset) with no midnight split.
+
+Each bar stacks **Ingested** (bottom) + the **estimated capped-away** volume (top), so the full bar height is the estimated uncapped volume; a dashed reference line marks the cap. A summary shows the **measured cap size** and the **detected reset time**.
 
 ```razor
 @using Quilt4Net.Toolkit.Blazor.Features.Log
@@ -207,9 +212,9 @@ A per-UTC-day view of billed volume against the configured daily cap: one column
 | `Context` | `IApplicationInsightsContext` | `null` | Workspace to query. When null, resolved via the DI selector / configured options. |
 | `Days` | `int` | `30` | Initial range; the in-view **14 / 30 / 90 days** selector changes it. |
 
-The cap value comes from the latest `"Daily quota changed to N"` config event in the `Operation` table; first-hit times from the `"stopped due to daily limit"` events. With no cap configured the view drops the reference line and just charts daily volume; when neither table is readable it shows an informational alert. The daily cap is a *soft* limit — ingestion isn't hard-stopped at the cap, so days can finish above it, which is exactly why the est.-uncapped overlay is worth showing.
+**Detection** (the daily cap reset hour varies per workspace, so this is data-driven): cap hits come from the `"stopped due to daily limit"` events and the reset/resume time from the `"daily limit reset"` events — precise to the event, unlike the ~1h-lagged `Usage` table. The **cap size** is measured as the billed volume in a complete reset→cap cycle (floored to whole GB, since collection stops just *past* the cap), falling back to the `"Daily quota changed to N"` config event if present. With no caps observed the view just charts daily volume; when the tables aren't readable it shows an informational alert.
 
-Both components honour the same remote/local `Context` precedence as the other views — pass an explicit `Context`, or let the DI selector drive them. On Quilt4Net Server they appear as the **Logging volume** and **Daily cap** tabs on `/monitor/metrics` and `/developer/metrics`.
+Both components honour the same remote/local `Context` precedence as the other views — pass an explicit `Context`, or let the DI selector drive them. On Quilt4Net Server they appear as the **Volume** and **Daily cap** tabs on the **Log volume** page (`/monitor/volume`, `/developer/volume`).
 
 ## Where next
 

--- a/docs/articles/metrics.md
+++ b/docs/articles/metrics.md
@@ -1,6 +1,6 @@
 # Metrics
 
-Three Blazor components in `Quilt4Net.Toolkit.Blazor.Features.Metrics` plot machine-level telemetry (CPU, memory, disk, network) sourced from the AI workspace via `IApplicationInsightsService`. The composite `MetricsView` is the drop-in surface that powers Quilt4Net Server's `/developer/metrics`; `MetricChart` and `MetricLatestChart` are the two primitives it renders and are exported so custom dashboards can compose their own charts off the same `MetricSample[]` stream.
+Three Blazor components in `Quilt4Net.Toolkit.Blazor.Features.Metrics` plot machine-level telemetry (CPU, memory, disk, network) sourced from the AI workspace via `IApplicationInsightsService`. The composite `MetricsView` is the drop-in surface that powers Quilt4Net Server's **Infrastructure** page (`/monitor/infrastructure`, `/developer/infrastructure`); `MetricChart` and `MetricLatestChart` are the two primitives it renders and are exported so custom dashboards can compose their own charts off the same `MetricSample[]` stream.
 
 ## Minimum
 
@@ -116,6 +116,7 @@ Both primitives accept a `MetricSample[]` you fetch yourself, so a host that alr
 |---|---|---|---|
 | `Context` | `IApplicationInsightsContext` | `null` | Explicit single workspace. Bypasses the selector / `Configs` dropdown. |
 | `Configs` | `IReadOnlyList<ApplicationInsightsConfigurationResponse>` | `null` | Explicit set; rendered as a dropdown when count > 1. Takes precedence over the DI selector; ignored when `Context` is set. |
+| `StorageScope` | `string` | `null` | When set (and a `Configs` dropdown is shown), the selected configuration is remembered across sessions in browser `localStorage` under `Quilt4Net.Metrics.{scope}.config`. Hosts pass e.g. the team key. |
 
 ## Where next
 


### PR DESCRIPTION
## Monitoring: restructure Infrastructure/Log-volume + cap & volume improvements

Reorganizes the monitoring views and substantially improves the daily-cap and logging-volume surfaces. Minor bump to **0.10** (new public API + a breaking `CapDay` change).

### LogVolumeView
- Range selector gains **Today** and **Yesterday** (absolute UTC-day windows) alongside 1h / 24h / 7d.
- **7d** now renders a **per-source line chart** (`GetVolumeTimelineAsync`); short ranges keep the by-source pie.
- Caption notes the billing-table (`Usage`) aggregation lag, which is why a short-range volume figure differs from the near-real-time Log count.

### CapTimelineView (daily cap)
- Detection now reads Azure **`Operation` events** (`stopped due to daily limit` / `daily limit reset`) for an accurate reset time, plus **per-reset-cycle** billed volume for an accurate measured cap size — fixing a case where gap-heuristic detection mis-read the cap as 74 GB/13:00 when Azure had 10 GB/12:00.
- **Break by** toggle: **Day** or **Cap cycle** (reset→next-reset; shows every day, including uncapped).
- Estimated-uncapped volume now renders as a **stacked column on top of Ingested** (was a separate line).
- "Capped for" column (hh:mm) with the cap-hit time(s) in a tooltip; summary shows measured cap size + detected reset time.

### MetricsView (Infrastructure)
- New `StorageScope` parameter: when set, the selected configuration is remembered across sessions in `localStorage`.

### Housekeeping
- `CapTimelineBuilder` is now `internal` (implementation detail); its tests moved to the core `Quilt4Net.Toolkit.Tests` project.
- Docs (`log-views.md`, `metrics.md`) and READMEs updated for the new ranges, cap detection, Break-by toggle, Infrastructure page, and the renamed **Volume** / **Daily cap** tabs.

### Tests
Core 180 / Blazor 121 / Mcp 15 — all green; warning count under the ratchet baseline.

### Note for consumers (API)
- **Breaking:** `CapDay.CapHitUtc` removed — replaced by `CappedIntervals` (and `GapDuration` / `ResumeUtc`).
- **New:** `VolumeTimelinePoint`, `CapCycle`, `CappedInterval`; new `CapTimeline` members (`DerivedCapGb`, `CapResetUtc`, `Cycles`); two new `IApplicationInsightsService` volume overloads; `MetricsView.StorageScope`.
