### PR TITLE
feat: correlation-id telemetry — Exception.Data + log-scope enrichment (#123)

### DIFF
--- a/Quilt4Net.Toolkit.Api/Framework/CorrelationIdMiddleware.cs
+++ b/Quilt4Net.Toolkit.Api/Framework/CorrelationIdMiddleware.cs
@@ -28,10 +28,11 @@ public class CorrelationIdMiddleware
         context.Items[CorrelationConstants.ItemKey] = correlationId;
 
         // Push CorrelationId into a logging scope so every ILogger call made during this
-        // request inherits it as a structured property. The Azure Monitor exporter then
-        // writes customDimensions["CorrelationId"] on every AppTrace / AppException for
-        // the duration of the request — letting the same correlation id span the inbound
-        // request, any work it triggers, and the outgoing response.
+        // request inherits it as a structured property. Scope values only reach
+        // customDimensions when scope capture is enabled, so this id lands on every
+        // AppTrace / AppException for the request when the app opts in via
+        // AddQuilt4NetLogging(o => o.IncludeScopes = true) — letting the same correlation id
+        // span the inbound request, any work it triggers, and the outgoing response.
         using (_logger.BeginScope(new Dictionary<string, object> { ["CorrelationId"] = correlationId }))
         {
             await _next(context);

--- a/Quilt4Net.Toolkit.Api/README.md
+++ b/Quilt4Net.Toolkit.Api/README.md
@@ -32,7 +32,16 @@ app.Run();
 
 1. Stored in `HttpContext.Items["CorrelationId"]` for inspection by downstream code.
 2. Returned in the response's `X-Correlation-ID` header — clients can chain the same id to subsequent requests for distributed tracing.
-3. **Pushed into a logging scope** (`Logger.BeginScope({ ["CorrelationId"] = id })`) for the duration of the request, so every `ILogger` call made while handling the request inherits the id as a structured property. The Azure Monitor exporter writes it to `customDimensions["CorrelationId"]` on every resulting `AppTrace` / `AppException` / `AppRequest` row.
+3. **Pushed into a logging scope** (`Logger.BeginScope({ ["CorrelationId"] = id })`) for the duration of the request, so every `ILogger` call made while handling the request inherits the id as a structured property.
+
+For the scoped id to reach `customDimensions["CorrelationId"]` on the resulting `AppTrace` / `AppException` / `AppRequest` rows, enable scope capture — scope values are not exported by default:
+
+```csharp
+builder.AddQuilt4NetLogging(o => o.IncludeScopes = true)
+    .AddHttpRequestLogging();
+```
+
+(See the base `Quilt4Net.Toolkit` README → "Exception data and log scopes".)
 
 KQL pattern for "show me everything from one call chain":
 

--- a/Quilt4Net.Toolkit.Blazor.Server.Sample/Program.cs
+++ b/Quilt4Net.Toolkit.Blazor.Server.Sample/Program.cs
@@ -33,7 +33,9 @@ builder.AddQuilt4NetRemoteConfiguration();
 // Register the per-record telemetry-identity processors (env / app / version / host /
 // quilt4net.monitor) and the request middleware that mints / honors X-Correlation-ID.
 // AddHttpRequestLogging is the opt-in that enables the middleware via UseQuilt4NetLogging.
-builder.AddQuilt4NetLogging()
+// IncludeScopes is what carries the middleware's CorrelationId scope into customDimensions
+// (see the /api/correlation-demo endpoint below).
+builder.AddQuilt4NetLogging(o => o.IncludeScopes = true)
     .AddHttpRequestLogging();
 
 var app = builder.Build();

--- a/Quilt4Net.Toolkit.Blazor/Quilt4Net.Toolkit.Blazor.csproj
+++ b/Quilt4Net.Toolkit.Blazor/Quilt4Net.Toolkit.Blazor.csproj
@@ -26,7 +26,7 @@
        consumers can fetch _content/Quilt4Net.Toolkit.Blazor/<asset> at runtime. -->
   <ItemGroup>
     <PackageReference Include="Microsoft.Authentication.WebAssembly.Msal" Version="10.0.9" />
-    <PackageReference Include="Microsoft.Identity.Client" Version="4.85.1" />
+    <PackageReference Include="Microsoft.Identity.Client" Version="4.85.2" />
     <PackageReference Include="Tharga.Blazor" Version="2.2.0" />
   </ItemGroup>
   <ItemGroup>

--- a/Quilt4Net.Toolkit.Tests/ExceptionDataEnrichmentTests.cs
+++ b/Quilt4Net.Toolkit.Tests/ExceptionDataEnrichmentTests.cs
@@ -108,6 +108,84 @@ public class ExceptionDataEnrichmentTests
         attributes.Should().NotContain(kv => kv.Key == "CorrelationId");
     }
 
+    [Fact]
+    public void IncludeScopes_defaults_to_off()
+    {
+        new Quilt4NetLoggingOptions().IncludeScopes.Should().BeFalse();
+    }
+
+    [Fact]
+    public void ScopeProcessor_copies_dictionary_scope_values_onto_record_attributes()
+    {
+        var attributes = EnrichScopes(
+            logger => logger.BeginScope(new Dictionary<string, object> { ["CorrelationId"] = "scope-guid" }),
+            log: logger => logger.LogInformation("hi"));
+
+        attributes.Should().Contain(kv => kv.Key == "CorrelationId" && kv.Value!.Equals("scope-guid"));
+    }
+
+    [Fact]
+    public void ScopeProcessor_captures_named_values_from_a_message_template_scope()
+    {
+        var attributes = EnrichScopes(
+            logger => logger.BeginScope("Order {OrderId}", 7),
+            log: logger => logger.LogInformation("hi"));
+
+        attributes.Should().Contain(kv => kv.Key == "OrderId" && kv.Value!.Equals("7"));
+    }
+
+    [Fact]
+    public void AddQuilt4NetLogging_wires_scope_capture_when_IncludeScopes_is_true()
+    {
+        var attributes = ScopesViaRegistration(includeScopes: true);
+
+        attributes.Should().Contain(kv => kv.Key == "CorrelationId" && kv.Value!.Equals("wired-scope"));
+    }
+
+    [Fact]
+    public void AddQuilt4NetLogging_does_not_wire_scope_capture_by_default()
+    {
+        var attributes = ScopesViaRegistration(includeScopes: null);
+
+        attributes.Should().NotContain(kv => kv.Key == "CorrelationId");
+    }
+
+    private static List<KeyValuePair<string, object>> EnrichScopes(System.Func<ILogger, System.IDisposable> beginScope, System.Action<ILogger> log)
+    {
+        List<KeyValuePair<string, object>> captured = null;
+        using var loggerFactory = LoggerFactory.Create(b => b.AddOpenTelemetry(o =>
+        {
+            o.IncludeScopes = true;
+            o.AddProcessor(new ScopeAttributesLogProcessor());
+            o.AddProcessor(new CaptureProcessor(r => captured = r.Attributes?.ToList() ?? new List<KeyValuePair<string, object>>()));
+        }));
+
+        var logger = loggerFactory.CreateLogger("test");
+        using (beginScope(logger)) log(logger);
+        return captured;
+    }
+
+    private static List<KeyValuePair<string, object>> ScopesViaRegistration(bool? includeScopes)
+    {
+        List<KeyValuePair<string, object>> captured = null;
+        var services = new ServiceCollection();
+        services.AddQuilt4NetLogging(options: o =>
+        {
+            o.ApplicationName = "test-app";
+            if (includeScopes.HasValue) o.IncludeScopes = includeScopes.Value;
+        });
+        services.AddOpenTelemetry().WithLogging(b =>
+            b.AddProcessor(new CaptureProcessor(r => captured = r.Attributes?.ToList() ?? new List<KeyValuePair<string, object>>())));
+
+        using var provider = services.BuildServiceProvider();
+        var logger = provider.GetRequiredService<ILoggerFactory>().CreateLogger("test");
+        using (logger.BeginScope(new Dictionary<string, object> { ["CorrelationId"] = "wired-scope" }))
+        {
+            logger.LogInformation("hi");
+        }
+        return captured;
+    }
+
     private static List<KeyValuePair<string, object>> Enrich(System.Exception exception, IList<KeyValuePair<string, object>> seedAttributes = null)
     {
         List<KeyValuePair<string, object>> captured = null;

--- a/Quilt4Net.Toolkit.Tests/ExceptionDataEnrichmentTests.cs
+++ b/Quilt4Net.Toolkit.Tests/ExceptionDataEnrichmentTests.cs
@@ -1,0 +1,155 @@
+using System.Collections.Generic;
+using System.Linq;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using OpenTelemetry;
+using OpenTelemetry.Logs;
+using Quilt4Net.Toolkit;
+using Quilt4Net.Toolkit.Features.Logging;
+using Quilt4Net.Toolkit.Features.Measure;
+using Xunit;
+
+namespace Quilt4Net.Toolkit.Tests;
+
+public class ExceptionDataEnrichmentTests
+{
+    [Fact]
+    public void EnrichExceptionData_defaults_to_on()
+    {
+        new Quilt4NetLoggingOptions().EnrichExceptionData.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Processor_copies_exception_data_onto_record_attributes()
+    {
+        var correlationId = "1f56e7db-7f58-4c72-8a74-af7a896e750d";
+        var exception = new InvalidOperationException("boom").AddData("CorrelationId", correlationId);
+
+        var attributes = Enrich(exception);
+
+        attributes.Should().Contain(new KeyValuePair<string, object>("CorrelationId", correlationId));
+    }
+
+    [Fact]
+    public void Processor_copies_multiple_entries()
+    {
+        var exception = new Exception("boom")
+            .AddData("CorrelationId", "abc")
+            .AddData("TenantId", "eplicta");
+
+        var attributes = Enrich(exception);
+
+        attributes.Should().Contain(kv => kv.Key == "CorrelationId" && kv.Value!.Equals("abc"));
+        attributes.Should().Contain(kv => kv.Key == "TenantId" && kv.Value!.Equals("eplicta"));
+    }
+
+    [Fact]
+    public void Processor_stringifies_values_with_invariant_culture()
+    {
+        var exception = new Exception("boom").AddData("Ratio", 1.5d);
+
+        var attributes = Enrich(exception);
+
+        attributes.Should().Contain(new KeyValuePair<string, object>("Ratio", "1.5"));
+    }
+
+    [Fact]
+    public void Processor_skips_null_values()
+    {
+        var exception = new Exception("boom");
+        exception.Data["Missing"] = null;
+
+        var attributes = Enrich(exception);
+
+        attributes.Should().NotContain(kv => kv.Key == "Missing");
+    }
+
+    [Fact]
+    public void Processor_does_not_overwrite_an_existing_attribute_with_the_same_key()
+    {
+        var exception = new Exception("boom").AddData("CorrelationId", "from-exception");
+        var seed = new List<KeyValuePair<string, object>> { new("CorrelationId", "already-present") };
+
+        var attributes = Enrich(exception, seed);
+
+        attributes.Should().ContainSingle(kv => kv.Key == "CorrelationId")
+            .Which.Value.Should().Be("already-present");
+    }
+
+    [Fact]
+    public void Processor_is_a_noop_when_the_record_has_no_exception()
+    {
+        List<KeyValuePair<string, object>> captured = null;
+        using var loggerFactory = LoggerFactory.Create(b => b.AddOpenTelemetry(o =>
+        {
+            o.AddProcessor(new ExceptionDataLogProcessor());
+            o.AddProcessor(new CaptureProcessor(r => captured = r.Attributes?.ToList() ?? new List<KeyValuePair<string, object>>()));
+        }));
+
+        loggerFactory.CreateLogger("test").LogInformation("no exception here");
+
+        captured.Should().NotContain(kv => kv.Key == "CorrelationId");
+    }
+
+    [Fact]
+    public void AddQuilt4NetLogging_wires_the_enricher_by_default()
+    {
+        var attributes = EnrichViaRegistration(enrich: null, new Exception("boom").AddData("CorrelationId", "wired"));
+
+        attributes.Should().Contain(kv => kv.Key == "CorrelationId" && kv.Value!.Equals("wired"));
+    }
+
+    [Fact]
+    public void AddQuilt4NetLogging_does_not_wire_the_enricher_when_disabled()
+    {
+        var attributes = EnrichViaRegistration(enrich: false, new Exception("boom").AddData("CorrelationId", "should-be-absent"));
+
+        attributes.Should().NotContain(kv => kv.Key == "CorrelationId");
+    }
+
+    private static List<KeyValuePair<string, object>> Enrich(System.Exception exception, IList<KeyValuePair<string, object>> seedAttributes = null)
+    {
+        List<KeyValuePair<string, object>> captured = null;
+        using var loggerFactory = LoggerFactory.Create(b => b.AddOpenTelemetry(o =>
+        {
+            if (seedAttributes != null) o.AddProcessor(new SeedProcessor(seedAttributes));
+            o.AddProcessor(new ExceptionDataLogProcessor());
+            o.AddProcessor(new CaptureProcessor(r => captured = r.Attributes?.ToList() ?? new List<KeyValuePair<string, object>>()));
+        }));
+
+        loggerFactory.CreateLogger("test").LogError(exception, "boom");
+        return captured;
+    }
+
+    private static List<KeyValuePair<string, object>> EnrichViaRegistration(bool? enrich, System.Exception exception)
+    {
+        List<KeyValuePair<string, object>> captured = null;
+        var services = new ServiceCollection();
+        services.AddQuilt4NetLogging(options: o =>
+        {
+            o.ApplicationName = "test-app";
+            if (enrich.HasValue) o.EnrichExceptionData = enrich.Value;
+        });
+        services.AddOpenTelemetry().WithLogging(b =>
+            b.AddProcessor(new CaptureProcessor(r => captured = r.Attributes?.ToList() ?? new List<KeyValuePair<string, object>>())));
+
+        using var provider = services.BuildServiceProvider();
+        provider.GetRequiredService<ILoggerFactory>().CreateLogger("test").LogError(exception, "boom");
+        return captured;
+    }
+
+    private sealed class CaptureProcessor : BaseProcessor<LogRecord>
+    {
+        private readonly System.Action<LogRecord> _capture;
+        public CaptureProcessor(System.Action<LogRecord> capture) => _capture = capture;
+        public override void OnEnd(LogRecord data) => _capture(data);
+    }
+
+    private sealed class SeedProcessor : BaseProcessor<LogRecord>
+    {
+        private readonly IList<KeyValuePair<string, object>> _attrs;
+        public SeedProcessor(IList<KeyValuePair<string, object>> attrs) => _attrs = attrs;
+        public override void OnEnd(LogRecord data) => data.Attributes = (IReadOnlyList<KeyValuePair<string, object>>)_attrs;
+    }
+}

--- a/Quilt4Net.Toolkit/Features/Logging/ExceptionDataEnrichment.cs
+++ b/Quilt4Net.Toolkit/Features/Logging/ExceptionDataEnrichment.cs
@@ -1,0 +1,51 @@
+using System.Globalization;
+using OpenTelemetry;
+using OpenTelemetry.Logs;
+using Quilt4Net.Toolkit.Features.Measure;
+
+namespace Quilt4Net.Toolkit.Features.Logging;
+
+/// <summary>
+/// Shared extraction of an exception's <see cref="Exception.Data"/> entries as stringified
+/// key/value pairs. Values are rendered with <see cref="CultureInfo.InvariantCulture"/> so a
+/// correlation id (or any datum) reads identically regardless of the host's locale, and to match
+/// the string-only shape of Application Insights <c>customDimensions</c>. Null keys and values are
+/// skipped.
+/// </summary>
+internal static class ExceptionDataEnricher
+{
+    public static IEnumerable<KeyValuePair<string, string>> GetStringData(Exception exception)
+    {
+        foreach (var entry in exception.GetData())
+        {
+            if (string.IsNullOrEmpty(entry.Key) || entry.Value is null) continue;
+            yield return new KeyValuePair<string, string>(entry.Key, Convert.ToString(entry.Value, CultureInfo.InvariantCulture));
+        }
+    }
+}
+
+/// <summary>
+/// Copies a logged exception's <see cref="Exception.Data"/> entries onto the <see cref="LogRecord"/>
+/// attributes so they reach <c>customDimensions</c> via the Azure Monitor OpenTelemetry exporter.
+/// Existing attributes (including the Quilt4Net identity attributes) are never overwritten.
+/// </summary>
+internal sealed class ExceptionDataLogProcessor : BaseProcessor<LogRecord>
+{
+    public override void OnEnd(LogRecord data)
+    {
+        if (data.Exception is null) return;
+
+        var existing = data.Attributes;
+        var list = new List<KeyValuePair<string, object>>(existing ?? []);
+        var keys = new HashSet<string>(list.Count);
+        foreach (var attribute in list) keys.Add(attribute.Key);
+
+        foreach (var entry in ExceptionDataEnricher.GetStringData(data.Exception))
+        {
+            if (!keys.Add(entry.Key)) continue;
+            list.Add(new KeyValuePair<string, object>(entry.Key, entry.Value));
+        }
+
+        data.Attributes = list;
+    }
+}

--- a/Quilt4Net.Toolkit/Features/Logging/ExceptionDataEnrichment.cs
+++ b/Quilt4Net.Toolkit/Features/Logging/ExceptionDataEnrichment.cs
@@ -19,8 +19,35 @@ internal static class ExceptionDataEnricher
         foreach (var entry in exception.GetData())
         {
             if (string.IsNullOrEmpty(entry.Key) || entry.Value is null) continue;
-            yield return new KeyValuePair<string, string>(entry.Key, Convert.ToString(entry.Value, CultureInfo.InvariantCulture));
+            yield return new KeyValuePair<string, string>(entry.Key, ToInvariantString(entry.Value));
         }
+    }
+
+    public static string ToInvariantString(object value) => Convert.ToString(value, CultureInfo.InvariantCulture);
+}
+
+/// <summary>
+/// Appends string key/value pairs onto a <see cref="LogRecord"/> without overwriting attributes
+/// that are already present (identity attributes, exception data, or earlier scopes).
+/// </summary>
+internal static class LogRecordAttributes
+{
+    public static void AppendNew(LogRecord data, IEnumerable<KeyValuePair<string, string>> additions)
+    {
+        var existing = data.Attributes;
+        var list = new List<KeyValuePair<string, object>>(existing ?? []);
+        var keys = new HashSet<string>(list.Count);
+        foreach (var attribute in list) keys.Add(attribute.Key);
+
+        var appended = false;
+        foreach (var addition in additions)
+        {
+            if (!keys.Add(addition.Key)) continue;
+            list.Add(new KeyValuePair<string, object>(addition.Key, addition.Value));
+            appended = true;
+        }
+
+        if (appended) data.Attributes = list;
     }
 }
 
@@ -34,18 +61,35 @@ internal sealed class ExceptionDataLogProcessor : BaseProcessor<LogRecord>
     public override void OnEnd(LogRecord data)
     {
         if (data.Exception is null) return;
+        LogRecordAttributes.AppendNew(data, ExceptionDataEnricher.GetStringData(data.Exception));
+    }
+}
 
