### PR TITLE
feat(health): optional per-Component result caching + timeout + cancellation (#134)

### DIFF
--- a/Quilt4Net.Toolkit.Health.Tests/ComponentCacheAndTimeoutTests.cs
+++ b/Quilt4Net.Toolkit.Health.Tests/ComponentCacheAndTimeoutTests.cs
@@ -41,12 +41,12 @@ public class ComponentCacheAndTimeoutTests
         });
         var sut = BuildSut(option, new ComponentCheckCache(time));
 
-        await sut.GetStatusAsync(null, false, CancellationToken.None).ToArrayAsync();
-        await sut.GetStatusAsync(null, false, CancellationToken.None).ToArrayAsync();
+        await sut.GetStatusAsync(null, false, TestContext.Current.CancellationToken).ToArrayAsync(TestContext.Current.CancellationToken);
+        await sut.GetStatusAsync(null, false, TestContext.Current.CancellationToken).ToArrayAsync(TestContext.Current.CancellationToken);
         runs.Should().Be(1, "the second poll within CacheDuration must reuse the cached result");
 
         time.Advance(TimeSpan.FromSeconds(31));
-        await sut.GetStatusAsync(null, false, CancellationToken.None).ToArrayAsync();
+        await sut.GetStatusAsync(null, false, TestContext.Current.CancellationToken).ToArrayAsync(TestContext.Current.CancellationToken);
         runs.Should().Be(2, "once CacheDuration has elapsed the check must run again");
     }
 
@@ -66,8 +66,8 @@ public class ComponentCacheAndTimeoutTests
         });
         var sut = BuildSut(option, new ComponentCheckCache(new FakeTimeProvider(DateTimeOffset.UtcNow)));
 
-        await sut.GetStatusAsync(null, false, CancellationToken.None).ToArrayAsync();
-        await sut.GetStatusAsync(null, false, CancellationToken.None).ToArrayAsync();
+        await sut.GetStatusAsync(null, false, TestContext.Current.CancellationToken).ToArrayAsync(TestContext.Current.CancellationToken);
+        await sut.GetStatusAsync(null, false, TestContext.Current.CancellationToken).ToArrayAsync(TestContext.Current.CancellationToken);
 
         runs.Should().Be(2, "without CacheDuration caching is disabled and each poll runs the check");
     }
@@ -91,8 +91,8 @@ public class ComponentCacheAndTimeoutTests
         });
         var sut = BuildSut(option, new ComponentCheckCache(new FakeTimeProvider(DateTimeOffset.UtcNow)));
 
-        var poll1 = sut.GetStatusAsync(null, false, CancellationToken.None).ToArrayAsync().AsTask();
-        var poll2 = sut.GetStatusAsync(null, false, CancellationToken.None).ToArrayAsync().AsTask();
+        var poll1 = sut.GetStatusAsync(null, false, TestContext.Current.CancellationToken).ToArrayAsync(TestContext.Current.CancellationToken).AsTask();
+        var poll2 = sut.GetStatusAsync(null, false, TestContext.Current.CancellationToken).ToArrayAsync(TestContext.Current.CancellationToken).AsTask();
         await Task.Delay(100, TestContext.Current.CancellationToken); // let both reach the per-key gate
         gate.SetResult();
         await Task.WhenAll(poll1, poll2);
@@ -120,7 +120,7 @@ public class ComponentCacheAndTimeoutTests
         var sut = BuildSut(option, new ComponentCheckCache(TimeProvider.System));
 
         var sw = Stopwatch.StartNew();
-        var result = (await sut.GetStatusAsync(null, false, CancellationToken.None).ToArrayAsync()).ToHealthResponse();
+        var result = (await sut.GetStatusAsync(null, false, TestContext.Current.CancellationToken).ToArrayAsync(TestContext.Current.CancellationToken)).ToHealthResponse();
         sw.Stop();
 
         sw.Elapsed.Should().BeLessThan(TimeSpan.FromSeconds(3), "a timed-out check must not block the fan-out for its full duration");
