### PR TITLE
docs: host & runtime metrics guidance (closes #115)

### DIFF
--- a/Quilt4Net.Toolkit/README.md
+++ b/Quilt4Net.Toolkit/README.md
@@ -424,6 +424,10 @@ builder.Services.AddApplicationInsightsTelemetry(o => { o.ConnectionString = "..
 // 3. Then any custom ILoggerFactory wrapping.
 ```
 
+### Host and runtime metrics
+
+`AddQuilt4NetLogging()` covers telemetry identity, logs, and traces — it does **not** emit host or process **metrics**. Host metrics (CPU, memory, disk space, network) belong to an OpenTelemetry Collector; .NET runtime/process metrics are available via standard OpenTelemetry instrumentation you can wire up yourself. See the docs article [Host and runtime metrics](../docs/articles/telemetry-identity.md#host-and-runtime-metrics) for how.
+
 ## Measure extensions
 
 Extension methods on `ILogger` to measure and log execution time.

--- a/docs/articles/telemetry-identity.md
+++ b/docs/articles/telemetry-identity.md
@@ -114,6 +114,25 @@ curl -i -H "X-Correlation-ID: my-test-1" https://localhost:7187/api/correlation-
 
 → three `AppTrace` rows in AI, all sharing `customDimensions["CorrelationId"] == "my-test-1"`.
 
+## Host and runtime metrics
+
+`AddQuilt4NetLogging()` sets up telemetry **identity, logs, and traces** — it deliberately does **not** emit host or process **metrics**. Two reasons:
+
+- **Host metrics** (CPU, memory, disk space, disk/network I/O, load average) belong to an **OpenTelemetry Collector** (`hostmetrics` receiver) or your platform's node monitoring — not an application library. An app reporting node-level disk space is both duplicative and misleading on a multi-tenant host.
+- **.NET runtime / process metrics** are already provided by **standard OpenTelemetry instrumentation** — no custom code in the toolkit is needed.
+
+If you want your app's runtime/process metrics in Application Insights, add the standard instrumentation to the metrics pipeline yourself:
+
+```csharp
+builder.Services.AddOpenTelemetry().WithMetrics(m => m
+    .AddRuntimeInstrumentation()      // GC, heap, thread-pool, JIT  (OpenTelemetry.Instrumentation.Runtime)
+    .AddProcessInstrumentation());    // process CPU + memory        (OpenTelemetry.Instrumentation.Process)
+```
+
+These land in the `AppMetrics` table (`customMetrics`). This **requires** exporting metrics via `Azure.Monitor.OpenTelemetry` — the classic Application Insights SDK on AI 3.x does not ingest them.
+
+For **host-level** metrics, run the OpenTelemetry Collector (`hostmetrics` + `kubeletstats`) into the same workspace. Its `system.*` metrics and the toolkit's identity attributes coexist in AI under the standard OpenTelemetry names, so a single query spans both.
+
 ## Where next
 
 - **[Log views](log-views.md)** — render and query the resulting telemetry.


### PR DESCRIPTION
Closes #115.

## Decision

After digging into the existing metrics subsystem, we decided **not** to add host/runtime metric collection to the toolkit, and to document the recommended approach instead.

Rationale:
- **Host metrics** (CPU, memory, disk space, disk/network I/O, load) are an **OpenTelemetry Collector** concern (`hostmetrics` / `kubeletstats`), not an application library's. An app reporting node-level disk space is duplicative and misleading on a multi-tenant host.
- **.NET runtime / process metrics** are already available via **standard OpenTelemetry instrumentation** (`OpenTelemetry.Instrumentation.Runtime` / `.Process`) — a consumer wires them into the OTel pipeline `AddQuilt4NetLogging()` already sets up, no toolkit code required.

The toolkit's existing `IMetricsService` (CPU/memory/disk snapshot) remains a pull-only health endpoint; it is intentionally not promoted to OTel metrics emission.

## Change

Docs only:
- `docs/articles/telemetry-identity.md` — new "Host and runtime metrics" section explaining the stance and showing the `AddRuntimeInstrumentation()` / `AddProcessInstrumentation()` wiring, the `AppMetrics` landing spot, and the `Azure.Monitor.OpenTelemetry` export requirement.
- `Quilt4Net.Toolkit/README.md` — short pointer to that section.