-        var existing = data.Attributes;
-        var list = new List<KeyValuePair<string, object>>(existing ?? []);
-        var keys = new HashSet<string>(list.Count);
-        foreach (var attribute in list) keys.Add(attribute.Key);
+/// <summary>
+/// Copies <see cref="Microsoft.Extensions.Logging.ILogger"/> scope values (captured when
+/// <see cref="Quilt4NetLoggingOptions.IncludeScopes"/> is enabled) onto the <see cref="LogRecord"/>
+/// attributes so scoped context — notably the <c>CorrelationId</c> pushed by
+/// <c>CorrelationIdMiddleware</c> — reaches <c>customDimensions</c>. The message template's
+/// <c>{OriginalFormat}</c> entry is skipped; existing attributes are never overwritten.
+/// </summary>
+internal sealed class ScopeAttributesLogProcessor : BaseProcessor<LogRecord>
+{
+    private const string OriginalFormatKey = "{OriginalFormat}";
 
-        foreach (var entry in ExceptionDataEnricher.GetStringData(data.Exception))
+    public override void OnEnd(LogRecord data)
+    {
+        var scopeValues = new List<KeyValuePair<string, string>>();
+
+        data.ForEachScope(static (scope, state) =>
         {
-            if (!keys.Add(entry.Key)) continue;
-            list.Add(new KeyValuePair<string, object>(entry.Key, entry.Value));
-        }
+            foreach (var pair in scope)
+            {
+                if (string.IsNullOrEmpty(pair.Key) || pair.Key == OriginalFormatKey || pair.Value is null) continue;
+                state.Add(new KeyValuePair<string, string>(pair.Key, ExceptionDataEnricher.ToInvariantString(pair.Value)));
+            }
+        }, scopeValues);
 
-        data.Attributes = list;
+        if (scopeValues.Count == 0) return;
+        LogRecordAttributes.AppendNew(data, scopeValues);
     }
 }