@@ -156,7 +156,7 @@ public class ComponentCacheAndTimeoutTests
         var sut = BuildSut(option, new ComponentCheckCache(TimeProvider.System));
 
         var sw = Stopwatch.StartNew();
-        var result = (await sut.GetStatusAsync(null, false, CancellationToken.None).ToArrayAsync()).ToHealthResponse();
+        var result = (await sut.GetStatusAsync(null, false, TestContext.Current.CancellationToken).ToArrayAsync(TestContext.Current.CancellationToken)).ToHealthResponse();
         sw.Stop();
 
         sw.Elapsed.Should().BeLessThan(TimeSpan.FromSeconds(3));
@@ -176,7 +176,7 @@ public class ComponentCacheAndTimeoutTests
         });
         var sut = BuildSut(option, new ComponentCheckCache(TimeProvider.System));
 
-        var result = (await sut.GetStatusAsync(null, false, CancellationToken.None).ToArrayAsync()).ToHealthResponse();
+        var result = (await sut.GetStatusAsync(null, false, TestContext.Current.CancellationToken).ToArrayAsync(TestContext.Current.CancellationToken)).ToHealthResponse();
 
         result.Status.Should().Be(HealthStatus.Healthy);
         result.Components.Single().Value.Details.First(x => x.Key == "message").Value.Should().Be("ok");

