### PR TITLE
fix: scope Log Summary by application (counts + drill-down) (#126)

### DIFF
--- a/Quilt4Net.Toolkit.Blazor.Tests/LogEnvironmentSelectorIncidentTests.cs
+++ b/Quilt4Net.Toolkit.Blazor.Tests/LogEnvironmentSelectorIncidentTests.cs
@@ -44,7 +44,7 @@ public class LogEnvironmentSelectorIncidentTests : BunitContext
         public IAsyncEnumerable<MeasureData> GetMeasureAsync(IApplicationInsightsContext context, string environment, TimeSpan timeSpan, CancellationToken cancellationToken = default) => Throw<MeasureData>();
         public IAsyncEnumerable<CountData> GetCountAsync(IApplicationInsightsContext context, string environment, TimeSpan timeSpan, CancellationToken cancellationToken = default) => Throw<CountData>();
         public Task<LogDetails> GetDetail(IApplicationInsightsContext context, string id, LogSource source, string environment, TimeSpan timeSpan) => Task.FromException<LogDetails>(_ex);
-        public Task<SummaryData> GetSummary(IApplicationInsightsContext context, string fingerprint, LogSource source, string environment, TimeSpan timeSpan, int maxItems = 100) => Task.FromException<SummaryData>(_ex);
+        public Task<SummaryData> GetSummary(IApplicationInsightsContext context, string fingerprint, LogSource source, string environment, TimeSpan timeSpan, int maxItems = 100, string application = null) => Task.FromException<SummaryData>(_ex);
         public IAsyncEnumerable<SummarySubset> GetSummaries(IApplicationInsightsContext context, string environment, TimeSpan timeSpan, CancellationToken cancellationToken = default) => Throw<SummarySubset>();
         public IAsyncEnumerable<VersionMatrixCell> GetVersionMatrixAsync(IApplicationInsightsContext context, TimeSpan? lookback = null, bool forceRefresh = false) => Throw<VersionMatrixCell>();
         public IAsyncEnumerable<LogItem> SearchByIncidentIdAsync(IApplicationInsightsContext context, string incidentId, TimeSpan timeSpan) => Throw<LogItem>();

--- a/Quilt4Net.Toolkit.Blazor.Tests/LogNavParamsTests.cs
+++ b/Quilt4Net.Toolkit.Blazor.Tests/LogNavParamsTests.cs
@@ -148,4 +148,16 @@ public class LogNavParamsTests
         // Assert
         decoded.Environment.Should().Be(original.Environment);
     }
+
+    [Fact]
+    public void Application_RoundTrips_Through_From_And_Encode_Decode()
+    {
+        // #126: the selected application must survive the navigation round-trip so the summary
+        // route scopes the drill-down to the same application the row represented.
+        var p = LogNavParams.From("Production", TimeSpan.FromDays(1), LogSource.Trace, null, "Detail", application: "Eplicta.Aggregator");
+        p.Application.Should().Be("Eplicta.Aggregator");
+
+        var decoded = LogNavParams.Decode(p.Encode());
+        decoded.Application.Should().Be("Eplicta.Aggregator");
+    }
 }

--- a/Quilt4Net.Toolkit.Blazor.Tests/LogSummaryContentApplicationScopeTests.cs
+++ b/Quilt4Net.Toolkit.Blazor.Tests/LogSummaryContentApplicationScopeTests.cs
@@ -1,0 +1,53 @@
+using System;
+using Bunit;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using Quilt4Net.Toolkit.Blazor.Features.Log;
+using Quilt4Net.Toolkit.Features.ApplicationInsights;
+using Xunit;
+
+namespace Quilt4Net.Toolkit.Blazor.Tests;
+
+/// <summary>
+/// #126: expanding a summary row must scope the instance list to the row's application. This pins
+/// the wiring — <see cref="LogSummaryContent"/> forwards its <c>Application</c> parameter to
+/// <c>IApplicationInsightsService.GetSummary</c> (which applies the KQL application filter).
+/// </summary>
+public class LogSummaryContentApplicationScopeTests : BunitContext
+{
+    [Fact]
+    public void Drilldown_forwards_selected_application_to_GetSummary()
+    {
+        string capturedApplication = "NOT-CALLED";
+        var mock = new Mock<IApplicationInsightsService>();
+        mock.Setup(x => x.GetSummary(
+                It.IsAny<IApplicationInsightsContext>(), It.IsAny<string>(), It.IsAny<LogSource>(),
+                It.IsAny<string>(), It.IsAny<TimeSpan>(), It.IsAny<int>(), It.IsAny<string>()))
+            .Callback((IApplicationInsightsContext _, string _, LogSource _, string _, TimeSpan _, int _, string application) => capturedApplication = application)
+            .ReturnsAsync(SampleSummary());
+
+        Services.AddSingleton(mock.Object);
+
+        Render<LogSummaryContent>(p => p
+            .Add(c => c.Fingerprint, "fp-123")
+            .Add(c => c.Environment, "Production")
+            .Add(c => c.Application, "Eplicta.Aggregator")
+            .Add(c => c.Range, (TimeSpan?)TimeSpan.FromDays(1))
+            .Add(c => c.Source, (LogSource?)LogSource.Trace));
+
+        capturedApplication.Should().Be("Eplicta.Aggregator");
+    }
+
+    private static SummaryData SampleSummary() => new()
+    {
+        Fingerprint = "fp-123",
+        Message = "boom",
+        Environment = "Production",
+        Application = "Eplicta.Aggregator",
+        SeverityLevel = SeverityLevel.Error,
+        Source = LogSource.Trace,
+        Items = [],
+        TotalCount = 0
+    };
+}