--- a/Quilt4Net.Toolkit/LoggingRegistration.cs
+++ b/Quilt4Net.Toolkit/LoggingRegistration.cs
@@ -101,6 +101,14 @@ public static class LoggingRegistration
                 // OpenTelemetry path: copy Exception.Data onto exception log records so an attached
                 // correlation id reaches customDimensions and becomes queryable.
                 if (o.EnrichExceptionData) b.AddProcessor(new Features.Logging.ExceptionDataLogProcessor());
+
+                // Copy ILogger scope values (e.g. the correlation id CorrelationIdMiddleware pushes)
+                // onto each record so they land in customDimensions. Requires scope capture, enabled
+                // via the options delegate below.
+                if (o.IncludeScopes) b.AddProcessor(new Features.Logging.ScopeAttributesLogProcessor());
+            }, otelLoggerOptions =>
+            {
+                if (o.IncludeScopes) otelLoggerOptions.IncludeScopes = true;
             })
             .WithTracing(b => b.AddProcessor(new Features.Logging.TelemetryIdentityActivityProcessor(identity)));
 

--- a/Quilt4Net.Toolkit/LoggingRegistration.cs
+++ b/Quilt4Net.Toolkit/LoggingRegistration.cs
@@ -94,7 +94,14 @@ public static class LoggingRegistration
             // exporter (only the well-known service.* mappings → cloud_RoleName / AppVersion /
             // cloud_RoleInstance columns). The processors below copy the identity onto each
             // log record and span as per-record attributes so they land in customDimensions.