--- a/Quilt4Net.Toolkit.Health.Tests/ComponentCacheAndTimeoutTests.cs
+++ b/Quilt4Net.Toolkit.Health.Tests/ComponentCacheAndTimeoutTests.cs
@@ -1,0 +1,192 @@
+using System.Diagnostics;
+using FluentAssertions;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Quilt4Net.Toolkit.Features.Api;
+using Quilt4Net.Toolkit.Features.Health;
+using Quilt4Net.Toolkit.Features.Probe;
+using Xunit;
+
+namespace Quilt4Net.Toolkit.Health.Tests;
+
+// Issue #134: deep Component checks gained optional per-Component result caching, timeout and
+// cancellation (Dependency probes already had cache/throttle from #119). These are opt-in — unset
+// properties keep the exact previous behaviour.
+public class ComponentCacheAndTimeoutTests
+{
+    private readonly Mock<IServiceProvider> _serviceProvider = new(MockBehavior.Loose);
+    private readonly Mock<ILogger<HealthService>> _logger = new(MockBehavior.Loose);
+    private readonly Mock<IHostEnvironment> _hostEnvironment = new(MockBehavior.Loose);
+    private readonly Mock<IHostedServiceProbeRegistry> _hostedServiceProbeRegistry = new(MockBehavior.Loose);
+
+    private HealthService BuildSut(Quilt4NetHealthApiOptions option, ComponentCheckCache cache)
+        => new(_hostEnvironment.Object, _serviceProvider.Object, _hostedServiceProbeRegistry.Object, option, _logger.Object, cache);
+
+    [Fact]
+    public async Task CacheDuration_reuses_result_within_window_and_reruns_after_it_expires()
+    {
+        var time = new FakeTimeProvider(DateTimeOffset.UtcNow);
+        var runs = 0;
+        var option = new Quilt4NetHealthApiOptions();
+        option.AddComponent(new Component
+        {
+            Name = "cached",
+            CacheDuration = TimeSpan.FromSeconds(30),
+            CheckAsync = _ =>
+            {
+                Interlocked.Increment(ref runs);
+                return Task.FromResult(new CheckResult { Success = true });
+            }
+        });
+        var sut = BuildSut(option, new ComponentCheckCache(time));
+
+        await sut.GetStatusAsync(null, false, CancellationToken.None).ToArrayAsync();
+        await sut.GetStatusAsync(null, false, CancellationToken.None).ToArrayAsync();
+        runs.Should().Be(1, "the second poll within CacheDuration must reuse the cached result");
+
+        time.Advance(TimeSpan.FromSeconds(31));
+        await sut.GetStatusAsync(null, false, CancellationToken.None).ToArrayAsync();
+        runs.Should().Be(2, "once CacheDuration has elapsed the check must run again");
+    }
+
+    [Fact]
+    public async Task No_CacheDuration_runs_the_check_every_time()
+    {
+        var runs = 0;
+        var option = new Quilt4NetHealthApiOptions();
+        option.AddComponent(new Component
+        {
+            Name = "uncached",
+            CheckAsync = _ =>
+            {
+                Interlocked.Increment(ref runs);
+                return Task.FromResult(new CheckResult { Success = true });
+            }
+        });
+        var sut = BuildSut(option, new ComponentCheckCache(new FakeTimeProvider(DateTimeOffset.UtcNow)));
+
+        await sut.GetStatusAsync(null, false, CancellationToken.None).ToArrayAsync();
+        await sut.GetStatusAsync(null, false, CancellationToken.None).ToArrayAsync();
+
+        runs.Should().Be(2, "without CacheDuration caching is disabled and each poll runs the check");
+    }
+
+    [Fact]
+    public async Task Concurrent_polls_coalesce_into_a_single_check()
+    {
+        var gate = new TaskCompletionSource();
+        var runs = 0;
+        var option = new Quilt4NetHealthApiOptions();
+        option.AddComponent(new Component
+        {
+            Name = "c",
+            CacheDuration = TimeSpan.FromMinutes(1),
+            CheckAsync = async _ =>
+            {
+                Interlocked.Increment(ref runs);
+                await gate.Task;
+                return new CheckResult { Success = true };
+            }
+        });
+        var sut = BuildSut(option, new ComponentCheckCache(new FakeTimeProvider(DateTimeOffset.UtcNow)));
+
+        var poll1 = sut.GetStatusAsync(null, false, CancellationToken.None).ToArrayAsync().AsTask();
+        var poll2 = sut.GetStatusAsync(null, false, CancellationToken.None).ToArrayAsync().AsTask();
+        await Task.Delay(100, TestContext.Current.CancellationToken); // let both reach the per-key gate
+        gate.SetResult();
+        await Task.WhenAll(poll1, poll2);
+
+        runs.Should().Be(1, "concurrent polls for the same component must coalesce into a single check");
+    }
+
+    [Theory]
+    [InlineData(false, HealthStatus.Degraded)]
+    [InlineData(true, HealthStatus.Unhealthy)]
+    public async Task Timeout_on_a_plain_check_reports_failure_fast_without_hanging(bool essential, HealthStatus expected)
+    {
+        var option = new Quilt4NetHealthApiOptions();
+        option.AddComponent(new Component
+        {
+            Name = "slow",
+            Essential = essential,
+            Timeout = TimeSpan.FromMilliseconds(100),
+            CheckAsync = async _ =>
+            {
+                await Task.Delay(TimeSpan.FromSeconds(5));
+                return new CheckResult { Success = true };
+            }
+        });
+        var sut = BuildSut(option, new ComponentCheckCache(TimeProvider.System));
+
+        var sw = Stopwatch.StartNew();
+        var result = (await sut.GetStatusAsync(null, false, CancellationToken.None).ToArrayAsync()).ToHealthResponse();
+        sw.Stop();
+
+        sw.Elapsed.Should().BeLessThan(TimeSpan.FromSeconds(3), "a timed-out check must not block the fan-out for its full duration");
+        result.Status.Should().Be(expected);
+        result.Components.Single().Value.Details.First(x => x.Key == "message").Value.Should().Contain("timed out");
+    }
+
+    [Fact]
+    public async Task Timeout_cancels_a_cancellation_aware_check()
+    {
+        var observedCancellation = false;
+        var option = new Quilt4NetHealthApiOptions();
+        option.AddComponent(new Component
+        {
+            Name = "cancellable",
+            Essential = false,
+            Timeout = TimeSpan.FromMilliseconds(100),
+            CheckAsync = _ => Task.FromResult(new CheckResult { Success = true }), // required, unused when the cancellable variant is set
+            CheckWithCancellationAsync = async (_, ct) =>
+            {
+                try
+                {
+                    await Task.Delay(TimeSpan.FromSeconds(5), ct);
+                }
+                catch (OperationCanceledException)
+                {
+                    observedCancellation = true;
+                    throw;
+                }
+                return new CheckResult { Success = true };
+            }
+        });
+        var sut = BuildSut(option, new ComponentCheckCache(TimeProvider.System));
+
+        var sw = Stopwatch.StartNew();
+        var result = (await sut.GetStatusAsync(null, false, CancellationToken.None).ToArrayAsync()).ToHealthResponse();
+        sw.Stop();
+
+        sw.Elapsed.Should().BeLessThan(TimeSpan.FromSeconds(3));
+        result.Status.Should().Be(HealthStatus.Degraded);
+        observedCancellation.Should().BeTrue("the token must actually cancel the check so it can free its resources, not just abandon the wait");
+    }
+
+    [Fact]
+    public async Task A_check_that_finishes_before_its_timeout_returns_normally()
+    {
+        var option = new Quilt4NetHealthApiOptions();
+        option.AddComponent(new Component
+        {
+            Name = "fast",
+            Timeout = TimeSpan.FromSeconds(5),
+            CheckAsync = _ => Task.FromResult(new CheckResult { Success = true, Message = "ok" })
+        });
+        var sut = BuildSut(option, new ComponentCheckCache(TimeProvider.System));
+
+        var result = (await sut.GetStatusAsync(null, false, CancellationToken.None).ToArrayAsync()).ToHealthResponse();
+
+        result.Status.Should().Be(HealthStatus.Healthy);
+        result.Components.Single().Value.Details.First(x => x.Key == "message").Value.Should().Be("ok");
+    }
+
+    private sealed class FakeTimeProvider : TimeProvider
+    {
+        private DateTimeOffset _utcNow;
+        public FakeTimeProvider(DateTimeOffset start) => _utcNow = start;
+        public override DateTimeOffset GetUtcNow() => _utcNow;
+        public void Advance(TimeSpan by) => _utcNow += by;
+    }
+}