--- a/Quilt4Net.Toolkit.Blazor.Tests/LogViewConfigTests.cs
+++ b/Quilt4Net.Toolkit.Blazor.Tests/LogViewConfigTests.cs
@@ -63,7 +63,7 @@ public class LogViewConfigTests : BunitContext
         public IAsyncEnumerable<MeasureData> GetMeasureAsync(IApplicationInsightsContext context, string environment, TimeSpan timeSpan, CancellationToken cancellationToken = default) => Empty<MeasureData>();
         public IAsyncEnumerable<CountData> GetCountAsync(IApplicationInsightsContext context, string environment, TimeSpan timeSpan, CancellationToken cancellationToken = default) => Empty<CountData>();
         public Task<LogDetails> GetDetail(IApplicationInsightsContext context, string id, LogSource source, string environment, TimeSpan timeSpan) => Task.FromResult<LogDetails>(null);
-        public Task<SummaryData> GetSummary(IApplicationInsightsContext context, string fingerprint, LogSource source, string environment, TimeSpan timeSpan, int maxItems = 100) => Task.FromResult<SummaryData>(null);
+        public Task<SummaryData> GetSummary(IApplicationInsightsContext context, string fingerprint, LogSource source, string environment, TimeSpan timeSpan, int maxItems = 100, string application = null) => Task.FromResult<SummaryData>(null);
         public IAsyncEnumerable<SummarySubset> GetSummaries(IApplicationInsightsContext context, string environment, TimeSpan timeSpan, CancellationToken cancellationToken = default) => Empty<SummarySubset>();
         public IAsyncEnumerable<VersionMatrixCell> GetVersionMatrixAsync(IApplicationInsightsContext context, TimeSpan? lookback = null, bool forceRefresh = false) => Empty<VersionMatrixCell>();
         public IAsyncEnumerable<LogItem> SearchByIncidentIdAsync(IApplicationInsightsContext context, string incidentId, TimeSpan timeSpan) => Empty<LogItem>();

--- a/Quilt4Net.Toolkit.Blazor.Tests/MetricsViewClusterTests.cs
+++ b/Quilt4Net.Toolkit.Blazor.Tests/MetricsViewClusterTests.cs
@@ -119,7 +119,7 @@ public class MetricsViewClusterTests : BunitContext
         public IAsyncEnumerable<MeasureData> GetMeasureAsync(IApplicationInsightsContext context, string environment, TimeSpan timeSpan, CancellationToken cancellationToken = default) => Empty<MeasureData>();
         public IAsyncEnumerable<CountData> GetCountAsync(IApplicationInsightsContext context, string environment, TimeSpan timeSpan, CancellationToken cancellationToken = default) => Empty<CountData>();
         public Task<LogDetails> GetDetail(IApplicationInsightsContext context, string id, LogSource source, string environment, TimeSpan timeSpan) => Task.FromResult<LogDetails>(null);
