### PR TITLE
fix(content): log missing-key (404) fallback at Debug, not Error (#131)

### DIFF
--- a/Quilt4Net.Toolkit.Tests/ContentNotFoundLoggingTests.cs
+++ b/Quilt4Net.Toolkit.Tests/ContentNotFoundLoggingTests.cs
@@ -1,0 +1,148 @@
+using System.Net;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Quilt4Net.Toolkit.Features.Content;
+using Quilt4Net.Toolkit.Features.FeatureToggle;
+using Quilt4Net.Toolkit.Framework;
+using Xunit;
+
+namespace Quilt4Net.Toolkit.Tests;
+
+// Issue #131: RemoteContentCallService logged an Error for every missing-key fallback, flooding
+// logs/telemetry. A key with no override (404) is the designed "use the caller's Default" path and
+// must log at Debug; genuinely unexpected failures (5xx) must still log Error.
+public class ContentNotFoundLoggingTests
+{
+    [Fact]
+    public async Task Missing_Key_404_Is_Logged_At_Debug_Not_Error()
+    {
+        using var listener = StartListener(out var prefix, out var requestCount, HttpStatusCode.NotFound);
+        var recorder = new RecordingLoggerProvider();
+        var service = BuildContentService(prefix, recorder);
+
+        var (value, success) = await service.GetContentAsync("Missing.Key", "the-default", Guid.NewGuid(), ContentFormat.String, application: "App");
+
+        value.Should().Be("the-default", "a missing key must fall back to the caller's default");
+        success.Should().BeFalse("the value came from the default, not the server");
+
+        recorder.Entries.Should().NotContain(e => e.Level == LogLevel.Error,
+            "a missing key (404) is the designed fallback path and must not be logged at Error");
+        recorder.Entries.Should().Contain(e => e.Level == LogLevel.Debug && e.Message.Contains("Missing.Key"),
+            "the miss should still be traceable at Debug");
+    }
+
+    [Fact]
+    public async Task Missing_Key_404_Is_Negative_Cached_And_Not_Re_Requested()
+    {
+        using var listener = StartListener(out var prefix, out var requestCount, HttpStatusCode.NotFound);
+        var service = BuildContentService(prefix, new RecordingLoggerProvider());
+        var languageKey = Guid.NewGuid();
+
+        await service.GetContentAsync("Missing.Key", "the-default", languageKey, ContentFormat.String, application: "App");
+        await service.GetContentAsync("Missing.Key", "the-default", languageKey, ContentFormat.String, application: "App");
+
+        requestCount().Should().Be(1,
+            "the 404 must be negative-cached so the same missing key isn't re-requested (and re-logged) on every render");
+    }
+
+    [Fact]
+    public async Task Server_Error_500_Still_Logs_Error()
+    {
+        using var listener = StartListener(out var prefix, out var requestCount, HttpStatusCode.InternalServerError);
+        var recorder = new RecordingLoggerProvider();
+        var service = BuildContentService(prefix, recorder);
+
+        var (value, _) = await service.GetContentAsync("Broken.Key", "the-default", Guid.NewGuid(), ContentFormat.String, application: "App");
+
+        value.Should().Be("the-default");
+        recorder.Entries.Should().Contain(e => e.Level == LogLevel.Error && e.Message.Contains("Broken.Key"),
+            "an unexpected 5xx must remain an Error — only the expected 404 miss is demoted");
+    }
+
+    private static IContentService BuildContentService(string baseAddress, ILoggerProvider loggerProvider)
+    {
+        var host = Host.CreateDefaultBuilder()
+            .ConfigureServices(services =>
+            {
+                services.AddQuilt4NetContent(null, o =>
+                {
+                    o.Quilt4NetAddress = baseAddress;
+                    o.ApiKey = "test-key";
+                });
+                services.AddLogging(b =>
+                {
+                    b.ClearProviders();
+                    b.SetMinimumLevel(LogLevel.Debug);
+                    b.AddProvider(loggerProvider);
+                });
+            })
+            .Build();
+
+        return host.Services.GetRequiredService<IContentService>();
+    }
+
+    private static HttpListener StartListener(out string prefix, out Func<int> requestCount, HttpStatusCode status)
+    {
+        var port = GetFreePort();
+        prefix = $"http://127.0.0.1:{port}/";
+        var listener = new HttpListener();
+        listener.Prefixes.Add(prefix);
+        listener.Start();
+
+        var hits = 0;
+        requestCount = () => Volatile.Read(ref hits);
+
+        _ = Task.Run(async () =>
+        {
+            while (listener.IsListening)
+            {
+                HttpListenerContext ctx;
+                try { ctx = await listener.GetContextAsync(); }
+                catch { return; }
+
+                Interlocked.Increment(ref hits);
+                ctx.Response.StatusCode = (int)status;
+                ctx.Response.Close();
+            }
+        });
+
+        return listener;
+    }
+
+    private static int GetFreePort()
+    {
+        using var l = new System.Net.Sockets.TcpListener(IPAddress.Loopback, 0);
+        l.Start();
+        var port = ((IPEndPoint)l.LocalEndpoint).Port;
+        l.Stop();
+        return port;
+    }
+
+    private sealed class RecordingLoggerProvider : ILoggerProvider
+    {
+        public List<(LogLevel Level, string Message)> Entries { get; } = new();
+        public ILogger CreateLogger(string categoryName) => new RecordingLogger(Entries);
+        public void Dispose() { }
+
+        private sealed class RecordingLogger : ILogger
+        {
+            private readonly List<(LogLevel, string)> _entries;
+            public RecordingLogger(List<(LogLevel, string)> entries) => _entries = entries;
+            public IDisposable BeginScope<TState>(TState state) where TState : notnull => NullScope.Instance;
+            public bool IsEnabled(LogLevel logLevel) => true;
+            public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception,
+                Func<TState, Exception, string> formatter)
+            {
+                lock (_entries) _entries.Add((logLevel, formatter(state, exception)));
+            }
+        }
+
+        private sealed class NullScope : IDisposable
+        {
+            public static readonly NullScope Instance = new();
+            public void Dispose() { }
+        }
+    }
+}