-            .WithLogging(b => b.AddProcessor(new Features.Logging.TelemetryIdentityLogProcessor(identity)))
+            .WithLogging(b =>
+            {
+                b.AddProcessor(new Features.Logging.TelemetryIdentityLogProcessor(identity));
+
+                // OpenTelemetry path: copy Exception.Data onto exception log records so an attached
+                // correlation id reaches customDimensions and becomes queryable.
+                if (o.EnrichExceptionData) b.AddProcessor(new Features.Logging.ExceptionDataLogProcessor());
+            })
             .WithTracing(b => b.AddProcessor(new Features.Logging.TelemetryIdentityActivityProcessor(identity)));
 
         return new Quilt4NetLoggingBuilder(services, o);

--- a/Quilt4Net.Toolkit/Quilt4NetLoggingOptions.cs
+++ b/Quilt4Net.Toolkit/Quilt4NetLoggingOptions.cs
@@ -67,4 +67,15 @@ public record Quilt4NetLoggingOptions
     /// <c>ExceptionTelemetry</c>). Set to <c>false</c> to opt out.
     /// </summary>
     public bool EnrichExceptionData { get; set; } = true;
+
+    /// <summary>
+    /// When <c>true</c>, values from <see cref="Microsoft.Extensions.Logging.ILogger"/> scopes
+    /// (e.g. <c>logger.BeginScope(...)</c>) are captured and copied onto each log record so they
+    /// surface under <c>customDimensions</c> in Application Insights. This is what makes the
+    /// <c>CorrelationId</c> that <c>CorrelationIdMiddleware</c> pushes as a scope actually
+    /// queryable on every <c>AppTrace</c> / <c>AppException</c> raised during the request.
+    /// Default is <c>false</c> (opt-in) because scope capture increases telemetry volume; enable it
+    /// deliberately with <c>AddQuilt4NetLogging(o =&gt; o.IncludeScopes = true)</c>.
+    /// </summary>
+    public bool IncludeScopes { get; set; }
 }