-        public Task<SummaryData> GetSummary(IApplicationInsightsContext context, string fingerprint, LogSource source, string environment, TimeSpan timeSpan, int maxItems = 100) => Task.FromResult<SummaryData>(null);
+        public Task<SummaryData> GetSummary(IApplicationInsightsContext context, string fingerprint, LogSource source, string environment, TimeSpan timeSpan, int maxItems = 100, string application = null) => Task.FromResult<SummaryData>(null);
         public IAsyncEnumerable<SummarySubset> GetSummaries(IApplicationInsightsContext context, string environment, TimeSpan timeSpan, CancellationToken cancellationToken = default) => Empty<SummarySubset>();
         public IAsyncEnumerable<VersionMatrixCell> GetVersionMatrixAsync(IApplicationInsightsContext context, TimeSpan? lookback = null, bool forceRefresh = false) => Empty<VersionMatrixCell>();
         public IAsyncEnumerable<LogItem> SearchByIncidentIdAsync(IApplicationInsightsContext context, string incidentId, TimeSpan timeSpan) => Empty<LogItem>();

--- a/Quilt4Net.Toolkit.Blazor.Tests/Quilt4Net.Toolkit.Blazor.Tests.csproj
+++ b/Quilt4Net.Toolkit.Blazor.Tests/Quilt4Net.Toolkit.Blazor.Tests.csproj
@@ -14,6 +14,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
+    <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Quilt4Net.Toolkit.Blazor/Features/Log/LogNavParams.cs
+++ b/Quilt4Net.Toolkit.Blazor/Features/Log/LogNavParams.cs
@@ -16,6 +16,7 @@ public record LogNavParams
     public string Context { get; init; }
     public string Reference { get; init; }
     public string Fingerprint { get; init; }
+    public string Application { get; init; }
 
     /// <summary>
     /// Encodes this instance to a URL-safe base64 string.
@@ -54,7 +55,7 @@ public record LogNavParams
     /// <summary>
     /// Creates a <see cref="LogNavParams"/> from the individual parameters used throughout the log components.
     /// </summary>
-    public static LogNavParams From(string environment, TimeSpan range, LogSource? source, IApplicationInsightsContext context, string reference, string fingerprint = null)
+    public static LogNavParams From(string environment, TimeSpan range, LogSource? source, IApplicationInsightsContext context, string reference, string fingerprint = null, string application = null)
     {
         return new LogNavParams
         {
@@ -63,7 +64,8 @@ public record LogNavParams
             Source = source?.ToString(),
             Context = context?.ToKey(),
             Reference = reference,
-            Fingerprint = fingerprint
+            Fingerprint = fingerprint,
+            Application = application
         };
     }
 

--- a/Quilt4Net.Toolkit.Blazor/Features/Log/LogSummaryContent.razor
+++ b/Quilt4Net.Toolkit.Blazor/Features/Log/LogSummaryContent.razor
@@ -96,6 +96,9 @@ else
     public string Environment { get; set; }
 
     [Parameter]
+    public string Application { get; set; }
+
+    [Parameter]
     public TimeSpan? Range { get; set; }
 
     [Parameter]
@@ -117,7 +120,7 @@ else
 
         if (!Source.HasValue || !Range.HasValue) return;
 
-        Model = await _ais.GetSummary(Context, Fingerprint, Source.Value, Environment, Range.Value);
+        Model = await _ais.GetSummary(Context, Fingerprint, Source.Value, Environment, Range.Value, application: Application);
 
         await base.OnParametersSetAsync();
     }

--- a/Quilt4Net.Toolkit.Blazor/Features/Log/LogSummaryListView.razor
+++ b/Quilt4Net.Toolkit.Blazor/Features/Log/LogSummaryListView.razor
@@ -24,7 +24,7 @@ else
             <RadzenDataGridColumn Title="Fingerprint" Width="60px" Sortable="false">
                 <Template>
                     <RadzenButton Icon="arrow_forward_ios" ButtonStyle="ButtonStyle.Light" Size="ButtonSize.Small"
-                                  Click="@(() => OpenSummaryAsync(context.Fingerprint, context.Source))" />
+                                  Click="@(() => OpenSummaryAsync(context.Fingerprint, context.Source, context.Application))" />
                 </Template>
             </RadzenDataGridColumn>
             <RadzenDataGridColumn Title="Last Time" Property="@nameof(SummarySubset.LastTimeGenerated)">
@@ -185,9 +185,9 @@ else
         return _aliasMap is { Count: > 0 } map ? map.GetValueOrDefault(raw, raw) : raw;
     }
 
