### PR TITLE
Content & UI improvements: lorem-api removal, Quilt4Button busy/disabled (#128), diagnostics (#132), per-language defaults (#135), Quilt4SplitButton (#129)

### DIFF
--- a/Quilt4Net.Toolkit.Blazor.Tests/ContentWarmupTests.cs
+++ b/Quilt4Net.Toolkit.Blazor.Tests/ContentWarmupTests.cs
@@ -45,7 +45,8 @@ public class ContentWarmupTests
         var call = new RecordingRemoteCallService();
         var other = new Language { Key = Guid.NewGuid(), Name = "Swedish" };
         var languages = new[] { new Language { Key = Guid.Empty, Name = "Default" }, other };
-        var sut = new LanguageStateService(new FakeLanguageService(languages), new NoopLocalStorage(), call);
+        var sut = new LanguageStateService(new FakeLanguageService(languages), new NoopLocalStorage(), call,
+            NullLogger<LanguageStateService>.Instance);
 
         sut.Selected = other;
 

--- a/Quilt4Net.Toolkit.Blazor.Tests/Quilt4ButtonTests.cs
+++ b/Quilt4Net.Toolkit.Blazor.Tests/Quilt4ButtonTests.cs
@@ -61,6 +61,49 @@ public class Quilt4ButtonTests : BunitContext
         cut.Find(".rz-button").TextContent.Should().Contain("Spara");
     }
 
+    [Fact]
+    public void Not_disabled_by_default()
+    {
+        _contentService.SetResult("Save");
+
+        var cut = Render<Quilt4Button>(parameters => parameters
+            .Add(p => p.TextKey, "btn.save")
+            .Add(p => p.DefaultText, "Save"));
+
+        cut.Find(".rz-button").HasAttribute("disabled").Should().BeFalse();
+    }
+
+    [Fact]
+    public void Disabled_parameter_disables_the_button()
+    {
+        _contentService.SetResult("Save");
+
+        var cut = Render<Quilt4Button>(parameters => parameters
+            .Add(p => p.TextKey, "btn.save")
+            .Add(p => p.DefaultText, "Save")
+            .Add(p => p.Disabled, true));
+
+        cut.Find(".rz-button").HasAttribute("disabled").Should().BeTrue();
+    }
+
+    [Fact]
+    public void Busy_disables_the_button_and_shows_the_busy_text()
+    {
+        // Content lookups miss so the label + busy label fall back to their defaults.
+        _contentService.SetResult(null, success: false);
+
+        var cut = Render<Quilt4Button>(parameters => parameters
+            .Add(p => p.TextKey, "btn.save")
+            .Add(p => p.DefaultText, "Save")
+            .Add(p => p.Busy, true)
+            .Add(p => p.BusyTextKey, "btn.save.busy")
+            .Add(p => p.DefaultBusyText, "Saving…"));
+
+        var button = cut.Find(".rz-button");
+        button.HasAttribute("disabled").Should().BeTrue();
+        button.TextContent.Should().Contain("Saving…");
+    }
+
     private class FakeContentService : IContentService
     {
         private string _value = "";

--- a/Quilt4Net.Toolkit.Blazor.Tests/Quilt4ContentTests.cs
+++ b/Quilt4Net.Toolkit.Blazor.Tests/Quilt4ContentTests.cs
@@ -73,9 +73,23 @@ public class Quilt4ContentTests : BunitContext
         _loggerProvider.Entries.Should().NotContain(e => e.Level == LogLevel.Warning);
     }
 
+    [Fact]
+    public void No_child_content_renders_local_placeholder_and_persists_nothing()
+    {
+        // Previously a key with no stored value and no ChildContent fetched lorem-ipsum from the
+        // external lorem-api.com and auto-registered it as the key's default. It must now render a
+        // purely local placeholder and write nothing back to the content store.
+        var cut = Render<Quilt4Content>(p => p
+            .Add(x => x.Key, "missing-key"));
+
+        cut.Markup.Should().Contain("No content for 'missing-key'.");
+        _contentService.SetContentCalls.Should().BeEmpty();
+    }
+
     private sealed class StubContentService : IContentService
     {
         public Exception SetContentThrow { get; set; }
+        public List<(string Key, string Value)> SetContentCalls { get; } = new();
 
         public Task<(string Value, bool Success)> GetContentAsync(string key, string defaultValue,
             Guid languageKey, ContentFormat? contentType, string application = null)
@@ -85,6 +99,7 @@ public class Quilt4ContentTests : BunitContext
             ContentFormat contentType, string application = null)
         {
             if (SetContentThrow != null) throw SetContentThrow;
+            SetContentCalls.Add((key, value));
             return Task.CompletedTask;
         }
 

--- a/Quilt4Net.Toolkit.Blazor.Tests/Quilt4SplitButtonTests.cs
+++ b/Quilt4Net.Toolkit.Blazor.Tests/Quilt4SplitButtonTests.cs
@@ -1,0 +1,169 @@
+using Bunit;
+using FluentAssertions;
+using Quilt4Net.Toolkit.Features.Content;
+using Quilt4Net.Toolkit.Features.FeatureToggle;
+using Xunit;
+
+namespace Quilt4Net.Toolkit.Blazor.Tests;
+
+public class Quilt4SplitButtonTests : BunitContext
+{
+    private readonly FakeContentService _contentService = new();
+    private readonly FakeLanguageStateService _languageStateService = new();
+
+    public Quilt4SplitButtonTests()
+    {
+        JSInterop.Mode = JSRuntimeMode.Loose;
+        Services.AddSingleton<IContentService>(_contentService);
+        Services.AddSingleton<ILanguageStateService>(_languageStateService);
+        _languageStateService.Selected = new Language { Key = Guid.NewGuid(), Name = "English" };
+    }
+
+    [Fact]
+    public void Renders_primary_text_from_content_service()
+    {
+        _contentService.Set("split.save", "Save Changes");
+
+        var cut = Render<Quilt4SplitButton>(parameters => parameters
+            .Add(p => p.TextKey, "split.save")
+            .Add(p => p.DefaultText, "Save"));
+
+        cut.Markup.Should().Contain("Save Changes");
+    }
+
+    [Fact]
+    public void Renders_primary_default_when_content_missing()
+    {
+        var cut = Render<Quilt4SplitButton>(parameters => parameters
+            .Add(p => p.TextKey, "split.missing")
+            .Add(p => p.DefaultText, "Fallback Primary"));
+
+        cut.Markup.Should().Contain("Fallback Primary");
+    }
+
+    [Fact]
+    public void Renders_menu_items_with_localized_text()
+    {
+        _contentService.Set("item.edit", "Edit");
+        _contentService.Set("item.delete", "Delete");
+
+        var cut = Render<Quilt4SplitButton>(parameters => parameters
+            .Add(p => p.TextKey, "split.actions")
+            .Add(p => p.DefaultText, "Actions")
+            .Add(p => p.Items, new List<Quilt4SplitButtonItem>
+            {
+                new() { TextKey = "item.edit", DefaultText = "Edit default", Value = "edit" },
+                new() { TextKey = "item.delete", DefaultText = "Delete default", Value = "delete" },
+            }));
+
+        cut.Markup.Should().Contain("Edit");
+        cut.Markup.Should().Contain("Delete");
+    }
+
+    [Fact]
+    public void Item_falls_back_to_default_when_content_missing()
+    {
+        var cut = Render<Quilt4SplitButton>(parameters => parameters
+            .Add(p => p.TextKey, "split.actions")
+            .Add(p => p.DefaultText, "Actions")
+            .Add(p => p.Items, new List<Quilt4SplitButtonItem>
+            {
+                new() { TextKey = "item.missing", DefaultText = "Item Fallback", Value = "x" },
+            }));
+
+        cut.Markup.Should().Contain("Item Fallback");
+    }
+
+    [Fact]
+    public void Updates_text_on_language_change()
+    {
+        _contentService.Set("split.save", "Save");
+
+        var cut = Render<Quilt4SplitButton>(parameters => parameters
+            .Add(p => p.TextKey, "split.save")
+            .Add(p => p.DefaultText, "Save"));
+
+        cut.Markup.Should().Contain("Save");
+
+        _contentService.Set("split.save", "Spara");
+        _languageStateService.RaiseLanguageChanged();
+
+        cut.WaitForState(() => cut.Markup.Contains("Spara"));
+        cut.Markup.Should().Contain("Spara");
+    }
+
+    [Fact]
+    public void Disabled_disables_the_primary_button()
+    {
+        _contentService.Set("split.save", "Save");
+
+        var cut = Render<Quilt4SplitButton>(parameters => parameters
+            .Add(p => p.TextKey, "split.save")
+            .Add(p => p.DefaultText, "Save")
+            .Add(p => p.Disabled, true));
+
+        cut.FindAll("button").Should().Contain(b => b.HasAttribute("disabled"));
+    }
+
+    [Fact]
+    public void Busy_shows_the_busy_text()
+    {
+        var cut = Render<Quilt4SplitButton>(parameters => parameters
+            .Add(p => p.TextKey, "split.save")
+            .Add(p => p.DefaultText, "Save")
+            .Add(p => p.Busy, true)
+            .Add(p => p.BusyTextKey, "split.save.busy")
+            .Add(p => p.DefaultBusyText, "Saving…"));
+
+        cut.Markup.Should().Contain("Saving…");
+    }
+
+    [Fact]
+    public void Primary_click_invokes_Click_handler()
+    {
+        _contentService.Set("split.save", "Save");
+        var clicked = false;
+
+        var cut = Render<Quilt4SplitButton>(parameters => parameters
+            .Add(p => p.TextKey, "split.save")
+            .Add(p => p.DefaultText, "Save")
+            .Add(p => p.Click, () => { clicked = true; return Task.CompletedTask; }));
+
+        cut.FindAll("button")[0].Click();
+
+        clicked.Should().BeTrue();
+    }
+
+    private class FakeContentService : IContentService
+    {
+        private readonly Dictionary<string, string> _values = new();
+
+        public void Set(string key, string value) => _values[key] = value;
+
+        public Task<(string Value, bool Success)> GetContentAsync(string key, string defaultValue, Guid languageKey, ContentFormat? contentType, string application = null)
+        {
+            if (!string.IsNullOrEmpty(key) && _values.TryGetValue(key, out var value))
+                return Task.FromResult((value, true));
+            return Task.FromResult((defaultValue ?? "", false));
+        }
+
+        public Task SetContentAsync(string key, string value, Guid languageKey, ContentFormat contentType, string application = null) => Task.CompletedTask;
+        public Task ClearCacheAsync() => Task.CompletedTask;
+    }
+
+    private class FakeLanguageStateService : ILanguageStateService
+    {
+        public event EventHandler<LanguageLoadedEventArgs> LanguageLoadedEvent;
+        public event EventHandler<LanguageChangedEventArgs> LanguageChangedEvent;
+        public event EventHandler<DeveloperModeEventArgs> DeveloperModeEvent;
+        public Language Selected { get; set; }
+        public Language[] Languages { get; set; } = [];
+        public bool DeveloperMode { get; set; }
+        public Task<Language[]> ReloadAsync() => Task.FromResult(Languages);
+
+        public void RaiseLanguageChanged()
+        {
+            LanguageChangedEvent?.Invoke(this, new LanguageChangedEventArgs());
+        }
+    }
+}