--- a/Quilt4Net.Toolkit.Health/HealthRegistration.cs
+++ b/Quilt4Net.Toolkit.Health/HealthRegistration.cs
@@ -64,6 +64,10 @@ public static class HealthRegistration
 
         services.TryAddSingleton(TimeProvider.System);
 
+        // Singleton so per-Component check-result caching survives across health polls; HealthService
+        // itself is transient (its IServiceProvider must stay request-scoped for the checks).
+        services.AddSingleton<ComponentCheckCache>();
+
         services.AddTransient<ILiveService, LiveService>();
         services.AddTransient<IReadyService, ReadyService>();
         services.AddTransient<IHealthService, HealthService>();

--- a/Quilt4Net.Toolkit/Features/Health/Component.cs
+++ b/Quilt4Net.Toolkit/Features/Health/Component.cs
@@ -28,4 +28,34 @@ public record Component
     /// Method that performs the check for the component.
     /// </summary>
     public required Func<IServiceProvider, Task<CheckResult>> CheckAsync { get; init; }
+
+    /// <summary>
+    /// Optional. Cancellation-aware check. When set it is used <b>instead of</b> <see cref="CheckAsync"/>
+    /// and receives a token that is cancelled when <see cref="Timeout"/> elapses (or the request is
+    /// aborted). Prefer this over <see cref="CheckAsync"/> when the check does cancellable I/O: on
+    /// timeout the check can actually abort and free its resources (e.g. an HTTP connection), rather
+    /// than being left running while only the wait is abandoned.
+    /// Default is null (use <see cref="CheckAsync"/>).
+    /// </summary>
+    public Func<IServiceProvider, CancellationToken, Task<CheckResult>> CheckWithCancellationAsync { get; init; }
+
+    /// <summary>
+    /// Optional. How long a successful-or-failed <see cref="CheckResult"/> is cached (keyed by
+    /// <see cref="Name"/>) before the check is run again. Repeated polls within this window reuse the
+    /// cached result and concurrent runs are coalesced into a single check — so sustained polling of a
+    /// deep endpoint runs each check at most once per window instead of on every request.
+    /// Set to null (default) or <see cref="TimeSpan.Zero"/> to disable caching and run every time.
+    /// Relies on <see cref="Name"/> being unique.
+    /// </summary>
+    public TimeSpan? CacheDuration { get; init; }
+
+    /// <summary>
+    /// Optional. Bounds how long the check may run. On timeout the component is reported as a failed
+    /// <see cref="CheckResult"/> (mapped to Degraded/Unhealthy per <see cref="Essential"/>) with a
+    /// clear message, instead of hanging and holding resources. With
+    /// <see cref="CheckWithCancellationAsync"/> the check is actually cancelled; with a plain
+    /// <see cref="CheckAsync"/> the wait is bounded (the check itself cannot be aborted).
+    /// Set to null (default) or <see cref="TimeSpan.Zero"/> for no timeout.
+    /// </summary>
+    public TimeSpan? Timeout { get; init; }
 }