-    private async Task OpenSummaryAsync(string fingerprint, LogSource source)
+    private async Task OpenSummaryAsync(string fingerprint, LogSource source, string application)
     {
-        var p = LogNavParams.From(Environment, Range, source, Context, "Detail");
+        var p = LogNavParams.From(Environment, Range, source, Context, "Detail", application: application);
         if (NavOptions?.SummaryPath != null)
         {
             NavigationManager.NavigateTo($"{NavOptions.SummaryPath}/{fingerprint}?p={p.Encode()}");
@@ -198,6 +198,7 @@ else
             {
                 { nameof(LogSummaryContent.Fingerprint), fingerprint },
                 { nameof(LogSummaryContent.Environment), Environment },
+                { nameof(LogSummaryContent.Application), application },
                 { nameof(LogSummaryContent.Range), (TimeSpan?)Range },
                 { nameof(LogSummaryContent.Source), (LogSource?)source },
                 { nameof(LogSummaryContent.Context), Context }

--- a/Quilt4Net.Toolkit.Blazor/Features/Log/LogSummaryView.razor
+++ b/Quilt4Net.Toolkit.Blazor/Features/Log/LogSummaryView.razor
@@ -11,6 +11,7 @@
             <CascadingValue Name="SourcePathRoots" Value="@SourcePathRoots">
                 <LogSummaryContent Fingerprint="@Fingerprint"
                                    Environment="@_params.Environment"
+                                   Application="@_params.Application"
                                    Range="@_params.GetRange()"
                                    Source="@_params.GetSource()"
                                    Context="@_params.GetContext()" />

--- a/Quilt4Net.Toolkit.Tests/SummarizeByFingerprintTests.cs
+++ b/Quilt4Net.Toolkit.Tests/SummarizeByFingerprintTests.cs
@@ -5,30 +5,38 @@ using Xunit;
 namespace Quilt4Net.Toolkit.Tests;
 
 /// <summary>
-/// The summary list KQL used to bucket by (Fingerprint, Message, Environment, Application, SeverityLevel),
-/// which on busy workspaces produced a row per (fingerprint × message variant) and could blow past
-/// Kusto's 64MB result-set limit. This file pins the new shape so a future edit can't regress to the
-/// over-keyed grouping.
+/// The summary list KQL buckets by <c>(Fingerprint, Application)</c> so each application that
+/// produced a fingerprint gets its own application-scoped row (matching the drill-down). Two things
+/// are pinned here: <c>Application</c> IS part of the key (issue #126 — otherwise counts and the
+/// instance list span every application), and <c>Message</c> is NOT (it varies per formatted trace
+/// line and blew past Kusto's 64MB result-set limit when it was in the key).
 /// </summary>
 public class SummarizeByFingerprintTests
 {
     [Fact]
-    public void Buckets_by_fingerprint_only()
+    public void Buckets_by_fingerprint_and_application()
     {
         ApplicationInsightsService.SummarizeByFingerprint
-            .Should().Contain("by Fingerprint")
-            .And.NotContain("by Fingerprint, Message")
-            .And.NotContain("by Fingerprint, Environment")
-            .And.NotContain("by Fingerprint, Application");
+            .Should().Contain("by Fingerprint, Application")
+            .And.NotContain("by Fingerprint, Message");
     }
 
     [Fact]
-    public void Takes_a_representative_sample_for_descriptive_columns()
+    public void Keeps_message_out_of_the_key_to_avoid_the_64mb_blowup()
     {
+        // Message must remain a representative sample, never a grouping key.
         ApplicationInsightsService.SummarizeByFingerprint
-            .Should().Contain("Message = take_any(Message)")
-            .And.Contain("Environment = take_any(Environment)")
-            .And.Contain("Application = take_any(Application)");
+            .Should().Contain("Message = take_any(Message)");
+    }
+
+    [Fact]
+    public void Takes_a_representative_sample_for_non_key_descriptive_columns()
+    {
+        // Environment stays a sample (already filtered upstream); Application is now a key, so it is
+        // no longer aggregated via take_any.
+        ApplicationInsightsService.SummarizeByFingerprint
+            .Should().Contain("Environment = take_any(Environment)")
+            .And.NotContain("Application = take_any(Application)");
     }
 
     [Fact]
@@ -47,7 +55,7 @@ public class SummarizeByFingerprintTests
     }
 
     [Fact]
-    public void Orders_results_so_the_C_sharp_layer_dedupe_keeps_the_most_recent()
+    public void Orders_results_most_recent_first()
     {
         ApplicationInsightsService.SummarizeByFingerprint
             .Should().Contain("order by LastTimeGenerated desc");

--- a/Quilt4Net.Toolkit/ApplicationInsightsRegistration.cs
+++ b/Quilt4Net.Toolkit/ApplicationInsightsRegistration.cs
@@ -55,9 +55,8 @@ public static class ApplicationInsightsRegistration
             {
                 x.DefaultFreshSpan = TimeSpan.FromSeconds(30);
             });
-            // Aggregation queries (measure, count, summary-list, single-fingerprint drilldown)
-            // — 1 minute is a reasonable fresh-reload cadence that still avoids re-running the
-            // same KQL on every page navigation.
+            // Aggregation queries (measure, count) — 1 minute is a reasonable fresh-reload cadence
+            // that still avoids re-running the same KQL on every page navigation.
             s.RegisterType<MeasureData[], IMemory>(x =>
             {
                 x.DefaultFreshSpan = TimeSpan.FromMinutes(1);
@@ -66,13 +65,16 @@ public static class ApplicationInsightsRegistration
             {
                 x.DefaultFreshSpan = TimeSpan.FromMinutes(1);
             });
+            // Summary list + single-fingerprint drilldown — 5 minutes: the underlying data changes
+            // slowly relative to how often operators navigate in/out of a summary, so a longer span
+            // cuts repeated KQL without feeling stale.
             s.RegisterType<SummaryData, IMemory>(x =>
             {
-                x.DefaultFreshSpan = TimeSpan.FromMinutes(1);
+                x.DefaultFreshSpan = TimeSpan.FromMinutes(5);
             });
             s.RegisterType<SummarySubset[], IMemory>(x =>
             {
-                x.DefaultFreshSpan = TimeSpan.FromMinutes(1);
+                x.DefaultFreshSpan = TimeSpan.FromMinutes(5);
             });
             // Version matrix scans for the latest version per (app, env). Versions change rarely
             // (one deploy per environment per day at most) and the underlying KQL is expensive;
@@ -178,8 +180,8 @@ public static class ApplicationInsightsRegistration
             s.RegisterType<LogItem[], IMemory>(x => { x.DefaultFreshSpan = TimeSpan.FromSeconds(30); });
             s.RegisterType<MeasureData[], IMemory>(x => { x.DefaultFreshSpan = TimeSpan.FromMinutes(1); });
             s.RegisterType<CountData[], IMemory>(x => { x.DefaultFreshSpan = TimeSpan.FromMinutes(1); });
-            s.RegisterType<SummaryData, IMemory>(x => { x.DefaultFreshSpan = TimeSpan.FromMinutes(1); });
-            s.RegisterType<SummarySubset[], IMemory>(x => { x.DefaultFreshSpan = TimeSpan.FromMinutes(1); });
+            s.RegisterType<SummaryData, IMemory>(x => { x.DefaultFreshSpan = TimeSpan.FromMinutes(5); });
+            s.RegisterType<SummarySubset[], IMemory>(x => { x.DefaultFreshSpan = TimeSpan.FromMinutes(5); });
             s.RegisterType<VersionMatrixCell[], IMemory>(x => { x.DefaultFreshSpan = TimeSpan.FromHours(1); });
             s.RegisterType<MetricSample[], IMemory>(x => { x.DefaultFreshSpan = TimeSpan.FromMinutes(10); });
             s.RegisterType<DiskCapacity[], IMemory>(x => { x.DefaultFreshSpan = TimeSpan.FromMinutes(10); });

--- a/Quilt4Net.Toolkit/Features/ApplicationInsights/ApplicationInsightsService.cs
+++ b/Quilt4Net.Toolkit/Features/ApplicationInsights/ApplicationInsightsService.cs
@@ -32,23 +32,22 @@ internal class ApplicationInsightsService : IApplicationInsightsService
 
     /// <summary>
     /// Canonical summarize clause for the <c>GetSummaries</c> queries. Buckets by
-    /// <c>Fingerprint</c> only and takes representative samples for the descriptive columns,
-    /// matching the post-fetch C# dedupe (one row per fingerprint, last-seen wins).
+    /// <c>(Fingerprint, Application)</c> so each application that produced a fingerprint gets its own
+    /// row with an application-scoped <c>Count</c>. The drill-down (<c>GetSummary</c>) is scoped the
+    /// same way, so the instance list matches the row's count instead of spanning every application.
     ///
-    /// Previously the summarize key was <c>(Fingerprint, Message, Environment, Application, SeverityLevel)</c>,
-    /// which split a single fingerprint into N rows whenever the message text varied (always, for
-    /// formatted trace logs) and could exceed Kusto's 64MB result-set limit. Aligning the server-side
-    /// grouping with what the UI actually shows shrinks the result set by orders of magnitude and
-    /// matches what <c>GetSummaries</c>'s C# layer was already enforcing post-fetch.
+    /// <c>Message</c> is intentionally kept OUT of the key: it varies per formatted trace line, so
+    /// including it split one fingerprint into N rows and could exceed Kusto's 64MB result-set limit.
+    /// <c>Application</c> is low-cardinality, so grouping by it is safe. <c>Environment</c> is already
+    /// filtered upstream to the selected value, so it stays a representative sample.
     /// </summary>
     internal const string SummarizeByFingerprint = @"| summarize
     Count = count(),
     LastTimeGenerated = max(TimeGenerated),
     Message = take_any(Message),
     Environment = take_any(Environment),
-    Application = take_any(Application),
     SeverityLevel = max(SeverityLevel)
-    by Fingerprint
+    by Fingerprint, Application
 | order by LastTimeGenerated desc";
 
     private static readonly LogsQueryOptions _probeOptions = new() { ServerTimeout = TimeSpan.FromSeconds(5) };
@@ -1051,18 +1050,28 @@ AppRequests
         };
     }
 
-    public async Task<SummaryData> GetSummary(IApplicationInsightsContext context, string fingerprint, LogSource source, string environment, TimeSpan timeSpan, int maxItems = 100)
+    public async Task<SummaryData> GetSummary(IApplicationInsightsContext context, string fingerprint, LogSource source, string environment, TimeSpan timeSpan, int maxItems = 100, string application = null)
     {
         if (maxItems <= 0) throw new ArgumentOutOfRangeException(nameof(maxItems), "maxItems must be positive.");
 
-        var cacheKey = $"summary|{context.ToKey()}|{fingerprint}|{source}|{environment}|{timeSpan}|{maxItems}";
-        return await _timeToLiveCache.GetAsync(cacheKey, () => GetSummaryInternalAsync(context, fingerprint, source, environment, timeSpan, maxItems));
+        var cacheKey = $"summary|{context.ToKey()}|{fingerprint}|{source}|{environment}|{application}|{timeSpan}|{maxItems}";
+        return await _timeToLiveCache.GetAsync(cacheKey, () => GetSummaryInternalAsync(context, fingerprint, source, environment, timeSpan, maxItems, application));
     }
 
-    private async Task<SummaryData> GetSummaryInternalAsync(IApplicationInsightsContext context, string fingerprint, LogSource source, string environment, TimeSpan timeSpan, int maxItems)
+    private async Task<SummaryData> GetSummaryInternalAsync(IApplicationInsightsContext context, string fingerprint, LogSource source, string environment, TimeSpan timeSpan, int maxItems, string application)
     {
         var client = GetClient(context);
         var workspaceId = context?.WorkspaceId ?? _options.WorkspaceId;
+
+        // Scope the drill-down to the same (environment, application) the summary row was grouped by,
+        // so the instance list matches the row's count instead of spanning every app/environment that
+        // shares the fingerprint. Both optional: null/empty means "no filter".
+        static string EscapeKql(string v) => v.Replace("'", "''").Replace("\r", " ").Replace("\n", " ");
+        var scopeFilter = string.Empty;
+        if (!string.IsNullOrWhiteSpace(environment))
+            scopeFilter += $"\n| where isempty(Environment) or Environment =~ '{EscapeKql(environment.Trim())}'";
+        if (!string.IsNullOrWhiteSpace(application))
+            scopeFilter += $"\n| where Application =~ '{EscapeKql(application.Trim())}'";
 
         // Each branch builds a `_matched` set, computes _total = count() before take, then projects
         // the top maxItems with TotalCount attached as a column on every row. This lets the UI
@@ -1078,7 +1087,7 @@ let _matched = AppExceptions
     Environment = {EnvironmentProjection},
     Application = coalesce(tostring(_p[""ApplicationName""]), tostring(AppRoleName)),
     Id = _ItemId
-| where Fingerprint == ""{fingerprint}""
+| where Fingerprint == ""{fingerprint}""{scopeFilter}
 | project Id, TimeGenerated, Message, Environment, Application, SeverityLevel;
 let _total = toscalar(_matched | count);
 _matched
@@ -1099,7 +1108,7 @@ let _matched = AppTraces
     FingerprintSource = iif(isempty(OriginalFormat), tostring(Message), OriginalFormat)
 | extend
     Fingerprint = base64_encode_tostring(tostring(hash(FingerprintSource)))
-| where Fingerprint == ""{fingerprint}""
+| where Fingerprint == ""{fingerprint}""{scopeFilter}
 | project Id, TimeGenerated, Message, Environment, Application, SeverityLevel;
 let _total = toscalar(_matched | count);
 _matched
@@ -1117,7 +1126,7 @@ let _matched = AppRequests
     Application = coalesce(tostring(_p[""ApplicationName""]), tostring(AppRoleName)),
     SeverityLevel = iif(tobool(Success), 1, 3),
     Id = _ItemId
-| where Fingerprint == ""{fingerprint}""
+| where Fingerprint == ""{fingerprint}""{scopeFilter}
 | project Id, TimeGenerated, Message, Environment, Application, SeverityLevel;
 let _total = toscalar(_matched | count);
 _matched

--- a/Quilt4Net.Toolkit/Features/ApplicationInsights/IApplicationInsightsService.cs
+++ b/Quilt4Net.Toolkit/Features/ApplicationInsights/IApplicationInsightsService.cs
@@ -42,8 +42,10 @@ public interface IApplicationInsightsService
     /// (default 100) — a fingerprint can match 100k+ rows over the lookback window, and
     /// returning all of them is what made detail/summary navigation hang. Items are ordered
     /// newest-first; only the top <paramref name="maxItems"/> are returned.
+    /// <paramref name="application"/> scopes the instances to a single application (matching the
+    /// summary row); null/empty means no application filter.
     /// </summary>
-    Task<SummaryData> GetSummary(IApplicationInsightsContext context, string fingerprint, LogSource source, string environment, TimeSpan timeSpan, int maxItems = 100);
+    Task<SummaryData> GetSummary(IApplicationInsightsContext context, string fingerprint, LogSource source, string environment, TimeSpan timeSpan, int maxItems = 100, string application = null);
     IAsyncEnumerable<SummarySubset> GetSummaries(IApplicationInsightsContext context, string environment, TimeSpan timeSpan, CancellationToken cancellationToken = default);
 
     /// <summary>


### PR DESCRIPTION
Fixes #126.

## Problem
The Log Summary view ignored the selected application. Both the summary counts and the drill-down instance list were scoped by **fingerprint alone**, so a fingerprint produced by multiple apps collapsed into one cross-application row and the drill-down listed other applications' records (and other environments'). See the corrected root-cause analysis in #126.

## Fix
- **Query grouping:** `SummarizeByFingerprint` now buckets `by Fingerprint, Application` (was `by Fingerprint` with `Application = take_any`). `Application` is low-cardinality, so this restores per-application rows/counts without reintroducing the `Message`-cardinality 64 MB blow-up that motivated the original change.
- **Drill-down:** `GetSummary` gained an `application` parameter and now filters `_matched` by **`Environment` + `Application`** in all three source branches (Exception/Trace/Request); the `environment` argument was previously passed but unused. Cache key updated to include `application`.
- **Blazor:** `LogSummaryContent` gained an `Application` parameter and forwards it to `GetSummary`; `LogSummaryListView` passes the row's application on expand (both the Radzen dialog and the navigation paths); `LogNavParams` now carries `Application`; `LogSummaryView` passes it through.
- **Cache:** raised the summary fresh-span from **1 → 5 minutes** (`SummaryData` + `SummarySubset[]`) in both the direct and remote registrations — the data changes slowly relative to navigation, so a longer span cuts repeated KQL.

## Result
A fingerprint seen in two applications renders as two rows, each with an application-scoped count; expanding a row lists only that application's (and environment's) instances.

## Tests
`SummarizeByFingerprintTests` updated to pin the new key; `LogNavParams` application round-trip; a bUnit test asserting `LogSummaryContent` forwards its application to `GetSummary`. Full Toolkit suite green (416).

## Commits
1. `fix: scope Log Summary query layer by application …`
2. `fix: thread selected application through … drill-down (dialog + navigation)`
3. `test: cover application scoping …`
4. `perf: raise Log Summary cache fresh-span from 1 to 5 minutes`