--- a/Quilt4Net.Toolkit.Blazor.Tests/Quilt4TextDefaultsTests.cs
+++ b/Quilt4Net.Toolkit.Blazor.Tests/Quilt4TextDefaultsTests.cs
@@ -1,0 +1,147 @@
+using System.Globalization;
+using Bunit;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Quilt4Net.Toolkit.Blazor;
+using Quilt4Net.Toolkit.Features.Content;
+using Quilt4Net.Toolkit.Features.FeatureToggle;
+using Radzen;
+using Xunit;
+
+namespace Quilt4Net.Toolkit.Blazor.Tests;
+
+// Issue #135: authoritative per-language default text. A content key can declare a default per
+// language (at least en + sv); the default shown before/without a stored translation is chosen by:
+// active-UI-culture code default -> English ("en" or the single Default) -> key. Backward compatible
+// with the single-Default flow.
+public class Quilt4TextDefaultsTests
+{
+    [Theory]
+    [InlineData("sv", "Ärendemening")]   // active culture matches
+    [InlineData("nb", "Case subject")]   // active culture missing -> English "en"
+    public void Resolver_picks_active_culture_then_english(string culture, string expected)
+    {
+        var defaults = new Dictionary<string, string> { ["en"] = "Case subject", ["sv"] = "Ärendemening" };
+
+        LanguageDefaultResolver.Resolve(defaults, invariantDefault: null, key: "case.subject", activeCultureCode: culture)
+            .Should().Be(expected);
+    }
+
+    [Fact]
+    public void Resolver_is_case_insensitive_on_language_code()
+    {
+        var defaults = new Dictionary<string, string> { ["SV"] = "Ärendemening" };
+
+        LanguageDefaultResolver.Resolve(defaults, null, "case.subject", "sv").Should().Be("Ärendemening");
+    }
+
+    [Fact]
+    public void Resolver_falls_back_to_single_default_as_english_then_key()
+    {
+        // No dictionary match and no "en" entry -> the single invariant Default acts as English.
+        LanguageDefaultResolver.Resolve(new Dictionary<string, string> { ["de"] = "Betreff" }, "Case subject", "case.subject", "sv")
+            .Should().Be("Case subject");
+
+        // Nothing at all -> the key.
+        LanguageDefaultResolver.Resolve(null, null, "case.subject", "sv").Should().Be("case.subject");
+    }
+
+    [Fact]
+    public void Quilt4Text_renders_active_culture_default_when_no_stored_value()
+    {
+        var original = CultureInfo.CurrentUICulture;
+        try
+        {
+            CultureInfo.CurrentUICulture = new CultureInfo("sv");
+            using var ctx = new BunitContext();
+            ctx.Services.AddSingleton<IContentService>(new NotFoundContentService());
+            ctx.Services.AddSingleton<IEditContentService>(new StubEditContentService());
+            ctx.Services.AddSingleton<ILanguageStateService>(new StubLanguageState());
+            ctx.Services.AddScoped<DialogService>();
+
+            var cut = ctx.Render<Quilt4Text>(p => p
+                .Add(x => x.Key, "case.subject")
+                .Add(x => x.Default, "Case subject")
+                .Add(x => x.Defaults, new Dictionary<string, string> { ["en"] = "Case subject", ["sv"] = "Ärendemening" }));
+
+            cut.Markup.Should().Contain("Ärendemening",
+                "on a Swedish UI culture the authoritative Swedish default must render before any stored translation exists");
+            cut.Markup.Should().NotContain("Case subject");
+        }
+        finally
+        {
+            CultureInfo.CurrentUICulture = original;
+        }
+    }
+
+    [Fact]
+    public void Quilt4Text_prefers_stored_value_over_per_language_default()
+    {
+        var original = CultureInfo.CurrentUICulture;
+        try
+        {
+            CultureInfo.CurrentUICulture = new CultureInfo("sv");
+            using var ctx = new BunitContext();
+            ctx.Services.AddSingleton<IContentService>(new StoredValueContentService("Diarienummer (stored)"));
+            ctx.Services.AddSingleton<IEditContentService>(new StubEditContentService());
+            ctx.Services.AddSingleton<ILanguageStateService>(new StubLanguageState());
+            ctx.Services.AddScoped<DialogService>();
+
+            var cut = ctx.Render<Quilt4Text>(p => p
+                .Add(x => x.Key, "case.diary")
+                .Add(x => x.Defaults, new Dictionary<string, string> { ["sv"] = "Diarienummer (default)" }));
+
+            cut.Markup.Should().Contain("Diarienummer (stored)");
+            cut.Markup.Should().NotContain("(default)");
+        }
+        finally
+        {
+            CultureInfo.CurrentUICulture = original;
+        }
+    }
+
+    private sealed class NotFoundContentService : IContentService
+    {
+        public Task<(string Value, bool Success)> GetContentAsync(string key, string defaultValue, Guid languageKey, ContentFormat? contentType, string application = null)
+            => Task.FromResult((defaultValue ?? "", false));
+        public Task SetContentAsync(string key, string value, Guid languageKey, ContentFormat contentType, string application = null) => Task.CompletedTask;
+        public Task ClearCacheAsync() => Task.CompletedTask;
+    }
+
+    private sealed class StoredValueContentService : IContentService
+    {
+        private readonly string _stored;
+        public StoredValueContentService(string stored) => _stored = stored;
+        public Task<(string Value, bool Success)> GetContentAsync(string key, string defaultValue, Guid languageKey, ContentFormat? contentType, string application = null)
+            => Task.FromResult((_stored, true));
+        public Task SetContentAsync(string key, string value, Guid languageKey, ContentFormat contentType, string application = null) => Task.CompletedTask;
+        public Task ClearCacheAsync() => Task.CompletedTask;
+    }
+
+    private sealed class StubEditContentService : IEditContentService
+    {
+        public event EventHandler<EditModeEventArgs> EditModeEvent;
+        public bool Enabled { get; set; }
+        private void Unused() => EditModeEvent?.Invoke(this, null);
+    }
+
+    private sealed class StubLanguageState : ILanguageStateService
+    {
+        public event EventHandler<LanguageLoadedEventArgs> LanguageLoadedEvent;
+        public event EventHandler<LanguageChangedEventArgs> LanguageChangedEvent;
+        public event EventHandler<DeveloperModeEventArgs> DeveloperModeEvent;
+
+        public Language Selected { get; set; } = new() { Name = "Swedish", Key = Guid.NewGuid() };
+        public Language[] Languages { get; set; } = [];
+        public bool DeveloperMode { get; set; }
+
+        public Task<Language[]> ReloadAsync() => Task.FromResult(Languages);
+
+        private void Unused()
+        {
+            LanguageLoadedEvent?.Invoke(this, null);
+            LanguageChangedEvent?.Invoke(this, null);
+            DeveloperModeEvent?.Invoke(this, null);
+        }
+    }
+}

--- a/Quilt4Net.Toolkit.Blazor/IQuilt4ContentService.cs
+++ b/Quilt4Net.Toolkit.Blazor/IQuilt4ContentService.cs
@@ -19,4 +19,19 @@ public interface IQuilt4ContentService
     /// </list>
     /// </param>
     Task<string> GetAsync(string key, string defaultValue, string application = null);