--- a/Quilt4Net.Toolkit/Features/Content/RemoteContentCallService.cs
+++ b/Quilt4Net.Toolkit/Features/Content/RemoteContentCallService.cs
@@ -255,8 +255,19 @@ internal class RemoteContentCallService : IRemoteContentCallService
 
             if (!response.IsSuccessStatusCode)
             {
-                _logger.LogError("Unable to get content for key '{Key}'. Response was {StatusCode} {ReasonPhrase}.",
-                    key, response.StatusCode, response.ReasonPhrase);
+                if (response.StatusCode == HttpStatusCode.NotFound)
+                {
+                    // A key with no override on the server is the designed fallback path — the caller's
+                    // Default is used. Expected and non-fatal, so log at Debug (not Error) to avoid
+                    // flooding logs/telemetry with a line per unseeded key on every render.
+                    _logger.LogDebug("No content override for key '{Key}' (404). Using default value.", key);
+                }
+                else
+                {
+                    _logger.LogError("Unable to get content for key '{Key}'. Response was {StatusCode} {ReasonPhrase}.",
+                        key, response.StatusCode, response.ReasonPhrase);
+                }
+                // Negative-cache either way so the key isn't re-requested (and re-logged) every render.
                 CacheFailure(cacheKey, defaultValue);
                 _logger.LogDebug("Content '{Key}' resolved in {Elapsed}ms. Source: Default, Stale: true.",
                     key, sw.ElapsedMilliseconds);
@@ -321,8 +332,16 @@ internal class RemoteContentCallService : IRemoteContentCallService
 
                 if (!response.IsSuccessStatusCode)
                 {
-                    _logger.LogError("Background refresh for content '{Key}' failed. Response was {StatusCode} {ReasonPhrase}.",
-                        key, response.StatusCode, response.ReasonPhrase);
+                    if (response.StatusCode == HttpStatusCode.NotFound)
+                    {
+                        // No override on the server — the designed fallback path, not a failure. Debug only.
+                        _logger.LogDebug("Background refresh for content '{Key}': no override (404). Keeping default value.", key);
+                    }
+                    else
+                    {
+                        _logger.LogError("Background refresh for content '{Key}' failed. Response was {StatusCode} {ReasonPhrase}.",
+                            key, response.StatusCode, response.ReasonPhrase);
+                    }
                     var staleValue = _localCache.TryGetValue(cacheKey, out var s) ? s.Value : defaultValue;
                     CacheFailure(cacheKey, staleValue);
                     return;


### PR DESCRIPTION
Addresses the **client side** of #131. (Scope agreed with the maintainer: Toolkit client only this pass; the server 500→404 + seed/AI-on-read latency is a follow-up that overlaps #133 — see below. This PR intentionally does **not** close #131.)

## Problem
`RemoteContentCallService` logs an `Error` (`fail:`) for **every** non-2xx content response, including a key the server simply has no override for. Because `Quilt4Text` / `IQuilt4ContentService.GetAsync(key, default)` is *designed* to fall back to the caller's `Default`, those misses are expected and non-fatal — yet each emits an error line on **every render**, flooding the console and inflating App Insights (one Error-level telemetry item per unseeded key, per render).

## Change
Treat a **404 (NotFound)** response as the designed "no override — use `Default`" path:
- Log it at **Debug**, not Error, in **both** fetch paths — the synchronous `FetchContentWithTimeout` and the stale-while-revalidate `StartBackgroundRefresh`.
- Keep **Error** for other non-2xx (5xx) — genuinely unexpected. (Timeouts already log Warning.)
- The existing negative cache (`CacheFailure`, `FailureCacheDuration` = 10 min) is preserved for the 404 path, so a missing key isn't re-requested (or re-logged) every render.

Forward-compatible with the server follow-up: once the server returns **404** for unknown keys, misses go completely silent; until then a 500 still logs Error, which is correct (a 500 *is* unexpected from the client's view).

## Follow-up (not in this PR)
- **Server (Azure repo):** return **404/empty** for an unknown key instead of 500.
- **Server:** the current GET path *seeds the default and runs synchronous AI translation fan-out* (`TranslateFanOutAsync` → ChatGPT per language) on a miss — this is the real source of the ~5s latency **and** the 500. Moving that off the request thread overlaps **#133** (translate-on-write, not on read).

## Tests
New `ContentNotFoundLoggingTests`:
- 404 → logged at Debug, **not** Error; returns the caller's default.
- 404 → negative-cached: two calls for the same missing key produce a **single** server request.
- 500 → **still** logs Error (guards against over-suppressing real failures).

Full `Quilt4Net.Toolkit.Tests` suite: **202/202** pass (incl. the 3 new). No new warnings.