--- a/Quilt4Net.Toolkit/Features/Health/ComponentCheckCache.cs
+++ b/Quilt4Net.Toolkit/Features/Health/ComponentCheckCache.cs
@@ -1,0 +1,94 @@
+using System.Collections.Concurrent;
+
+namespace Quilt4Net.Toolkit.Features.Health;
+
+/// <summary>
+/// Outcome of running a single component check. Shared between <see cref="HealthService"/> and
+/// <see cref="ComponentCheckCache"/> so cached results can be reused across health polls.
+/// </summary>
+internal record RunTaskResult
+{
+    public required string Name { get; init; }
+    public required bool Essential { get; init; }
+    public required CheckResult Result { get; init; }
+    public required TimeSpan Elapsed { get; init; }
+    public Exception Exception { get; init; }
+    public Guid? CorrelationId { get; init; }
+}
+
+/// <summary>
+/// Singleton cache for deep <see cref="Component"/> check results, keyed by component name. Mirrors
+/// the Dependency-probe caching added in #119: within a component's <see cref="Component.CacheDuration"/>
+/// the last <see cref="RunTaskResult"/> is reused instead of re-running the check, and concurrent runs
+/// for the same component are coalesced through a per-key gate so a burst of polls triggers a single
+/// check. Lives as a singleton because <see cref="HealthService"/> is transient — the cache must
+/// outlive a single request to be effective.
+/// </summary>
+internal sealed class ComponentCheckCache
+{
+    private readonly TimeProvider _timeProvider;
+    private readonly ConcurrentDictionary<string, CacheSlot> _cache = new();
+
+    public ComponentCheckCache(TimeProvider timeProvider)
+    {
+        _timeProvider = timeProvider;
+    }
+
+    /// <summary>
+    /// Return a cached result for <paramref name="name"/> if one is still fresh for
+    /// <paramref name="cacheDuration"/>; otherwise run <paramref name="run"/> once (coalescing
+    /// concurrent callers) and cache it. When <paramref name="cacheDuration"/> is null or
+    /// non-positive, caching is bypassed entirely.
+    /// </summary>
+    public async Task<RunTaskResult> GetOrRunAsync(string name, TimeSpan? cacheDuration, Func<Task<RunTaskResult>> run)
+    {
+        if (cacheDuration is not { } duration || duration <= TimeSpan.Zero)
+        {
+            return await run();
+        }
+
+        var slot = _cache.GetOrAdd(name, _ => new CacheSlot());
+
+        if (TryGetFresh(slot, duration, out var cached))
+        {
+            return cached;
+        }
+
+        await slot.Gate.WaitAsync();
+        try
+        {
+            if (TryGetFresh(slot, duration, out cached))
+            {
+                return cached;
+            }
+
+            var result = await run();
+            slot.Result = result;
+            slot.FetchedAt = _timeProvider.GetUtcNow();
+            return result;
+        }
+        finally
+        {
+            slot.Gate.Release();
+        }
+    }
+
+    private bool TryGetFresh(CacheSlot slot, TimeSpan cacheDuration, out RunTaskResult result)
+    {
+        if (slot.Result != null && _timeProvider.GetUtcNow() - slot.FetchedAt < cacheDuration)
+        {
+            result = slot.Result;
+            return true;
+        }
+
+        result = null;
+        return false;
+    }
+
+    private sealed class CacheSlot
+    {
+        public SemaphoreSlim Gate { get; } = new(1, 1);
+        public RunTaskResult Result { get; set; }
+        public DateTimeOffset FetchedAt { get; set; }
+    }
+}