+
+    /// <summary>
+    /// Get content by key using the currently selected language, with an authoritative default text
+    /// declared per language (issue #135) — for domain-critical vocabulary whose wording must be
+    /// correct before or without a stored/translated value (e.g. legal/archival terms).
+    /// </summary>
+    /// <param name="key">Content key.</param>
+    /// <param name="defaultsByLanguage">
+    /// Default text keyed by two-letter ISO language code (e.g. <c>"en"</c>, <c>"sv"</c>), matched
+    /// case-insensitively. The default used is chosen by this chain: code default for the active UI
+    /// culture → English (<c>"en"</c>) code default → the content key. A stored translation for the
+    /// selected language still takes precedence over the resolved default.
+    /// </param>
+    /// <param name="application">Application scope; see <see cref="GetAsync(string, string, string)"/>.</param>
+    Task<string> GetAsync(string key, IReadOnlyDictionary<string, string> defaultsByLanguage, string application = null);
 }

--- a/Quilt4Net.Toolkit.Blazor/LanguageDefaultResolver.cs
+++ b/Quilt4Net.Toolkit.Blazor/LanguageDefaultResolver.cs
@@ -1,0 +1,56 @@
+using System.Globalization;
+
+namespace Quilt4Net.Toolkit.Blazor;
+
+/// <summary>
+/// Resolves the authoritative <em>default</em> text for a content key when a per-language default
+/// set is supplied (issue #135). Domain-critical vocabulary (e.g. Swedish legal/archival terms) can
+/// declare an authoritative default per language so the correct wording renders before — or without —
+/// any stored/translated value, bypassing lossy machine translation.
+///
+/// The caller passes the resolved value as the <c>defaultValue</c> to
+/// <c>IContentService.GetContentAsync</c>, so a stored translation (when present) still takes
+/// precedence. The default itself is chosen with this fallback chain:
+/// <list type="number">
+/// <item>code default for the active UI culture (<see cref="CultureInfo.CurrentUICulture"/>, two-letter ISO code);</item>
+/// <item>English code default (<c>"en"</c> in the set, or the single invariant default);</item>
+/// <item>the content key.</item>
+/// </list>
+/// Language-code lookups are case-insensitive.
+/// </summary>
+internal static class LanguageDefaultResolver
+{
+    public static string Resolve(IReadOnlyDictionary<string, string> defaultsByLanguage, string invariantDefault, string key)
+        => Resolve(defaultsByLanguage, invariantDefault, key, CultureInfo.CurrentUICulture.TwoLetterISOLanguageName);
+
+    public static string Resolve(IReadOnlyDictionary<string, string> defaultsByLanguage, string invariantDefault, string key, string activeCultureCode)
+    {
+        if (defaultsByLanguage is { Count: > 0 })
+        {
+            if (TryGet(defaultsByLanguage, activeCultureCode, out var forCulture)) return forCulture;
+            if (TryGet(defaultsByLanguage, "en", out var forEnglish)) return forEnglish;
+        }
+
+        // The single Default is treated as the English/default-language default (backward compatible).
+        if (!string.IsNullOrEmpty(invariantDefault)) return invariantDefault;
+
+        return key;
+    }
+
+    private static bool TryGet(IReadOnlyDictionary<string, string> defaults, string code, out string value)
+    {
+        value = null;
+        if (string.IsNullOrEmpty(code)) return false;
+
+        foreach (var kv in defaults)
+        {
+            if (string.Equals(kv.Key, code, StringComparison.OrdinalIgnoreCase) && !string.IsNullOrEmpty(kv.Value))
+            {
+                value = kv.Value;
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/Quilt4Net.Toolkit.Blazor/LanguageStateService.cs
+++ b/Quilt4Net.Toolkit.Blazor/LanguageStateService.cs
@@ -1,4 +1,6 @@
-﻿using Blazored.LocalStorage;
+﻿using System.Diagnostics;
+using Blazored.LocalStorage;
+using Microsoft.Extensions.Logging;
 using Microsoft.JSInterop;
 using Quilt4Net.Toolkit.Features.Content;
 
@@ -9,15 +11,17 @@ internal class LanguageStateService : ILanguageStateService
     private readonly ILanguageService _languageService;
     private readonly ILocalStorageService _localStorageService;
     private readonly IRemoteContentCallService _remoteContentCallService;
+    private readonly ILogger<LanguageStateService> _logger;
     private Language _selected;
     private bool _developerMode;
     private readonly Language _defaultLanguage;
 
-    public LanguageStateService(ILanguageService languageService, ILocalStorageService localStorageService, IRemoteContentCallService remoteContentCallService)
+    public LanguageStateService(ILanguageService languageService, ILocalStorageService localStorageService, IRemoteContentCallService remoteContentCallService, ILogger<LanguageStateService> logger)
     {
         _languageService = languageService;
         _localStorageService = localStorageService;
         _remoteContentCallService = remoteContentCallService;
+        _logger = logger;
         _defaultLanguage = new Language { Name = null };
 
         Task.Run(async () =>
@@ -54,6 +58,7 @@ internal class LanguageStateService : ILanguageStateService
         {
             if (_developerMode == value) return;
             _developerMode = value;
+            _logger.LogDebug("Developer mode set to {DeveloperMode}; reloading languages.", value);
             Task.Run(async () =>
             {
                 await ReloadAsync(false);
@@ -69,6 +74,10 @@ internal class LanguageStateService : ILanguageStateService
 
     public async Task<Language[]> ReloadAsync(bool forceReload)
     {
+        // #132: bracket the language reload with timing so a spinning selector can be attributed to
+        // the language load specifically. Debug — opt-in via log config.
+        var sw = Stopwatch.StartNew();
+        _logger.LogDebug("Reloading languages (forceReload: {ForceReload}, developerMode: {DeveloperMode}).", forceReload, DeveloperMode);
         var languages = await _languageService.GetLanguagesAsync(forceReload);
         if (DeveloperMode)
         {
@@ -100,6 +109,9 @@ internal class LanguageStateService : ILanguageStateService
             _selected = languages.Single(x => x.Key == Selected.Key);
         }
 
+        _logger.LogDebug("Languages reloaded in {Elapsed}ms: {Count} language(s); selected '{Selected}'.",
+            sw.ElapsedMilliseconds, Languages?.Length ?? 0, Selected?.Name);
+
         return languages;
     }
 
@@ -110,6 +122,8 @@ internal class LanguageStateService : ILanguageStateService
         {
             if (_selected?.Key != value?.Key)
             {
+                _logger.LogDebug("Selected language changing from '{From}' to '{To}' (key {Key}); raising LanguageChangedEvent to trigger content reload.",
+                    _selected?.Name, value?.Name, value?.Key);
                 _selected = value;
                 Task.Run(async () =>
                 {

--- a/Quilt4Net.Toolkit.Blazor/Quilt4Button.razor
+++ b/Quilt4Net.Toolkit.Blazor/Quilt4Button.razor
@@ -8,10 +8,14 @@
               Icon="@Icon"
               Click="@Click"
               Style="@Style"
+              Disabled="@Disabled"
+              IsBusy="@Busy"
+              BusyText="@_busyText"
               Attributes="@_attributes" />
 
 @code {
     private string _text;
+    private string _busyText;
     // RadzenButton renders unknown DOM attributes from its `Attributes` dictionary. We use
     // it to set the native HTML `title` for tooltips so icon-only buttons can carry a
     // localised hover-text without TooltipService plumbing. Null/empty title attribute is
@@ -32,6 +36,30 @@
 
     [Parameter]
     public string Style{ get; set; }
+
+    /// <summary>When <c>true</c> the button is disabled (mirrors
+    /// <c>RadzenButton.Disabled</c>). Use to guard against clicks while a precondition
+    /// isn't met.</summary>
+    [Parameter]
+    public bool Disabled { get; set; }
+
+    /// <summary>When <c>true</c> the button shows an in-button spinner and is
+    /// non-interactive (mirrors <c>RadzenButton.IsBusy</c>). Set this for the duration of a
+    /// slow async <see cref="Click"/> handler to give feedback and prevent double-clicks.</summary>
+    [Parameter]
+    public bool Busy { get; set; }
+
+    /// <summary>Optional content key for the label shown while <see cref="Busy"/> is
+    /// <c>true</c> (e.g. "Saving…"). Falls back to <see cref="DefaultBusyText"/> on miss /
+    /// empty / lookup failure; when both are unset the button keeps its normal label next to
+    /// the spinner.</summary>
+    [Parameter]
+    public string BusyTextKey { get; set; }
+
+    /// <summary>Fallback busy label used when <see cref="BusyTextKey"/> isn't set or the
+    /// lookup yields nothing. Set this alone for a static, non-localised busy label.</summary>
+    [Parameter]
+    public string DefaultBusyText { get; set; }
 
     /// <summary>Optional content key resolved for the button's hover tooltip (HTML
     /// <c>title</c> attribute). Falls back to <see cref="DefaultTooltip"/> on miss / empty /
@@ -62,6 +90,7 @@
     private async Task LoadContentAsync()
     {
         _text = (await ContentService.GetContentAsync(TextKey, DefaultText, LanguageStateService.Selected.Key, ContentFormat.String)).Value;
+        _busyText = await PlaceholderResolver.ResolveAsync(ContentService, LanguageStateService, BusyTextKey, DefaultBusyText);
         var tooltip = await PlaceholderResolver.ResolveAsync(ContentService, LanguageStateService, TooltipKey, DefaultTooltip);
         _attributes = string.IsNullOrEmpty(tooltip)
             ? null

--- a/Quilt4Net.Toolkit.Blazor/Quilt4Content.razor
+++ b/Quilt4Net.Toolkit.Blazor/Quilt4Content.razor
@@ -1,6 +1,4 @@
-﻿@using System.Net.Http.Json
-@using System.Text.RegularExpressions
-@using Microsoft.AspNetCore.Components.Web
+﻿@using Microsoft.AspNetCore.Components.Web
 @using Microsoft.Extensions.Logging
 @using Microsoft.JSInterop
 @using Quilt4Net.Toolkit.Features.Content
@@ -71,53 +69,40 @@
 
         if (string.IsNullOrEmpty(_content) && _mod is not null)
         {
-            string defaultHtml;
             if (ChildContent is null)
             {
-                try
-                {
-                    using var client = new HttpClient();
-                    var item = await client.GetAsync("https://lorem-api.com/api/article/foo");
-                    var payload = await item.Content.ReadFromJsonAsync<Article>();
-                    defaultHtml = payload.content;
-                }
-                catch (Exception)
-                {
-                    defaultHtml = $"No content for '{Key}'.";
-                }
+                // No default was supplied and the key has no stored value: render a local
+                // placeholder. We deliberately do NOT persist it — auto-registering scaffolding
+                // text (previously fetched from the external lorem-api.com) as the key's default
+                // corrupts the content store and leaks a network call from every consumer app.
+                _content = $"No content for '{Key}'.";
             }
             else
             {
-                defaultHtml = await _mod.InvokeAsync<string>("getInnerHtml", _holder);
+                var defaultHtml = await _mod.InvokeAsync<string>("getInnerHtml", _holder);
+
+                if (_response.Success)
+                {
+                    // Auto-registering the default value is best-effort: a transient HTTP failure
+                    // (401, server unreachable, etc.) must not crash the consuming page — the
+                    // component still renders the captured default below. Reads already behave this
+                    // way; this matches them.
+                    try
+                    {
+                        await ContentService.SetContentAsync(Key, defaultHtml, Guid.Empty, ContentFormat.Html);
+                    }
+                    catch (Exception e)
+                    {
+                        Logger.LogWarning(e, "Failed to auto-register default content for key '{Key}'. Rendering fallback.", Key);
+                    }
+                }
+
+                _content = defaultHtml;
             }
 
-            if (_response.Success)
-            {
-                // Auto-registering the default value is best-effort: a transient HTTP failure
-                // (401, server unreachable, etc.) must not crash the consuming page — the
-                // component still renders the Default fallback below. Reads already behave this
-                // way; this matches them.
-                try
-                {
-                    await ContentService.SetContentAsync(Key, defaultHtml, Guid.Empty, ContentFormat.Html);
-                }
-                catch (Exception e)
-                {
-                    Logger.LogWarning(e, "Failed to auto-register default content for key '{Key}'. Rendering fallback.", Key);
-                }
-            }
-
-            _content = defaultHtml;
             StateHasChanged();
         }
     }
-
-    private static readonly Regex _blazorAttrs = new(
-        @"\s@(?:onclick|on\w+|bind(?:-\w+)?|ref|attributes)\s*=\s*""[^""]*""",
-        RegexOptions.IgnoreCase | RegexOptions.Compiled);
-
-    private static string Sanitize(string html) =>
-        string.IsNullOrEmpty(html) ? string.Empty : _blazorAttrs.Replace(html, "");
 
     private async Task OnKeyDown(KeyboardEventArgs e)
     {
@@ -142,10 +127,5 @@
         _response = await ContentService.GetContentAsync(Key, null, LanguageStateService.Selected?.Key ?? Guid.Empty, null);
         _content = _response.Value;
         StateHasChanged();
-    }
-
-    public record Article
-    {
-        public string content { get; set; }
     }
 }

--- a/Quilt4Net.Toolkit.Blazor/Quilt4ContentService.cs
+++ b/Quilt4Net.Toolkit.Blazor/Quilt4ContentService.cs
@@ -19,4 +19,13 @@ internal class Quilt4ContentService : IQuilt4ContentService
         var result = await _contentService.GetContentAsync(key, defaultValue, _languageStateService.Selected.Key, ContentFormat.String, application);
         return result.Value;
     }
+
+    public async Task<string> GetAsync(string key, IReadOnlyDictionary<string, string> defaultsByLanguage, string application = null)
+    {
+        // Resolve the authoritative default for the active culture, then let a stored translation for
+        // the selected language win over it inside GetContentAsync (issue #135).
+        var codeDefault = LanguageDefaultResolver.Resolve(defaultsByLanguage, invariantDefault: null, key);
+        var result = await _contentService.GetContentAsync(key, codeDefault, _languageStateService.Selected.Key, ContentFormat.String, application);
+        return result.Value;
+    }
 }

--- a/Quilt4Net.Toolkit.Blazor/Quilt4Net.Toolkit.Blazor.csproj
+++ b/Quilt4Net.Toolkit.Blazor/Quilt4Net.Toolkit.Blazor.csproj
@@ -26,8 +26,8 @@
        consumers can fetch _content/Quilt4Net.Toolkit.Blazor/<asset> at runtime. -->
   <ItemGroup>
     <PackageReference Include="Microsoft.Authentication.WebAssembly.Msal" Version="10.0.9" />
-    <PackageReference Include="Microsoft.Identity.Client" Version="4.85.2" />
-    <PackageReference Include="Tharga.Blazor" Version="2.2.0" />
+    <PackageReference Include="Microsoft.Identity.Client" Version="4.86.0" />
+    <PackageReference Include="Tharga.Blazor" Version="2.2.1" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Quilt4Net.Toolkit\Quilt4Net.Toolkit.csproj" />

--- a/Quilt4Net.Toolkit.Blazor/Quilt4SplitButton.razor
+++ b/Quilt4Net.Toolkit.Blazor/Quilt4SplitButton.razor
@@ -1,0 +1,120 @@
+@using Quilt4Net.Toolkit.Features.Content
+@inject IContentService ContentService
+@inject ILanguageStateService LanguageStateService
+
+<RadzenSplitButton Text="@_text"
+                   Icon="@Icon"
+                   Click="@OnClickAsync"
+                   Style="@Style"
+                   Disabled="@Disabled"
+                   IsBusy="@Busy"
+                   BusyText="@_busyText">
+    @foreach (var resolved in _items)
+    {
+        <RadzenSplitButtonItem Text="@resolved.Text"
+                               Value="@resolved.Item.Value"
+                               Icon="@resolved.Item.Icon"
+                               Disabled="@resolved.Item.Disabled" />
+    }
+</RadzenSplitButton>
+
+@code {
+    private string _text;
+    private string _busyText;
+    private IReadOnlyList<ResolvedItem> _items = [];
+
+    /// <summary>Content key for the primary button label.</summary>
+    [Parameter]
+    public string TextKey { get; set; }
+
+    /// <summary>Fallback label used when <see cref="TextKey"/> is unset or the lookup misses.</summary>
+    [Parameter]
+    public string DefaultText { get; set; }
+
+    /// <summary>Optional Radzen icon name for the primary button.</summary>
+    [Parameter]
+    public string Icon { get; set; }
+
+    /// <summary>Inline style forwarded to the underlying <c>RadzenSplitButton</c>.</summary>
+    [Parameter]
+    public string Style { get; set; }
+
+    /// <summary>When <c>true</c> the whole split button is disabled (primary + menu).</summary>
+    [Parameter]
+    public bool Disabled { get; set; }
+
+    /// <summary>When <c>true</c> the primary button shows an in-button spinner and is
+    /// non-interactive (mirrors <c>RadzenSplitButton.IsBusy</c>). Set this for the duration of
+    /// a slow async <see cref="Click"/> handler to give feedback and prevent double-clicks.</summary>
+    [Parameter]
+    public bool Busy { get; set; }
+
+    /// <summary>Optional content key for the label shown while <see cref="Busy"/> is
+    /// <c>true</c> (e.g. "Saving…"). Falls back to <see cref="DefaultBusyText"/> on miss.</summary>
+    [Parameter]
+    public string BusyTextKey { get; set; }
+
+    /// <summary>Fallback busy label used when <see cref="BusyTextKey"/> isn't set or the
+    /// lookup yields nothing.</summary>
+    [Parameter]
+    public string DefaultBusyText { get; set; }
+
+    /// <summary>Invoked when the primary button (not a menu item) is clicked.</summary>
+    [Parameter]
+    public Func<Task> Click { get; set; }
+
+    /// <summary>The drop-down menu items. Each item's label is content-localised from its
+    /// <see cref="Quilt4SplitButtonItem.TextKey"/> / <see cref="Quilt4SplitButtonItem.DefaultText"/>.</summary>
+    [Parameter]
+    public IReadOnlyList<Quilt4SplitButtonItem> Items { get; set; }
+
+    /// <summary>Invoked with the chosen item's <see cref="Quilt4SplitButtonItem.Value"/> when a
+    /// menu item is clicked.</summary>
+    [Parameter]
+    public Func<string, Task> ItemClick { get; set; }
+
+    protected override async Task OnInitializedAsync()
+    {
+        LanguageStateService.LanguageChangedEvent += async (_, _) =>
+        {
+            await LoadContentAsync();
+            await InvokeAsync(StateHasChanged);
+        };
+
+        await LoadContentAsync();
+
+        await base.OnInitializedAsync();
+    }
+
+    private async Task LoadContentAsync()
+    {
+        _text = await PlaceholderResolver.ResolveAsync(ContentService, LanguageStateService, TextKey, DefaultText);
+        _busyText = await PlaceholderResolver.ResolveAsync(ContentService, LanguageStateService, BusyTextKey, DefaultBusyText);
+
+        var resolved = new List<ResolvedItem>();
+        if (Items != null)
+        {
+            foreach (var item in Items)
+            {
+                var text = await PlaceholderResolver.ResolveAsync(ContentService, LanguageStateService, item.TextKey, item.DefaultText);
+                resolved.Add(new ResolvedItem(item, text));
+            }
+        }
+
+        _items = resolved;
+    }
+
+    private async Task OnClickAsync(RadzenSplitButtonItem item)
+    {
+        if (item is null)
+        {
+            if (Click != null) await Click();
+        }
+        else if (ItemClick != null)
+        {
+            await ItemClick(item.Value);
+        }
+    }
+
+    private sealed record ResolvedItem(Quilt4SplitButtonItem Item, string Text);
+}

--- a/Quilt4Net.Toolkit.Blazor/Quilt4SplitButtonItem.cs
+++ b/Quilt4Net.Toolkit.Blazor/Quilt4SplitButtonItem.cs
@@ -1,0 +1,25 @@
+namespace Quilt4Net.Toolkit.Blazor;
+
+/// <summary>
+/// A menu item for <see cref="Quilt4SplitButton"/>. The label is content-localised from
+/// <see cref="TextKey"/> with <see cref="DefaultText"/> as the fallback — the same
+/// resolution <c>Quilt4Button</c> and <c>Quilt4Text</c> use. <see cref="Value"/> is handed
+/// back to the split button's item-click handler to identify which item was chosen.
+/// </summary>
+public sealed class Quilt4SplitButtonItem
+{
+    /// <summary>Content key for the item label.</summary>
+    public string TextKey { get; init; }
+
+    /// <summary>Fallback label used when <see cref="TextKey"/> is unset or the lookup misses.</summary>
+    public string DefaultText { get; init; }
+
+    /// <summary>Opaque value passed to the split button's item-click handler when this item is chosen.</summary>
+    public string Value { get; init; }
+
+    /// <summary>Optional Radzen icon name shown before the label.</summary>
+    public string Icon { get; init; }
+
+    /// <summary>When <c>true</c> the item renders disabled and cannot be chosen.</summary>
+    public bool Disabled { get; init; }
+}

--- a/Quilt4Net.Toolkit.Blazor/Quilt4Text.razor
+++ b/Quilt4Net.Toolkit.Blazor/Quilt4Text.razor
@@ -20,6 +20,16 @@
     [Parameter]
     public string Default { get; set; }
 
+    /// <summary>
+    /// Optional authoritative default text per language (issue #135), keyed by two-letter ISO code
+    /// (e.g. <c>"en"</c>, <c>"sv"</c>). When set, the default shown before/without a stored
+    /// translation is chosen by: active-UI-culture code default → English (<c>"en"</c> here or
+    /// <see cref="Default"/>) → key. Use for domain-critical vocabulary whose wording must be correct
+    /// out-of-the-box (e.g. legal/archival terms). Leave unset for the ordinary single-<see cref="Default"/> flow.
+    /// </summary>
+    [Parameter]
+    public IReadOnlyDictionary<string, string> Defaults { get; set; }
+
     [Parameter]
     public TextStyle TextStyle { get; set; } = TextStyle.Body1;
 
@@ -50,7 +60,12 @@
 
     private async Task LoadContentAsync()
     {
-        _response = await ContentService.GetContentAsync(Key, Default, LanguageStateService.Selected?.Key ?? Guid.Empty, ContentFormat.String);
+        // Backward compatible: with no per-language Defaults, pass Default through unchanged. When
+        // Defaults is supplied, resolve the authoritative default for the active culture (#135).
+        var effectiveDefault = Defaults is { Count: > 0 }
+            ? LanguageDefaultResolver.Resolve(Defaults, Default, Key)
+            : Default;
+        _response = await ContentService.GetContentAsync(Key, effectiveDefault, LanguageStateService.Selected?.Key ?? Guid.Empty, ContentFormat.String);
         _content = _response.Value;
     }
 

--- a/Quilt4Net.Toolkit.Blazor/README.md
+++ b/Quilt4Net.Toolkit.Blazor/README.md
@@ -36,7 +36,7 @@ builder.AddQuilt4NetBlazorContent(o =>
 
 Two shapes ship in this package, with the same purpose — render text managed via Quilt4Net.Server in a Blazor app and have it switch language live without per-component plumbing.
 
-- **Standalone components** (`Quilt4Text`, `Quilt4Content`, `Quilt4Span`, `Quilt4Raw`, `Quilt4Button`, `Quilt4PageTitle`) — content-aware controls. Drop them in where you'd otherwise hard-code a string.
+- **Standalone components** (`Quilt4Text`, `Quilt4Content`, `Quilt4Span`, `Quilt4Raw`, `Quilt4Button`, `Quilt4SplitButton`, `Quilt4PageTitle`) — content-aware controls. Drop them in where you'd otherwise hard-code a string.
 - **Content-aware Radzen wrappers** (`Quilt4Radzen*`) — thin wrappers around Radzen components that resolve a specific `string` attribute (Text / Title / Placeholder / EmptyText / Tooltip) through the content service. Drop them in where the only thing you need to localise on a Radzen control is one or two text attributes.
 
 Every component below:
@@ -127,6 +127,38 @@ Renders a Radzen button with managed text — and, optionally, a managed hover t
 | `Busy` | Shows an in-button spinner and blocks clicks while set (mirrors `RadzenButton.IsBusy`). Set it around a slow async `Click` for feedback and double-click protection. |
 | `BusyTextKey` | Optional content key for the label shown while `Busy` (e.g. "Saving…"). |
 | `DefaultBusyText` | Optional fallback busy label. Set without `BusyTextKey` for a static, non-localised busy label; leave both unset to keep the normal label next to the spinner. |
+
+#### Quilt4SplitButton
+
+Wraps `RadzenSplitButton` with managed text on both the primary button and every drop-down item — the content-localized counterpart of a split button. Use it for per-row "primary action + menu of secondary actions" without hand-resolving each label via `IQuilt4ContentService.GetAsync`.
+
+```razor
+<Quilt4SplitButton TextKey="row.open" DefaultText="Open" Icon="folder_open"
+                   Click="@OnOpen"
+                   Items="_actions" ItemClick="@OnAction" />
+
+@code {
+    private readonly IReadOnlyList<Quilt4SplitButtonItem> _actions =
+    [
+        new() { TextKey = "row.rename", DefaultText = "Rename", Value = "rename", Icon = "edit" },
+        new() { TextKey = "row.delete", DefaultText = "Delete", Value = "delete", Icon = "delete", Disabled = false },
+    ];
+
+    private Task OnOpen() => /* primary action */;
+    private Task OnAction(string value) => value switch { "rename" => Rename(), "delete" => Delete(), _ => Task.CompletedTask };
+}
+```
+
+| Parameter | Description |
+|-----------|-------------|
+| `TextKey` / `DefaultText` | Content key + fallback for the primary button label. |
+| `Icon` | Radzen icon name for the primary button. |
+| `Click` | Async handler for the primary button (`Func<Task>`). |
+| `Items` | The drop-down items (`Quilt4SplitButtonItem`): each has `TextKey` / `DefaultText` (localized label), `Value`, `Icon`, `Disabled`. |
+| `ItemClick` | Async handler invoked with the chosen item's `Value` (`Func<string, Task>`). |
+| `Disabled` | Disables the whole split button. |
+| `Busy` / `BusyTextKey` / `DefaultBusyText` | In-button spinner + optional localized busy label (as `Quilt4Button`). |
+| `Style` | Custom CSS styles. |
 
 #### Quilt4PageTitle
 

--- a/Quilt4Net.Toolkit.Blazor/README.md
+++ b/Quilt4Net.Toolkit.Blazor/README.md
@@ -115,6 +115,10 @@ Renders a Radzen button with managed text — and, optionally, a managed hover t
 | `DefaultTooltip` | Optional fallback tooltip text. Set without `TooltipKey` for a static, non-localised tooltip. |
 | `Click` | Async click handler (`Func<Task>`). |
 | `Style` | Custom CSS styles. |
+| `Disabled` | Disables the button (mirrors `RadzenButton.Disabled`). |
+| `Busy` | Shows an in-button spinner and blocks clicks while set (mirrors `RadzenButton.IsBusy`). Set it around a slow async `Click` for feedback and double-click protection. |
+| `BusyTextKey` | Optional content key for the label shown while `Busy` (e.g. "Saving…"). |
+| `DefaultBusyText` | Optional fallback busy label. Set without `BusyTextKey` for a static, non-localised busy label; leave both unset to keep the normal label next to the spinner. |
 
 #### Quilt4PageTitle
 

--- a/Quilt4Net.Toolkit.Blazor/README.md
+++ b/Quilt4Net.Toolkit.Blazor/README.md
@@ -58,10 +58,18 @@ Renders plain text using a Radzen `TextStyle`.
 | Parameter | Default | Description |
 |-----------|---------|-------------|
 | `Key` | — | Content key. |
-| `Default` | — | Fallback text when no content exists. |
+| `Default` | — | Fallback text when no content exists (treated as the English/default-language default). |
+| `Defaults` | `null` | Optional authoritative default text per language, keyed by two-letter ISO code (e.g. `["en"]`, `["sv"]`). When set, the default shown before/without a stored translation is chosen by: active-UI-culture code default → English (`"en"` here or `Default`) → key. Use for domain-critical vocabulary (e.g. legal/archival terms) that must render correct wording out-of-the-box. |
 | `TextStyle` | `Body1` | Radzen `TextStyle` (H1, H2, Body1, etc.). |
 | `Visible` | `true` | Show or hide the component. |
 | `Style` | `null` | Custom CSS styles. |
+
+```razor
+@* Authoritative Swedish wording for a domain-critical key, before any translation exists: *@
+<Quilt4Text Key="case.subject"
+            Default="Case subject"
+            Defaults="@(new Dictionary<string,string> { ["en"] = "Case subject", ["sv"] = "Ärendemening" })" />
+```
 
 #### Quilt4Content
 

--- a/Quilt4Net.Toolkit.Tests/ContentDiagnosticsLoggingTests.cs
+++ b/Quilt4Net.Toolkit.Tests/ContentDiagnosticsLoggingTests.cs
@@ -1,0 +1,141 @@
+using System.Net;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Quilt4Net.Toolkit.Features.Content;
+using Quilt4Net.Toolkit.Features.FeatureToggle;
+using Xunit;
+
+namespace Quilt4Net.Toolkit.Tests;
+
+// Issue #132: opt-in diagnostics across the content/language load paths. Per-resolution Debug lines
+// now carry the resolved language (so a spinning/looping content load can be traced by key+language),
+// and a genuinely slow server round-trip surfaces as a single Warning — visible even without Debug
+// logging — gated by ContentOptions.SlowLogThreshold (TimeSpan.Zero disables).
+public class ContentDiagnosticsLoggingTests
+{
+    [Fact]
+    public async Task Slow_content_load_logs_a_warning_when_threshold_exceeded()
+    {
+        using var listener = StartListener(out var prefix, HttpStatusCode.NotFound, TimeSpan.FromMilliseconds(80));
+        var recorder = new RecordingLoggerProvider();
+        var service = BuildContentService(prefix, recorder, o => o.SlowLogThreshold = TimeSpan.FromMilliseconds(1));
+
+        await service.GetContentAsync("Slow.Key", "the-default", Guid.NewGuid(), ContentFormat.String, application: "App");
+
+        recorder.Entries.Should().Contain(e => e.Level == LogLevel.Warning && e.Message.Contains("Slow content load"),
+            "a server round-trip slower than SlowLogThreshold must surface as a Warning even when Debug logging is off");
+    }
+
+    [Fact]
+    public async Task Slow_content_load_warning_is_suppressed_when_threshold_is_zero()
+    {
+        using var listener = StartListener(out var prefix, HttpStatusCode.NotFound, TimeSpan.FromMilliseconds(80));
+        var recorder = new RecordingLoggerProvider();
+        var service = BuildContentService(prefix, recorder, o => o.SlowLogThreshold = TimeSpan.Zero);
+
+        await service.GetContentAsync("Slow.Key", "the-default", Guid.NewGuid(), ContentFormat.String, application: "App");
+
+        recorder.Entries.Should().NotContain(e => e.Message.Contains("Slow content load"),
+            "TimeSpan.Zero must disable the slow-load warning");
+    }
+
+    [Fact]
+    public async Task Resolution_debug_line_names_the_resolved_language()
+    {
+        var languageKey = Guid.NewGuid();
+        using var listener = StartListener(out var prefix, HttpStatusCode.NotFound, TimeSpan.Zero);
+        var recorder = new RecordingLoggerProvider();
+        var service = BuildContentService(prefix, recorder, o => o.SlowLogThreshold = TimeSpan.Zero);
+
+        await service.GetContentAsync("Some.Key", "the-default", languageKey, ContentFormat.String, application: "App");
+
+        recorder.Entries.Should().Contain(e => e.Level == LogLevel.Debug
+                && e.Message.Contains("Some.Key") && e.Message.Contains(languageKey.ToString()),
+            "the per-resolution Debug line must carry the resolved language so a slow/looping load is traceable by key + language");
+    }
+
+    private static IContentService BuildContentService(string baseAddress, ILoggerProvider loggerProvider, Action<ContentOptions> configure)
+    {
+        var host = Host.CreateDefaultBuilder()
+            .ConfigureServices(services =>
+            {
+                services.AddQuilt4NetContent(null, o =>
+                {
+                    o.Quilt4NetAddress = baseAddress;
+                    o.ApiKey = "test-key";
+                    configure(o);
+                });
+                services.AddLogging(b =>
+                {
+                    b.ClearProviders();
+                    b.SetMinimumLevel(LogLevel.Debug);
+                    b.AddProvider(loggerProvider);
+                });
+            })
+            .Build();
+
+        return host.Services.GetRequiredService<IContentService>();
+    }
+
+    private static HttpListener StartListener(out string prefix, HttpStatusCode status, TimeSpan delay)
+    {
+        var port = GetFreePort();
+        prefix = $"http://127.0.0.1:{port}/";
+        var listener = new HttpListener();
+        listener.Prefixes.Add(prefix);
+        listener.Start();
+
+        _ = Task.Run(async () =>
+        {
+            while (listener.IsListening)
+            {
+                HttpListenerContext ctx;
+                try { ctx = await listener.GetContextAsync(); }
+                catch { return; }
+
+                if (delay > TimeSpan.Zero) await Task.Delay(delay);
+                ctx.Response.StatusCode = (int)status;
+                ctx.Response.Close();
+            }
+        });
+
+        return listener;
+    }
+
+    private static int GetFreePort()
+    {
+        using var l = new System.Net.Sockets.TcpListener(IPAddress.Loopback, 0);
+        l.Start();
+        var port = ((IPEndPoint)l.LocalEndpoint).Port;
+        l.Stop();
+        return port;
+    }
+
+    private sealed class RecordingLoggerProvider : ILoggerProvider
+    {
+        public List<(LogLevel Level, string Message)> Entries { get; } = new();
+        public ILogger CreateLogger(string categoryName) => new RecordingLogger(Entries);
+        public void Dispose() { }
+
+        private sealed class RecordingLogger : ILogger
+        {
+            private readonly List<(LogLevel, string)> _entries;
+            public RecordingLogger(List<(LogLevel, string)> entries) => _entries = entries;
+            public IDisposable BeginScope<TState>(TState state) where TState : notnull => NullScope.Instance;
+            public bool IsEnabled(LogLevel logLevel) => true;
+            public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception,
+                Func<TState, Exception, string> formatter)
+            {
+                lock (_entries) _entries.Add((logLevel, formatter(state, exception)));
+            }
+        }
+
+        private sealed class NullScope : IDisposable
+        {
+            public static readonly NullScope Instance = new();
+            public void Dispose() { }
+        }
+    }
+}

--- a/Quilt4Net.Toolkit/ContentOptions.cs
+++ b/Quilt4Net.Toolkit/ContentOptions.cs
@@ -72,4 +72,16 @@ public record ContentOptions
     /// Default is false.
     /// </summary>
     public bool AssumeAdmin { get; set; }
+
+    /// <summary>
+    /// Diagnostics (issue #132): when a content fetch or language-list load from the server takes
+    /// at least this long, a single <c>Warning</c> is logged naming the endpoint, elapsed time and
+    /// HTTP status — so slow content/language loads surface in production even when <c>Debug</c>
+    /// logging is off. The detailed per-resolution timing lines (key, resolved language, cache
+    /// hit/miss, source, elapsed) are logged at <c>Debug</c> on category
+    /// <c>Quilt4Net.Toolkit.Features.Content.RemoteContentCallService</c> and are opt-in via normal
+    /// log configuration. Set <see cref="TimeSpan.Zero"/> to disable the slow-load warning.
+    /// Default is 3 seconds.
+    /// </summary>
+    public TimeSpan SlowLogThreshold { get; set; } = TimeSpan.FromSeconds(3);
 }

--- a/Quilt4Net.Toolkit/Features/Content/RemoteContentCallService.cs
+++ b/Quilt4Net.Toolkit/Features/Content/RemoteContentCallService.cs
@@ -63,8 +63,7 @@ internal class RemoteContentCallService : IRemoteContentCallService
             // at their original levels. Matches RemoteConfigCallService.
             if (!needRefresh)
             {
-                _logger.LogDebug("Content '{Key}' resolved in {Elapsed}ms. Source: Cache, Stale: false.",
-                    key, sw.ElapsedMilliseconds);
+                LogResolved(key, languageKey, effectiveApplication, sw.ElapsedMilliseconds, "Cache", stale: false);
                 return (cached.Value ?? defaultValue, true);
             }
 
@@ -73,8 +72,7 @@ internal class RemoteContentCallService : IRemoteContentCallService
             if (cached != null && _contentOptions.StaleWhileRevalidate)
             {
                 StartBackgroundRefresh(key, cacheKey, defaultValue, languageKey, contentType, effectiveApplication);
-                _logger.LogDebug("Content '{Key}' resolved in {Elapsed}ms. Source: StaleCache, Stale: true.",
-                    key, sw.ElapsedMilliseconds);
+                LogResolved(key, languageKey, effectiveApplication, sw.ElapsedMilliseconds, "StaleCache", stale: true);
                 return (cached.Value ?? defaultValue, true);
             }
 
@@ -88,8 +86,7 @@ internal class RemoteContentCallService : IRemoteContentCallService
             var staleValue = stale?.Value ?? defaultValue;
             _logger.LogError(e, "{Message} Using stale cache or fallback for key {Key}.", e.Message, key);
             CacheFailure(cacheKey, staleValue);
-            _logger.LogDebug("Content '{Key}' resolved in {Elapsed}ms. Source: {Source}, Stale: true.",
-                key, sw.ElapsedMilliseconds, stale != null ? "StaleCache" : "Default");
+            LogResolved(key, languageKey, effectiveApplication, sw.ElapsedMilliseconds, stale != null ? "StaleCache" : "Default", stale: true);
             return (staleValue, false);
         }
     }
@@ -136,15 +133,25 @@ internal class RemoteContentCallService : IRemoteContentCallService
     {
         if (string.IsNullOrEmpty(_contentOptions.ApiKey)) return [new Language { Name = "No ApiKey provided.", Key = Language.NoApiKeyLanguageKey }];
 
-        if (_languages != null && !forceReload && DateTime.UtcNow < _languagesValidTo) return _languages;
+        if (_languages != null && !forceReload && DateTime.UtcNow < _languagesValidTo)
+        {
+            // #132: trace cache-served language lists so a spinning selector can be told apart from
+            // an actual server round-trip. Debug, opt-in via log config.
+            _logger.LogDebug("Languages resolved from cache: {Count} language(s), valid to {ValidTo}.",
+                _languages.Length, _languagesValidTo);
+            return _languages;
+        }
+
+        var sw = Stopwatch.StartNew();
+        var assemblyName = _contentOptions.Application ?? Assembly.GetEntryAssembly()?.GetName()?.Name;
+        var address = $"Api/Language/{assemblyName}/{_environmentName.Name}";
 
         try
         {
-            var assemblyName = _contentOptions.Application ?? Assembly.GetEntryAssembly()?.GetName()?.Name;
-
             using var client = GetHttpClient();
-            var address = $"Api/Language/{assemblyName}/{_environmentName.Name}";
             var response = await client.GetAsync(address);
+
+            WarnIfSlow(sw.ElapsedMilliseconds, $"language load via '{address}'", (int)response.StatusCode, response.ReasonPhrase);
 
             if (!response.IsSuccessStatusCode)
             {
@@ -161,6 +168,9 @@ internal class RemoteContentCallService : IRemoteContentCallService
             var langInterval = result.ValidTo - DateTime.UtcNow;
             if (langInterval > TimeSpan.Zero)
                 _lastKnownLanguageTtl = langInterval;
+
+            _logger.LogDebug("Languages loaded from '{Address}' in {Elapsed}ms: {Count} language(s), valid to {ValidTo}.",
+                address, sw.ElapsedMilliseconds, _languages.Length, _languagesValidTo);
 
             return _languages;
         }
@@ -253,6 +263,8 @@ internal class RemoteContentCallService : IRemoteContentCallService
             var address = $"Api/Content/{complexKey}";
             var response = await client.GetAsync(address, cts.Token);
 
+            WarnIfSlow(sw.ElapsedMilliseconds, $"content load for '{key}' (language {languageKey})", (int)response.StatusCode, response.ReasonPhrase);
+
             if (!response.IsSuccessStatusCode)
             {
                 if (response.StatusCode == HttpStatusCode.NotFound)
@@ -269,8 +281,7 @@ internal class RemoteContentCallService : IRemoteContentCallService
                 }
                 // Negative-cache either way so the key isn't re-requested (and re-logged) every render.
                 CacheFailure(cacheKey, defaultValue);
-                _logger.LogDebug("Content '{Key}' resolved in {Elapsed}ms. Source: Default, Stale: true.",
-                    key, sw.ElapsedMilliseconds);
+                LogResolved(key, languageKey, effectiveApplication, sw.ElapsedMilliseconds, "Default", stale: true);
                 return (defaultValue, false);
             }
 
@@ -282,8 +293,7 @@ internal class RemoteContentCallService : IRemoteContentCallService
 
             _localCache.AddOrUpdate(cacheKey, result, (_, _) => result);
 
-            _logger.LogDebug("Content '{Key}' resolved in {Elapsed}ms. Source: Server, Stale: false.",
-                key, sw.ElapsedMilliseconds);
+            LogResolved(key, languageKey, effectiveApplication, sw.ElapsedMilliseconds, "Server", stale: false);
             return (result.Value ?? defaultValue, true);
         }
         catch (OperationCanceledException)
@@ -291,16 +301,14 @@ internal class RemoteContentCallService : IRemoteContentCallService
             _logger.LogWarning("HTTP request timed out for content '{Key}' after {Timeout}ms. Using default value.",
                 key, _contentOptions.HttpTimeout.TotalMilliseconds);
             CacheFailure(cacheKey, defaultValue);
-            _logger.LogDebug("Content '{Key}' resolved in {Elapsed}ms. Source: Default, Stale: true.",
-                key, sw.ElapsedMilliseconds);
+            LogResolved(key, languageKey, effectiveApplication, sw.ElapsedMilliseconds, "Default", stale: true);
             return (defaultValue, false);
         }
         catch (Exception e)
         {
             _logger.LogError(e, "{Message} Using default for content key {Key}.", e.Message, key);
             CacheFailure(cacheKey, defaultValue);
-            _logger.LogDebug("Content '{Key}' resolved in {Elapsed}ms. Source: Default, Stale: true.",
-                key, sw.ElapsedMilliseconds);
+            LogResolved(key, languageKey, effectiveApplication, sw.ElapsedMilliseconds, "Default", stale: true);
             return (defaultValue, false);
         }
     }
@@ -375,6 +383,29 @@ internal class RemoteContentCallService : IRemoteContentCallService
                 _refreshInProgress.TryRemove(cacheKey, out _);
             }
         });
+    }
+
+    // #132 diagnostics: one consistent Debug line per content resolution, carrying the resolved
+    // language + application so a slow or looping content load can be traced by key+language.
+    // These fire on every read (typically a 0ms cache hit) so they stay at Debug — opt-in via the
+    // category Quilt4Net.Toolkit.Features.Content.RemoteContentCallService at Debug.
+    private void LogResolved(string key, Guid languageKey, string application, long elapsedMs, string source, bool stale)
+    {
+        _logger.LogDebug(
+            "Content '{Key}' (language {LanguageKey}, application '{Application}') resolved in {Elapsed}ms. Source: {Source}, Stale: {Stale}.",
+            key, languageKey, application ?? "", elapsedMs, source, stale);
+    }
+
+    // #132 diagnostics: surface a genuinely slow server round-trip as a single Warning (visible
+    // without Debug logging) so consumers can tell network latency apart from cache/render cost.
+    // Gated by ContentOptions.SlowLogThreshold (TimeSpan.Zero disables). Only called after a
+    // completed HTTP response, so a timeout — which already logs its own Warning — isn't double-counted.
+    private void WarnIfSlow(long elapsedMs, string what, int statusCode, string reasonPhrase)
+    {
+        var threshold = _contentOptions.SlowLogThreshold;
+        if (threshold <= TimeSpan.Zero || elapsedMs < threshold.TotalMilliseconds) return;
+        _logger.LogWarning("Slow {What}: {Elapsed}ms → {StatusCode} {ReasonPhrase} (threshold {Threshold}ms).",
+            what, elapsedMs, statusCode, reasonPhrase, (long)threshold.TotalMilliseconds);
     }
 
     private void CacheFailure(string cacheKey, string value)

--- a/Quilt4Net.Toolkit/README.md
+++ b/Quilt4Net.Toolkit/README.md
@@ -119,8 +119,26 @@ var (value, success) = await _contentService.GetContentAsync("welcome-message", 
 | `Quilt4NetAddress` | `"https://quilt4net.com/"` | Quilt4Net server address. |
 | `ApiKey` | `null` | API key from [Quilt4Net Web](https://quilt4net.com). |
 | `StaleWhileRevalidate` | `true` | When `true`, an expired value is returned immediately and refreshed in the background. Set `false` to refresh synchronously so callers always get a fresh value (subject to `HttpTimeout`). |
+| `SlowLogThreshold` | `3s` | When a content fetch or language-list load from the server takes at least this long, a single `Warning` is logged (endpoint, elapsed, HTTP status) — so slow loads surface even with `Debug` off. Set `TimeSpan.Zero` to disable. |
 
 Configuration path: `Quilt4Net:Content`
+
+#### Diagnostic logging
+
+To diagnose slow or looping content/language loads, enable `Debug` logging for the content categories — no code change required:
+
+```json
+{
+  "Logging": {
+    "LogLevel": {
+      "Quilt4Net.Toolkit.Features.Content.RemoteContentCallService": "Debug",
+      "Quilt4Net.Toolkit.Blazor.LanguageStateService": "Debug"
+    }
+  }
+}
+```
+
+At `Debug` you get, per content read, the key, resolved language + application, cache hit/miss (`Cache` / `StaleCache` / `Server` / `Default`) and elapsed time; per language load, the source (cache vs server), count and elapsed time; and, in Blazor, each language reload (with timing) and every selected-language change that triggers a content reload. Genuinely slow server round-trips are logged at `Warning` regardless (see `SlowLogThreshold`).
 
 ## Health check client
 

--- a/docs/articles/content-components.md
+++ b/docs/articles/content-components.md
@@ -24,10 +24,19 @@ Plain text inside a Radzen `<RadzenText>` with a `TextStyle`.
 | Parameter | Default | Description |
 |---|---|---|
 | `Key` | — | Content key. |
-| `Default` | — | Fallback text. |
+| `Default` | — | Fallback text (treated as the English/default-language default). |
+| `Defaults` | `null` | Optional authoritative default text per language, keyed by two-letter ISO code (`"en"`, `"sv"`, …). Resolution chain: active-UI-culture code default → English (`"en"` or `Default`) → key. For domain-critical vocabulary whose wording must be correct before any translation exists. |
 | `TextStyle` | `Body1` | Radzen text style. |
 | `Visible` | `true` | Show or hide. |
 | `Style` | `null` | Inline CSS. |
+
+```razor
+<Quilt4Text Key="case.subject"
+            Default="Case subject"
+            Defaults="@(new Dictionary<string,string> { ["en"] = "Case subject", ["sv"] = "Ärendemening" })" />
+```
+
+Also available on the service: `IQuilt4ContentService.GetAsync(key, IReadOnlyDictionary<string,string> defaultsByLanguage, application)`.
 
 ### `<Quilt4Content>`
 

--- a/docs/articles/content-components.md
+++ b/docs/articles/content-components.md
@@ -80,6 +80,37 @@ A Radzen button with managed Text **and** an optional managed hover tooltip (HTM
 | `Busy` | Shows an in-button spinner and blocks clicks while set (mirrors `RadzenButton.IsBusy`) — set it around a slow async `Click`. |
 | `BusyTextKey` / `DefaultBusyText` | Optional busy-label content key + fallback shown while `Busy` (e.g. "Saving…"). Leave both unset to keep the normal label next to the spinner. |
 
+### `<Quilt4SplitButton>`
+
+A `RadzenSplitButton` with managed text on the primary button **and** every drop-down item — a primary action plus a menu of secondary actions, all content-localized. Drops the manual `IQuilt4ContentService.GetAsync` label plumbing per item.
+
+```razor
+<Quilt4SplitButton TextKey="row.open" DefaultText="Open" Icon="folder_open"
+                   Click="@OnOpen"
+                   Items="_actions" ItemClick="@OnAction" />
+
+@code {
+    private readonly IReadOnlyList<Quilt4SplitButtonItem> _actions =
+    [
+        new() { TextKey = "row.rename", DefaultText = "Rename", Value = "rename", Icon = "edit" },
+        new() { TextKey = "row.delete", DefaultText = "Delete", Value = "delete", Icon = "delete" },
+    ];
+
+    private Task OnAction(string value) => /* dispatch on value */;
+}
+```
+
+| Parameter | Description |
+|---|---|
+| `TextKey` / `DefaultText` | Primary button label content key + fallback. |
+| `Icon` | Radzen icon name for the primary button. |
+| `Click` | `Func<Task>` handler for the primary button. |
+| `Items` | Drop-down items (`Quilt4SplitButtonItem`): each has `TextKey` / `DefaultText`, `Value`, `Icon`, `Disabled`. |
+| `ItemClick` | `Func<string, Task>` invoked with the chosen item's `Value`. |
+| `Disabled` | Disables the whole split button. |
+| `Busy` / `BusyTextKey` / `DefaultBusyText` | In-button spinner + optional localized busy label (as `Quilt4Button`). |
+| `Style` | Inline CSS. |
+
 ### `<Quilt4PageTitle>`
 
 Wraps Blazor's `<PageTitle>` with a content-aware title.

--- a/docs/articles/content-components.md
+++ b/docs/articles/content-components.md
@@ -67,6 +67,9 @@ A Radzen button with managed Text **and** an optional managed hover tooltip (HTM
 | `Icon` | Radzen icon name. |
 | `Click` | `Func<Task>` click handler. |
 | `Style` | Inline CSS. |
+| `Disabled` | Disables the button (mirrors `RadzenButton.Disabled`). |
+| `Busy` | Shows an in-button spinner and blocks clicks while set (mirrors `RadzenButton.IsBusy`) — set it around a slow async `Click`. |
+| `BusyTextKey` / `DefaultBusyText` | Optional busy-label content key + fallback shown while `Busy` (e.g. "Saving…"). Leave both unset to keep the normal label next to the spinner. |
 
 ### `<Quilt4PageTitle>`
 


### PR DESCRIPTION
Content & UI improvements — Toolkit items worked in priority order. Each is an isolated commit so they can be reviewed (or split) independently.

## 1. Remove `Quilt4Content` external lorem-api.com fallback (`9532143`)
`Quilt4Content` fetched placeholder text from the third-party `https://lorem-api.com` when a key had no stored value and no `ChildContent`, then **auto-registered that lorem-ipsum article as the key's default**. This leaked an outbound network call from every consumer app and corrupted the content store with scaffolding text. Now renders a purely local `"No content for '{Key}'."` placeholder and persists nothing; auto-registration is kept only for the `ChildContent` path. Also removes the dead `Sanitize`/`_blazorAttrs` regex + `Article` record and now-unused usings.

## 2. `Quilt4Button`: `Disabled` + `Busy` parameters — closes #128 (`39f98a0`)
Consumers had to fall back to `RadzenButton` (losing content-localization) for any async-handler button that needed disable/spinner. Adds `Disabled` → `RadzenButton.Disabled`, `Busy` → `RadzenButton.IsBusy` (in-button spinner, blocks clicks), and `BusyTextKey`/`DefaultBusyText` → content-localized `BusyText`.

## 3. Content/Language diagnostic logging — closes #132 (`d17178d`)
Opt-in diagnostics across the content + language load paths:
- Per-resolution `Debug` lines now carry the resolved **language + application** (was key + elapsed only).
- `GetLanguagesAsync` logs `Debug` for cache-served vs server loads with count + elapsed.
- `LanguageStateService` (previously had **no** logger): logs each reload (timing + count), every selected-language change that triggers a content reload, and developer-mode toggles.
- New `ContentOptions.SlowLogThreshold` (default 3s, `TimeSpan.Zero` disables): a server round-trip slower than the threshold logs a single `Warning` (endpoint, elapsed, status) — visible even with `Debug` off.

## 4. Authoritative per-language default text — closes #135 (`f0c60c6`)
Domain-critical vocabulary (e.g. Swedish legal/archival terms) can now declare an authoritative default **per language**, bypassing lossy machine translation. Adds an `IQuilt4ContentService.GetAsync(key, IReadOnlyDictionary<string,string> defaultsByLanguage, application)` overload and a `Quilt4Text` `Defaults` parameter. Fallback chain: stored translation for the selected language → code default for the active UI culture (`CultureInfo.CurrentUICulture`) → English (`"en"` or the single `Default`) → key. Fully backward compatible.

## 5. Quilt4SplitButton — content-localized split button — closes #129 (`cab5316`)
FortDocs used `RadzenSplitButton` for per-row actions (primary action + a menu of secondary actions), which — unlike the other Quilt4 components — is **not** content-localized: every item label had to be resolved by hand via `IQuilt4ContentService.GetAsync` and cached in fields. Adds `Quilt4SplitButton` wrapping `RadzenSplitButton`, mirroring the `Quilt4Button` pattern:
- Primary button: `TextKey`/`DefaultText` (content-resolved), `Icon`, `Click`, `Disabled`, `Busy` + `BusyTextKey`/`DefaultBusyText`, `Style`.
- Menu items via `Items` (a `Quilt4SplitButtonItem` model: `TextKey`, `DefaultText`, `Value`, `Icon`, `Disabled`) with each label content-resolved; `ItemClick(value)` fires with the chosen item's `Value`.
- Re-resolves on `LanguageChangedEvent` and reuses the existing `PlaceholderResolver`, exactly matching the other Quilt4 components.

## Notes
- #133 (translate-on-write) is intentionally **not** included — despite being filed on this repo, the real change is server-side (`ContentService.TranslateFanOutAsync`) and is tracked for the Server.
- README + `docs/articles/content-components.md` updated for #128/#129/#132/#135.

## Testing
- New tests: `ContentDiagnosticsLoggingTests` (3, loopback-HttpListener), `Quilt4TextDefaultsTests` (6, resolver + component), `Quilt4Button` (3), `Quilt4Content` (1), `Quilt4SplitButtonTests` (8).
- Full solution green: **451 tests** — `Quilt4Net.Toolkit.Tests` 205, `Quilt4Net.Toolkit.Blazor.Tests` 141, `Quilt4Net.Toolkit.Health.Tests` 67, `Quilt4Net.Toolkit.Api.Tests` 23, `Quilt4Net.Toolkit.Mcp.Tests` 15.
- Clean solution build: 0 errors; warning-neutral against the ratchet baseline.