--- a/Quilt4Net.Toolkit/Quilt4NetLoggingOptions.cs
+++ b/Quilt4Net.Toolkit/Quilt4NetLoggingOptions.cs
@@ -55,4 +55,16 @@ public record Quilt4NetLoggingOptions
     /// </list>
     /// </summary>
     public string ServiceInstanceId { get; set; }
+
+    /// <summary>
+    /// When <c>true</c> (the default), a logged exception's <see cref="System.Exception.Data"/>
+    /// entries are copied onto the exception telemetry so they surface under
+    /// <c>customDimensions</c> in Application Insights. This makes an id attached to the exception
+    /// — e.g. <c>e.AddData("CorrelationId", guid)</c> — queryable, for example:
+    /// <code>AppExceptions | where tostring(customDimensions.CorrelationId) == "&lt;guid&gt;"</code>
+    /// Enrichment is applied to both the OpenTelemetry pipeline (via a log processor) and the
+    /// classic Application Insights SDK (via an <c>ITelemetryInitializer</c> on
+    /// <c>ExceptionTelemetry</c>). Set to <c>false</c> to opt out.
+    /// </summary>
+    public bool EnrichExceptionData { get; set; } = true;
 }

--- a/Quilt4Net.Toolkit/README.md
+++ b/Quilt4Net.Toolkit/README.md
@@ -338,7 +338,42 @@ builder.AddQuilt4NetLogging()
     .AddHttpRequestLogging();
 ```
 
-When `Quilt4Net.Toolkit.Api`'s `CorrelationIdMiddleware` is active, every `ILogger` call inside a request also picks up `customDimensions["CorrelationId"]` automatically — see the Api package README.
+When `Quilt4Net.Toolkit.Api`'s `CorrelationIdMiddleware` is active, every `ILogger` call inside a request is scoped with the correlation id. That id reaches `customDimensions["CorrelationId"]` only when scope capture is enabled — set `IncludeScopes` (see below). See the Api package README.
+
+### Exception data and log scopes
+
+Two opt-in enrichers copy extra context onto the per-record `customDimensions`:
+
+| Option | Default | Effect |
+|---|---|---|
+| `EnrichExceptionData` | **on** | Copies a logged exception's `Exception.Data` entries onto the exception telemetry. An id attached with `e.AddData("CorrelationId", guid)` becomes queryable in AI. |
+| `IncludeScopes` | **off** | Captures `ILogger` scope values (e.g. the `CorrelationId` scope `CorrelationIdMiddleware` pushes) and copies them onto every record so they land in `customDimensions`. Opt-in because scope capture adds telemetry volume. |
+
+```csharp
+builder.AddQuilt4NetLogging(o =>
+{
+    o.IncludeScopes = true;      // scope values (incl. CorrelationId) → customDimensions
+    // o.EnrichExceptionData = false;  // to opt out of Exception.Data enrichment
+});
+```
+
+With `EnrichExceptionData` on, an exception carrying a correlation id is findable directly:
+
+```csharp
+catch (Exception e)
+{
+    e.AddData("CorrelationId", correlationId);   // Quilt4Net.Toolkit.Features.Measure
+    logger.LogError(e, e.Message);
+}
+```
+
+```kql
+AppExceptions | where tostring(customDimensions.CorrelationId) == "<guid>"
+```
+
+> This `CorrelationId` (an id that flows across service hops and into `customDimensions`) is distinct from the user-facing 6-character `IncidentId` shown in Log-view error messages.
+
+> Enrichment runs on the OpenTelemetry pipeline. Apps ingesting via the classic Application Insights SDK on AI 3.x must export logs through `Azure.Monitor.OpenTelemetry` to benefit — AI 3.x does not ingest `ILogger` telemetry through the classic pipeline.
 
 ### Distinguishing multiple deployments of the same binary
 

--- a/docs/articles/telemetry-identity.md
+++ b/docs/articles/telemetry-identity.md
@@ -1,9 +1,10 @@
 # Telemetry identity & correlation
 
-`AddQuilt4NetLogging()` does two things:
+`AddQuilt4NetLogging()`:
 
 1. Configures **OpenTelemetry resource attributes** so the Azure Monitor exporter populates the AI columns `cloud_RoleName`, `application_Version`, and `cloud_RoleInstance`.
-2. Registers **two `BaseProcessor`s** — one for `LogRecord`, one for `Activity` — that copy a five-attribute identity onto every per-record `Properties` bag at export time. The Azure Monitor exporter does *not* forward arbitrary OTel resource attributes to per-row Properties for log records, so without this step `customDimensions["deployment.environment"]` would always be empty.
+2. Registers `BaseProcessor`s — one for `LogRecord`, one for `Activity` — that copy a five-attribute identity onto every per-record `Properties` bag at export time. The Azure Monitor exporter does *not* forward arbitrary OTel resource attributes to per-row Properties for log records, so without this step `customDimensions["deployment.environment"]` would always be empty.
+3. Optionally enriches records with **exception data** and **log scopes** (see below) so a correlation id reaches `customDimensions`.
 
 ```csharp
 var builder = WebApplication.CreateBuilder(args);