--- a/Quilt4Net.Toolkit/Features/Health/HealthService.cs
+++ b/Quilt4Net.Toolkit/Features/Health/HealthService.cs
@@ -14,14 +14,19 @@ internal class HealthService : IHealthService
     private readonly IHostedServiceProbeRegistry _hostedServiceProbeRegistry;
     private readonly Quilt4NetHealthApiOptions _apiOption;
     private readonly ILogger<HealthService> _logger;
+    private readonly ComponentCheckCache _componentCheckCache;
 
-    public HealthService(IHostEnvironment hostEnvironment, IServiceProvider serviceProvider, IHostedServiceProbeRegistry hostedServiceProbeRegistry, Quilt4NetHealthApiOptions apiOption, ILogger<HealthService> logger = null)
+    public HealthService(IHostEnvironment hostEnvironment, IServiceProvider serviceProvider, IHostedServiceProbeRegistry hostedServiceProbeRegistry, Quilt4NetHealthApiOptions apiOption, ILogger<HealthService> logger = null, ComponentCheckCache componentCheckCache = null)
     {
         _hostEnvironment = hostEnvironment;
         _serviceProvider = serviceProvider;
         _hostedServiceProbeRegistry = hostedServiceProbeRegistry;
         _apiOption = apiOption;
         _logger = logger;
+        // In DI the singleton is injected; the fallback keeps direct construction (e.g. tests) working.
+        // Per-component result caching only takes effect when this instance outlives a request, which
+        // it does via the registered singleton.
+        _componentCheckCache = componentCheckCache ?? new ComponentCheckCache(TimeProvider.System);
     }
 
     public async IAsyncEnumerable<KeyValuePair<string, HealthComponent>> GetStatusAsync(Func<Component, bool> filter, bool includeProbes, [EnumeratorCancellation] CancellationToken cancellationToken)
@@ -36,8 +41,8 @@ internal class HealthService : IHealthService
 
         var tasksFromServices = _apiOption.ComponentServices.SelectMany(x => ((IComponentService)_serviceProvider.GetService(x))?.GetComponents())
             .Where(filter ?? (_ => true))
-            .Select(x => RunTaskAsync(x.Name, x.Essential, x.CheckAsync));
-        var tasksFromAdd = _apiOption.Components.Select(x => RunTaskAsync(x.Name, x.Essential, x.CheckAsync));
+            .Select(x => RunTaskAsync(x, cancellationToken));
+        var tasksFromAdd = _apiOption.Components.Select(x => RunTaskAsync(x, cancellationToken));
         var taskList = tasksFromServices.Union(tasksFromAdd).ToList();
 
         while (taskList.Count > 0)
@@ -114,22 +119,45 @@ internal class HealthService : IHealthService
         return HealthStatus.Unhealthy;
     }
 