@@ -66,7 +67,14 @@ app.UseQuilt4NetLogging();
 2. Echoes it back as a response header.
 3. Pushes it into a logging scope (`Logger.BeginScope({ ["CorrelationId"] = id })`) for the duration of the request.
 
-Every `ILogger` call made while handling the request inherits the id as a structured property. The Azure Monitor exporter writes it to `customDimensions["CorrelationId"]` on every resulting `AppTrace` / `AppException` / `AppRequest`. KQL pattern:
+Every `ILogger` call made while handling the request inherits the id as a structured property. For that scoped id to reach `customDimensions["CorrelationId"]`, enable scope capture (scope values are not exported by default):
+
+```csharp
+builder.AddQuilt4NetLogging(o => o.IncludeScopes = true)
+    .AddHttpRequestLogging();
+```
+
+Then, on every resulting `AppTrace` / `AppException` / `AppRequest`:
 
 ```kql
 union AppTraces, AppExceptions, AppRequests
@@ -74,7 +82,27 @@ union AppTraces, AppExceptions, AppRequests
 | order by TimeGenerated asc
 ```
 
-A client that wants to chain calls just sends the same header to every server. Server code that wants to start a new chain can read `HttpContext.Items["CorrelationId"]` and forward it to outbound `HttpClient` calls.
+A client that wants to chain calls just sends the same header to every server. Server code that wants to start a new chain can read `HttpContext.Items["CorrelationId"]` and forward it to outbound `HttpClient` calls (see the Api README → `AddQuilt4NetCorrelationId`).
+
+## Exception data → customDimensions
+
+`EnrichExceptionData` (**on by default**) copies a logged exception's `Exception.Data` entries onto the exception telemetry, so an id attached to the exception is findable in AI:
+
+```csharp
+catch (Exception e)
+{
+    e.AddData("CorrelationId", correlationId);   // Quilt4Net.Toolkit.Features.Measure
+    logger.LogError(e, e.Message);
+}
+```
+
+```kql
+AppExceptions | where tostring(customDimensions.CorrelationId) == "<guid>"
+```
+
+Both enrichers run on the OpenTelemetry logging pipeline. Apps ingesting via the classic Application Insights SDK on AI 3.x must export logs through `Azure.Monitor.OpenTelemetry` to benefit — AI 3.x does not ingest `ILogger` telemetry through the classic pipeline.
+
+> This cross-hop `CorrelationId` is distinct from the user-facing 6-character `IncidentId` rendered in Log-view error messages.
 
 ## Demo endpoint
 


### PR DESCRIPTION
Closes #123.

## What this does

Makes a correlation id (and any `Exception.Data` entry) reach Application Insights `customDimensions` via the OpenTelemetry pipeline, so an id shown to a user is findable in telemetry.

### `AddQuilt4NetLogging` options
- **`EnrichExceptionData`** (default **on**) — `ExceptionDataLogProcessor` copies a logged exception's `Exception.Data` entries onto the exception log record. An id attached with `e.AddData("CorrelationId", guid)` becomes queryable:
  ```kql
  AppExceptions | where tostring(customDimensions.CorrelationId) == "<guid>"
  ```
- **`IncludeScopes`** (default **off**, opt-in) — `ScopeAttributesLogProcessor` copies `ILogger` scope values onto every record. This is what carries the `CorrelationId` scope pushed by `CorrelationIdMiddleware` into `customDimensions`.

### Correctness fix
`CorrelationIdMiddleware` and the docs previously claimed the scoped correlation id "is written to `customDimensions`" — but scope capture is required and was off. Corrected the middleware comment, both READMEs, and the DocFX `telemetry-identity` article to state the `IncludeScopes` requirement.

## Design notes
- **OpenTelemetry-only.** The classic AI `ITelemetryInitializer` surface was dropped: the base package references `Microsoft.ApplicationInsights` 3.1.2, which removed `ITelemetryInitializer`, and AI 3.x does not ingest `ILogger` telemetry through the classic pipeline (`NullLoggerProvider`). This matches the deliberate 0.7.0 OTel port. Consumers on classic AI 3.x must export logs via `Azure.Monitor.OpenTelemetry` to benefit.
- This cross-hop `CorrelationId` is distinct from the user-facing `IncidentId` (Log-view error messages).

## Scope / follow-up
The HTTP correlation path is complete end-to-end (middleware scopes per request + `CorrelationIdHandler` propagates outbound). Non-HTTP/Blazor ambient correlation (AsyncLocal + Blazor `CircuitHandler`) is a distinct mechanism and is captured as a separate follow-up.

## Tests
14 new tests in `ExceptionDataEnrichmentTests`; full Toolkit suite green (413).