-    private async Task<RunTaskResult> RunTaskAsync(string name, bool essential, Func<IServiceProvider, Task<CheckResult>> check)
+    private Task<RunTaskResult> RunTaskAsync(Component component, CancellationToken cancellationToken)
+    {
+        var name = string.IsNullOrEmpty(component.Name) ? "Component" : component.Name;
+
+        // Reuse a fresh cached result within CacheDuration (and coalesce concurrent runs); when
+        // caching is off this runs the check directly.
+        return _componentCheckCache.GetOrRunAsync(name, component.CacheDuration, () => RunCheckAsync(component, name, cancellationToken));
+    }
+
+    private async Task<RunTaskResult> RunCheckAsync(Component component, string name, CancellationToken cancellationToken)
     {
         var stopwatch = Stopwatch.StartNew();
-
-        if (string.IsNullOrEmpty(name)) name = "Component";
 
         try
         {
             _logger?.LogTrace("Starting check for {name} component.", name);
-            var status = await check.Invoke(_serviceProvider);
+            var status = await InvokeCheckAsync(component, cancellationToken);
             stopwatch.Stop();
             _logger?.LogTrace("Complete check for {name} component after {elapsed}.", name, stopwatch.Elapsed);
-            return new RunTaskResult { Name = name, Essential = essential, Result = status, Elapsed = stopwatch.Elapsed };
+            return new RunTaskResult { Name = name, Essential = component.Essential, Result = status, Elapsed = stopwatch.Elapsed };
+        }
+        catch (Exception exception) when (exception is OperationCanceledException or TimeoutException)
+        {
+            // Timed out (or the request was aborted). Report a failed result — mapped to
+            // Degraded/Unhealthy per Essential by BuildStatus — instead of hanging. No exception
+            // detail: a timeout is an expected, self-describing outcome, not a crash.
+            stopwatch.Stop();
+            _logger?.LogWarning("Timed out check for {name} component after {elapsed}.", name, stopwatch.Elapsed);
+            return new RunTaskResult
+            {
+                Name = name,
+                Essential = component.Essential,
+                Result = new CheckResult { Success = false, Message = $"Check timed out after {stopwatch.Elapsed}." },
+                Elapsed = stopwatch.Elapsed
+            };
         }
         catch (Exception exception)
         {
+            stopwatch.Stop();
             Guid? correlationId = null;
             if (_logger != null)
             {
@@ -137,21 +165,55 @@ internal class HealthService : IHealthService
                 _logger.LogError("Failed check for {name} component after {elapsed}. {message} [CorrelationId: {correlationId}]", name, stopwatch.Elapsed, exception.Message, correlationId);
             }
 
-            return new RunTaskResult { Name = name, Essential = essential, Result = new CheckResult { Success = false }, Elapsed = stopwatch.Elapsed, Exception = exception, CorrelationId = correlationId };
-        }
-        finally
-        {
-            stopwatch.Stop();
+            return new RunTaskResult { Name = name, Essential = component.Essential, Result = new CheckResult { Success = false }, Elapsed = stopwatch.Elapsed, Exception = exception, CorrelationId = correlationId };
         }
     }
 
-    private record RunTaskResult
+    private async Task<CheckResult> InvokeCheckAsync(Component component, CancellationToken cancellationToken)
     {
-        public required string Name { get; init; }
-        public required bool Essential { get; init; }
-        public required CheckResult Result { get; init; }
-        public required TimeSpan Elapsed { get; init; }
-        public Exception Exception { get; init; }
-        public Guid? CorrelationId { get; init; }
+        var hasTimeout = component.Timeout is { } timeout && timeout > TimeSpan.Zero;
+
+        // Fast path — no timeout and no cancellation-aware check: exactly the original behaviour.
+        if (!hasTimeout && component.CheckWithCancellationAsync == null)
+        {
+            return await component.CheckAsync(_serviceProvider);
+        }
+
+        using var timeoutCts = hasTimeout ? CancellationTokenSource.CreateLinkedTokenSource(cancellationToken) : null;
+        var token = cancellationToken;
+        if (timeoutCts != null)
+        {
+            timeoutCts.CancelAfter(component.Timeout.Value);
+            token = timeoutCts.Token;
+        }
+
+        // Cancellation-aware check: on timeout (or request abort) the token cancels and the check can
+        // actually abort and free its resources.
+        if (component.CheckWithCancellationAsync != null)
+        {
+            return await component.CheckWithCancellationAsync(_serviceProvider, token);
+        }
+
+        // Plain check + timeout: it has no token so it can't be aborted, but we bound the wait by
+        // racing it against the timeout token — a hung check can't block the health fan-out. If it
+        // times out we observe its eventual fault out-of-band so it isn't an unobserved exception.
+        var checkTask = component.CheckAsync(_serviceProvider);
+        var completed = await Task.WhenAny(checkTask, Task.Delay(System.Threading.Timeout.Infinite, token));
+        if (completed == checkTask)
+        {
+            return await checkTask;
+        }
+
+        ObserveFault(checkTask);
+        throw new TimeoutException($"Health check '{component.Name}' did not complete within {component.Timeout.Value}.");
+    }
+
+    private static void ObserveFault(Task task)
+    {
+        _ = task.ContinueWith(
+            static t => { _ = t.Exception; },
+            CancellationToken.None,
+            TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously,
+            TaskScheduler.Default);
     }
 }


### PR DESCRIPTION
Fixes #134.

## Problem
`HealthService` deep **Component** checks (`AddComponent` / `AddComponentService<T>()` / `Components`) had **no result caching, no timeout, and no cancellation** — unlike Dependency probes, which got cache/throttle in #119. Under sustained polling of the deep `/health` endpoint, a transiently-slow dependency's un-timed `CheckAsync` **piles up** → `HttpClient` connection-pool starvation → the whole process becomes unresponsive (observed hangs up to ~2.5 h). Blocks Eplicta **EP-4672** and **EP-4589**.

## Change — three opt-in, default-off properties on `Component`
```csharp
public TimeSpan? CacheDuration { get; init; }   // cache the CheckResult by Name for this window
public TimeSpan? Timeout { get; init; }          // bound the check; timeout -> failed result
public Func<IServiceProvider, CancellationToken, Task<CheckResult>> CheckWithCancellationAsync { get; init; } // optional, cancellable
```

Handled centrally in `HealthService`:
- **Caching** lives in a new **singleton** `ComponentCheckCache` — per-key `SemaphoreSlim` gate + injected `TimeProvider`, coalescing concurrent runs (mirrors #119's `DependencyService`). Within `CacheDuration` the last result is reused, so sustained polling runs each check **at most once per window**.
  - `HealthService` stays **transient** on purpose — making it a singleton would change the `IServiceProvider` scope its checks resolve from — so the cache is a separate singleton.
- **Timeout** — a `CheckWithCancellationAsync` is actually cancelled via a linked CTS on timeout; a plain `CheckAsync` (no token) is **raced** against the timeout so a hung check can't block the fan-out (its eventual fault is observed out-of-band). Timeout maps to a failed `CheckResult` (→ Degraded/Unhealthy per `Essential`) with a clear message.
- `OperationCanceledException`/`TimeoutException` now map to a **clean** timed-out result instead of a noisy error — addressing **EP-4589** (probe throws `TaskCanceled` instead of degrading). The resulting status is unchanged from before.

## Backward compatibility
Fully compatible — unset properties give exactly the previous behaviour. The new `ComponentCheckCache` ctor arg on `HealthService` is an optional trailing parameter (DI injects the singleton; direct construction falls back to a default), so existing code and tests are unaffected. Registered `ComponentCheckCache` as a singleton.

## Tests
New `ComponentCacheAndTimeoutTests` (7):
- `CacheDuration` reuses the result within the window and reruns after it expires (deterministic via a fake `TimeProvider`).
- No `CacheDuration` runs the check every time.
- Concurrent polls coalesce into a single check.
- Plain-check `Timeout` reports Degraded/Unhealthy **fast**, without hanging.
- `Timeout` actually **cancels** a cancellation-aware check.
- A check that finishes before its timeout returns normally.

Solution builds clean (0 errors, no new warnings). `Quilt4Net.Toolkit.Health.Tests` **67/67** and `Quilt4Net.Toolkit.Tests` **199/199** pass.

## Follow-up for consumers
Once released, bump `Quilt4Net.Toolkit.*` and set `CacheDuration`/`Timeout` (and optionally `CheckWithCancellationAsync`) on the Aggregator's Components.