### PR TITLE
Content: developer-supplied direct per-language translations (#135)

### DIFF
--- a/Quilt4Net.Toolkit.Blazor.Tests/ContentWarmupTests.cs
+++ b/Quilt4Net.Toolkit.Blazor.Tests/ContentWarmupTests.cs
@@ -75,7 +75,7 @@ public class ContentWarmupTests
             return Task.CompletedTask;
         }
 
-        public Task<(string Value, bool Success)> GetContentAsync(string key, string defaultValue, Guid languageKey, ContentFormat? contentType, string application = null)
+        public Task<(string Value, bool Success)> GetContentAsync(string key, string defaultValue, Guid languageKey, ContentFormat? contentType, string application = null, IReadOnlyDictionary<string, string> translations = null)
             => Task.FromResult((defaultValue, true));
         public Task SetContentAsync(string key, string defaultValue, Guid languageKey, ContentFormat contentType, string application = null) => Task.CompletedTask;
         public Task<Language[]> GetLanguagesAsync(bool forceReload) => Task.FromResult(Array.Empty<Language>());

--- a/Quilt4Net.Toolkit.Blazor.Tests/Quilt4ButtonTests.cs
+++ b/Quilt4Net.Toolkit.Blazor.Tests/Quilt4ButtonTests.cs
@@ -115,7 +115,7 @@ public class Quilt4ButtonTests : BunitContext
             _success = success;
         }
 
-        public Task<(string Value, bool Success)> GetContentAsync(string key, string defaultValue, Guid languageKey, ContentFormat? contentType, string application = null)
+        public Task<(string Value, bool Success)> GetContentAsync(string key, string defaultValue, Guid languageKey, ContentFormat? contentType, string application = null, IReadOnlyDictionary<string, string> translations = null)
         {
             if (_success && !string.IsNullOrEmpty(_value))
                 return Task.FromResult((_value, true));

--- a/Quilt4Net.Toolkit.Blazor.Tests/Quilt4ContentServiceTests.cs
+++ b/Quilt4Net.Toolkit.Blazor.Tests/Quilt4ContentServiceTests.cs
@@ -1,0 +1,67 @@
+using FluentAssertions;
+using Quilt4Net.Toolkit.Features.Content;
+using Quilt4Net.Toolkit.Features.FeatureToggle;
+using Xunit;
+
+namespace Quilt4Net.Toolkit.Blazor.Tests;
+
+public class Quilt4ContentServiceTests
+{
+    [Fact]
+    public async Task GetAsync_with_translations_forwards_default_selected_language_and_translations()
+    {
+        var content = new CapturingContentService("Ärende");
+        var language = new StubLanguageState();
+        var sut = new Quilt4ContentService(content, language);
+
+        var translations = new Dictionary<string, string> { ["Swedish"] = "Ärende" };
+        var value = await sut.GetAsync("case.subject", "Case subject", translations);
+
+        value.Should().Be("Ärende");
+        content.LastDefaultValue.Should().Be("Case subject");
+        content.LastLanguageKey.Should().Be(language.Selected.Key);
+        content.LastTranslations.Should().BeSameAs(translations);
+    }
+
+    [Fact]
+    public async Task GetAsync_two_arg_overload_sends_no_translations()
+    {
+        var content = new CapturingContentService("Case subject");
+        var sut = new Quilt4ContentService(content, new StubLanguageState());
+
+        await sut.GetAsync("case.subject", "Case subject");
+
+        content.LastTranslations.Should().BeNull();
+    }
+
+    private sealed class CapturingContentService : IContentService
+    {
+        private readonly string _value;
+        public string LastDefaultValue { get; private set; }
+        public Guid LastLanguageKey { get; private set; }
+        public IReadOnlyDictionary<string, string> LastTranslations { get; private set; }
+        public CapturingContentService(string value) => _value = value;
+
+        public Task<(string Value, bool Success)> GetContentAsync(string key, string defaultValue, Guid languageKey, ContentFormat? contentType, string application = null, IReadOnlyDictionary<string, string> translations = null)
+        {
+            LastDefaultValue = defaultValue;
+            LastLanguageKey = languageKey;
+            LastTranslations = translations;
+            return Task.FromResult((_value, true));
+        }
+        public Task SetContentAsync(string key, string value, Guid languageKey, ContentFormat contentType, string application = null) => Task.CompletedTask;
+        public Task ClearCacheAsync() => Task.CompletedTask;
+    }
+
+    private sealed class StubLanguageState : ILanguageStateService
+    {
+        public event EventHandler<LanguageLoadedEventArgs> LanguageLoadedEvent;
+        public event EventHandler<LanguageChangedEventArgs> LanguageChangedEvent;
+        public event EventHandler<DeveloperModeEventArgs> DeveloperModeEvent;
+        public Language Selected { get; set; } = new() { Name = "Swedish", Key = Guid.NewGuid() };
+        public Language[] Languages { get; set; } = [];
+        public bool DeveloperMode { get; set; }
+        public Task<Language[]> ReloadAsync() => Task.FromResult(Languages);
+        private void Unused() { LanguageLoadedEvent?.Invoke(this, null); LanguageChangedEvent?.Invoke(this, null); DeveloperModeEvent?.Invoke(this, null); }
+    }
+}

--- a/Quilt4Net.Toolkit.Blazor.Tests/Quilt4ContentTests.cs
+++ b/Quilt4Net.Toolkit.Blazor.Tests/Quilt4ContentTests.cs
@@ -92,7 +92,7 @@ public class Quilt4ContentTests : BunitContext
         public List<(string Key, string Value)> SetContentCalls { get; } = new();
 
         public Task<(string Value, bool Success)> GetContentAsync(string key, string defaultValue,
-            Guid languageKey, ContentFormat? contentType, string application = null)
+            Guid languageKey, ContentFormat? contentType, string application = null, IReadOnlyDictionary<string, string> translations = null)
             => Task.FromResult<(string, bool)>(("", true));
 
         public Task SetContentAsync(string key, string value, Guid languageKey,

--- a/Quilt4Net.Toolkit.Blazor.Tests/Quilt4NotificationServiceTests.cs
+++ b/Quilt4Net.Toolkit.Blazor.Tests/Quilt4NotificationServiceTests.cs
@@ -72,7 +72,7 @@ public class Quilt4NotificationServiceTests
     {
         public Dictionary<string, string> Map { get; } = new();
 
-        public Task<(string Value, bool Success)> GetContentAsync(string key, string defaultValue, Guid languageKey, ContentFormat? contentType, string application = null)
+        public Task<(string Value, bool Success)> GetContentAsync(string key, string defaultValue, Guid languageKey, ContentFormat? contentType, string application = null, IReadOnlyDictionary<string, string> translations = null)
         {
             if (Map.TryGetValue(key ?? "", out var v) && !string.IsNullOrEmpty(v)) return Task.FromResult((v, true));
             return Task.FromResult((defaultValue ?? "", false));

--- a/Quilt4Net.Toolkit.Blazor.Tests/Quilt4PageTitleTests.cs
+++ b/Quilt4Net.Toolkit.Blazor.Tests/Quilt4PageTitleTests.cs
@@ -82,7 +82,7 @@ public class Quilt4PageTitleTests : BunitContext
             _success = success;
         }
 
-        public Task<(string Value, bool Success)> GetContentAsync(string key, string defaultValue, Guid languageKey, ContentFormat? contentType, string application = null)
+        public Task<(string Value, bool Success)> GetContentAsync(string key, string defaultValue, Guid languageKey, ContentFormat? contentType, string application = null, IReadOnlyDictionary<string, string> translations = null)
         {
             if (_success && !string.IsNullOrEmpty(_value))
                 return Task.FromResult((_value, true));

--- a/Quilt4Net.Toolkit.Blazor.Tests/Quilt4RadzenAlertTests.cs
+++ b/Quilt4Net.Toolkit.Blazor.Tests/Quilt4RadzenAlertTests.cs
@@ -101,7 +101,7 @@ public class Quilt4RadzenAlertTests : BunitContext
     {
         public Dictionary<string, string> Map { get; } = new();
 
-        public Task<(string Value, bool Success)> GetContentAsync(string key, string defaultValue, Guid languageKey, ContentFormat? contentType, string application = null)
+        public Task<(string Value, bool Success)> GetContentAsync(string key, string defaultValue, Guid languageKey, ContentFormat? contentType, string application = null, IReadOnlyDictionary<string, string> translations = null)
         {
             if (Map.TryGetValue(key ?? "", out var value) && !string.IsNullOrEmpty(value))
                 return Task.FromResult((value, true));

--- a/Quilt4Net.Toolkit.Blazor.Tests/Quilt4RadzenDataGridColumnTests.cs
+++ b/Quilt4Net.Toolkit.Blazor.Tests/Quilt4RadzenDataGridColumnTests.cs
@@ -83,7 +83,7 @@ public class Quilt4RadzenDataGridColumnTests : BunitContext
             _success = success;
         }
 
-        public Task<(string Value, bool Success)> GetContentAsync(string key, string defaultValue, Guid languageKey, ContentFormat? contentType, string application = null)
+        public Task<(string Value, bool Success)> GetContentAsync(string key, string defaultValue, Guid languageKey, ContentFormat? contentType, string application = null, IReadOnlyDictionary<string, string> translations = null)
         {
             if (_success && !string.IsNullOrEmpty(_value))
                 return Task.FromResult((_value, true));

--- a/Quilt4Net.Toolkit.Blazor.Tests/Quilt4RadzenDataGridTests.cs
+++ b/Quilt4Net.Toolkit.Blazor.Tests/Quilt4RadzenDataGridTests.cs
@@ -63,7 +63,7 @@ public class Quilt4RadzenDataGridTests : BunitContext
     {
         public Dictionary<string, string> Map { get; } = new();
 
-        public Task<(string Value, bool Success)> GetContentAsync(string key, string defaultValue, Guid languageKey, ContentFormat? contentType, string application = null)
+        public Task<(string Value, bool Success)> GetContentAsync(string key, string defaultValue, Guid languageKey, ContentFormat? contentType, string application = null, IReadOnlyDictionary<string, string> translations = null)
         {
             if (Map.TryGetValue(key ?? "", out var v) && !string.IsNullOrEmpty(v)) return Task.FromResult((v, true));
             return Task.FromResult((defaultValue ?? "", false));

--- a/Quilt4Net.Toolkit.Blazor.Tests/Quilt4RadzenPanelMenuItemTests.cs
+++ b/Quilt4Net.Toolkit.Blazor.Tests/Quilt4RadzenPanelMenuItemTests.cs
@@ -85,7 +85,7 @@ public class Quilt4RadzenPanelMenuItemTests : BunitContext
             _success = success;
         }
 
-        public Task<(string Value, bool Success)> GetContentAsync(string key, string defaultValue, Guid languageKey, ContentFormat? contentType, string application = null)
+        public Task<(string Value, bool Success)> GetContentAsync(string key, string defaultValue, Guid languageKey, ContentFormat? contentType, string application = null, IReadOnlyDictionary<string, string> translations = null)
         {
             if (_success && !string.IsNullOrEmpty(_value))
                 return Task.FromResult((_value, true));

--- a/Quilt4Net.Toolkit.Blazor.Tests/Quilt4RadzenPlaceholderTests.cs
+++ b/Quilt4Net.Toolkit.Blazor.Tests/Quilt4RadzenPlaceholderTests.cs
@@ -118,7 +118,7 @@ public class Quilt4RadzenPlaceholderTests : BunitContext
     {
         public Dictionary<string, string> Map { get; } = new();
 
-        public Task<(string Value, bool Success)> GetContentAsync(string key, string defaultValue, Guid languageKey, ContentFormat? contentType, string application = null)
+        public Task<(string Value, bool Success)> GetContentAsync(string key, string defaultValue, Guid languageKey, ContentFormat? contentType, string application = null, IReadOnlyDictionary<string, string> translations = null)
         {
             if (Map.TryGetValue(key ?? "", out var v) && !string.IsNullOrEmpty(v)) return Task.FromResult((v, true));
             return Task.FromResult((defaultValue ?? "", false));

--- a/Quilt4Net.Toolkit.Blazor.Tests/Quilt4RadzenTabsItemAndLabelTests.cs
+++ b/Quilt4Net.Toolkit.Blazor.Tests/Quilt4RadzenTabsItemAndLabelTests.cs
@@ -87,7 +87,7 @@ public class Quilt4RadzenTabsItemAndLabelTests : BunitContext
     {
         public Dictionary<string, string> Map { get; } = new();
 
-        public Task<(string Value, bool Success)> GetContentAsync(string key, string defaultValue, Guid languageKey, ContentFormat? contentType, string application = null)
+        public Task<(string Value, bool Success)> GetContentAsync(string key, string defaultValue, Guid languageKey, ContentFormat? contentType, string application = null, IReadOnlyDictionary<string, string> translations = null)
         {
             if (Map.TryGetValue(key ?? "", out var v) && !string.IsNullOrEmpty(v)) return Task.FromResult((v, true));
             return Task.FromResult((defaultValue ?? "", false));

--- a/Quilt4Net.Toolkit.Blazor.Tests/Quilt4SplitButtonTests.cs
+++ b/Quilt4Net.Toolkit.Blazor.Tests/Quilt4SplitButtonTests.cs
@@ -140,7 +140,7 @@ public class Quilt4SplitButtonTests : BunitContext
 
         public void Set(string key, string value) => _values[key] = value;
 
-        public Task<(string Value, bool Success)> GetContentAsync(string key, string defaultValue, Guid languageKey, ContentFormat? contentType, string application = null)
+        public Task<(string Value, bool Success)> GetContentAsync(string key, string defaultValue, Guid languageKey, ContentFormat? contentType, string application = null, IReadOnlyDictionary<string, string> translations = null)
         {
             if (!string.IsNullOrEmpty(key) && _values.TryGetValue(key, out var value))
                 return Task.FromResult((value, true));

--- a/Quilt4Net.Toolkit.Blazor.Tests/Quilt4TextDefaultsTests.cs
+++ b/Quilt4Net.Toolkit.Blazor.Tests/Quilt4TextDefaultsTests.cs
@@ -102,7 +102,7 @@ public class Quilt4TextDefaultsTests
 
     private sealed class NotFoundContentService : IContentService
     {
-        public Task<(string Value, bool Success)> GetContentAsync(string key, string defaultValue, Guid languageKey, ContentFormat? contentType, string application = null)
+        public Task<(string Value, bool Success)> GetContentAsync(string key, string defaultValue, Guid languageKey, ContentFormat? contentType, string application = null, IReadOnlyDictionary<string, string> translations = null)
             => Task.FromResult((defaultValue ?? "", false));
         public Task SetContentAsync(string key, string value, Guid languageKey, ContentFormat contentType, string application = null) => Task.CompletedTask;
         public Task ClearCacheAsync() => Task.CompletedTask;
@@ -112,7 +112,7 @@ public class Quilt4TextDefaultsTests
     {
         private readonly string _stored;
         public StoredValueContentService(string stored) => _stored = stored;
-        public Task<(string Value, bool Success)> GetContentAsync(string key, string defaultValue, Guid languageKey, ContentFormat? contentType, string application = null)
+        public Task<(string Value, bool Success)> GetContentAsync(string key, string defaultValue, Guid languageKey, ContentFormat? contentType, string application = null, IReadOnlyDictionary<string, string> translations = null)
             => Task.FromResult((_stored, true));
         public Task SetContentAsync(string key, string value, Guid languageKey, ContentFormat contentType, string application = null) => Task.CompletedTask;
         public Task ClearCacheAsync() => Task.CompletedTask;

--- a/Quilt4Net.Toolkit.Blazor.Tests/Quilt4TooltipTests.cs
+++ b/Quilt4Net.Toolkit.Blazor.Tests/Quilt4TooltipTests.cs
@@ -61,7 +61,7 @@ public class Quilt4TooltipTests : BunitContext
     {
         public Dictionary<string, string> Map { get; } = new();
 
-        public Task<(string Value, bool Success)> GetContentAsync(string key, string defaultValue, Guid languageKey, ContentFormat? contentType, string application = null)
+        public Task<(string Value, bool Success)> GetContentAsync(string key, string defaultValue, Guid languageKey, ContentFormat? contentType, string application = null, IReadOnlyDictionary<string, string> translations = null)
         {
             if (Map.TryGetValue(key ?? "", out var v) && !string.IsNullOrEmpty(v)) return Task.FromResult((v, true));
             return Task.FromResult((defaultValue ?? "", false));

--- a/Quilt4Net.Toolkit.Blazor/IQuilt4ContentService.cs
+++ b/Quilt4Net.Toolkit.Blazor/IQuilt4ContentService.cs
@@ -34,4 +34,21 @@ public interface IQuilt4ContentService
     /// </param>
     /// <param name="application">Application scope; see <see cref="GetAsync(string, string, string)"/>.</param>
     Task<string> GetAsync(string key, IReadOnlyDictionary<string, string> defaultsByLanguage, string application = null);
+
+    /// <summary>
+    /// Get content by key using the currently selected language, supplying the default-language value
+    /// AND exact direct translations for one or more other languages (issue #135 server half). Each
+    /// supplied translation is stored verbatim on the server as authoritative for the matching
+    /// language when the key is first materialized, and AI translation is <b>skipped</b> for those
+    /// languages; the remaining AI-enabled languages are machine-translated as usual.
+    /// </summary>
+    /// <param name="key">Content key.</param>
+    /// <param name="defaultValue">The default-language value (as in <see cref="GetAsync(string, string, string)"/>).</param>
+    /// <param name="translations">
+    /// Exact values keyed by <b>language name</b> exactly as entered on the server (e.g.
+    /// <c>{ ["Swedish"] = "Ärende" }</c>). A name matching no configured language is ignored. Pass
+    /// null/empty for "default only" — equivalent to the two-argument overload.
+    /// </param>
+    /// <param name="application">Application scope; see <see cref="GetAsync(string, string, string)"/>.</param>
+    Task<string> GetAsync(string key, string defaultValue, IReadOnlyDictionary<string, string> translations, string application = null);
 }

--- a/Quilt4Net.Toolkit.Blazor/Quilt4ContentService.cs
+++ b/Quilt4Net.Toolkit.Blazor/Quilt4ContentService.cs
@@ -28,4 +28,13 @@ internal class Quilt4ContentService : IQuilt4ContentService
         var result = await _contentService.GetContentAsync(key, codeDefault, _languageStateService.Selected.Key, ContentFormat.String, application);
         return result.Value;
     }
+
+    public async Task<string> GetAsync(string key, string defaultValue, IReadOnlyDictionary<string, string> translations, string application = null)
+    {
+        // Send the default-language value plus the exact per-language translations. The server stores
+        // each supplied translation as authoritative and skips AI translation for those languages when
+        // the key is first materialized (issue #135 server half).
+        var result = await _contentService.GetContentAsync(key, defaultValue, _languageStateService.Selected.Key, ContentFormat.String, application, translations);
+        return result.Value;
+    }
 }

--- a/Quilt4Net.Toolkit.Blazor/README.md
+++ b/Quilt4Net.Toolkit.Blazor/README.md
@@ -492,6 +492,19 @@ Inject `IQuilt4ContentService` to retrieve content programmatically. It automati
 var text = await ContentService.GetAsync("welcome-message", "Hello!");
 ```
 
+### Supplying exact translations from code
+
+You can provide the default value **plus exact translations for one or more other languages** on the same key. Each supplied translation is stored on the server as **authoritative** the first time the key is materialized, and AI translation is **skipped** for those languages; the remaining AI-enabled languages are machine-translated as usual. Translations are keyed by **language name** exactly as entered on the server (a name matching no configured language is ignored):
+
+```csharp
+var subject = await ContentService.GetAsync(
+    "case.subject",
+    "Case subject",                                     // default-language value
+    new Dictionary<string, string> { ["Swedish"] = "Ärende" });
+```
+
+Use it for domain-critical vocabulary (e.g. legal/archival terms) whose wording must be exact rather than machine-translated. Available from Quilt4Net.Toolkit.Blazor >= 0.10.3. (Requires a server that understands the field; older servers ignore it.)
+
 For advanced scenarios (specific language, HTML format), inject `IContentService` directly:
 
 ```csharp

--- a/Quilt4Net.Toolkit/Features/Content/ContentService.cs
+++ b/Quilt4Net.Toolkit/Features/Content/ContentService.cs
@@ -11,9 +11,9 @@ internal class ContentService : IContentService
         _remoteContentCallService = remoteContentCallService;
     }
 
-    public Task<(string Value, bool Success)> GetContentAsync(string key, string defaultValue, Guid languageKey, ContentFormat? contentType, string application = null)
+    public Task<(string Value, bool Success)> GetContentAsync(string key, string defaultValue, Guid languageKey, ContentFormat? contentType, string application = null, IReadOnlyDictionary<string, string> translations = null)
     {
-        return _remoteContentCallService.GetContentAsync(key, defaultValue, languageKey, contentType, application);
+        return _remoteContentCallService.GetContentAsync(key, defaultValue, languageKey, contentType, application, translations);
     }
 
     public Task SetContentAsync(string key, string value, Guid languageKey, ContentFormat contentType, string application = null)

--- a/Quilt4Net.Toolkit/Features/Content/IContentService.cs
+++ b/Quilt4Net.Toolkit/Features/Content/IContentService.cs
@@ -4,7 +4,7 @@ namespace Quilt4Net.Toolkit.Features.Content;
 
 public interface IContentService
 {
-    Task<(string Value, bool Success)> GetContentAsync(string key, string defaultValue, Guid languageKey, ContentFormat? contentType, string application = null);
+    Task<(string Value, bool Success)> GetContentAsync(string key, string defaultValue, Guid languageKey, ContentFormat? contentType, string application = null, IReadOnlyDictionary<string, string> translations = null);
     Task SetContentAsync(string key, string value, Guid languageKey, ContentFormat contentType, string application = null);
     Task ClearCacheAsync();
 }

--- a/Quilt4Net.Toolkit/Features/Content/IRemoteContentCallService.cs
+++ b/Quilt4Net.Toolkit/Features/Content/IRemoteContentCallService.cs
@@ -4,7 +4,7 @@ namespace Quilt4Net.Toolkit.Features.Content;
 
 public interface IRemoteContentCallService
 {
-    Task<(string Value, bool Success)> GetContentAsync(string key, string defaultValue, Guid languageKey, ContentFormat? contentType, string application = null);
+    Task<(string Value, bool Success)> GetContentAsync(string key, string defaultValue, Guid languageKey, ContentFormat? contentType, string application = null, IReadOnlyDictionary<string, string> translations = null);
     Task SetContentAsync(string key, string defaultValue, Guid languageKey, ContentFormat contentType, string application = null);
     Task<Language[]> GetLanguagesAsync(bool forceReload);
     Task ClearContentCacheAsync();

--- a/Quilt4Net.Toolkit/Features/Content/RemoteContentCallService.cs
+++ b/Quilt4Net.Toolkit/Features/Content/RemoteContentCallService.cs
@@ -38,7 +38,7 @@ internal class RemoteContentCallService : IRemoteContentCallService
         _logger = logger;
     }
 
-    public async Task<(string Value, bool Success)> GetContentAsync(string key, string defaultValue, Guid languageKey, ContentFormat? contentType, string application = null)
+    public async Task<(string Value, bool Success)> GetContentAsync(string key, string defaultValue, Guid languageKey, ContentFormat? contentType, string application = null, IReadOnlyDictionary<string, string> translations = null)
     {
         if (languageKey == Language.DeveloperLanguageKey) return ("X", true);
 
@@ -71,14 +71,14 @@ internal class RemoteContentCallService : IRemoteContentCallService
             // Disabled via options → fall through to a synchronous fetch so the caller gets a fresh value.
             if (cached != null && _contentOptions.StaleWhileRevalidate)
             {
-                StartBackgroundRefresh(key, cacheKey, defaultValue, languageKey, contentType, effectiveApplication);
+                StartBackgroundRefresh(key, cacheKey, defaultValue, languageKey, contentType, effectiveApplication, translations);
                 LogResolved(key, languageKey, effectiveApplication, sw.ElapsedMilliseconds, "StaleCache", stale: true);
                 return (cached.Value ?? defaultValue, true);
             }
 
             // No cache (or stale-while-revalidate disabled) — fetch with timeout; the catch below
             // still falls back to any stale cached value on failure.
-            return await FetchContentWithTimeout(key, cacheKey, defaultValue, languageKey, contentType, sw, effectiveApplication);
+            return await FetchContentWithTimeout(key, cacheKey, defaultValue, languageKey, contentType, sw, effectiveApplication, translations);
         }
         catch (Exception e)
         {
@@ -242,7 +242,7 @@ internal class RemoteContentCallService : IRemoteContentCallService
         }
     }
 
-    private async Task<(string Value, bool Success)> FetchContentWithTimeout(string key, string cacheKey, string defaultValue, Guid languageKey, ContentFormat? contentType, Stopwatch sw, string effectiveApplication)
+    private async Task<(string Value, bool Success)> FetchContentWithTimeout(string key, string cacheKey, string defaultValue, Guid languageKey, ContentFormat? contentType, Stopwatch sw, string effectiveApplication, IReadOnlyDictionary<string, string> translations = null)
     {
         try
         {
@@ -254,7 +254,8 @@ internal class RemoteContentCallService : IRemoteContentCallService
                 Environment = _environmentName.Name,
                 Instance = null,
                 DefaultValue = contentType == null ? null : $"{defaultValue}",
-                ContentFormat = contentType
+                ContentFormat = contentType,
+                Translations = translations
             };
             var complexKey = BuildKey(request);
 
@@ -313,7 +314,7 @@ internal class RemoteContentCallService : IRemoteContentCallService
         }
     }
 
-    private void StartBackgroundRefresh(string key, string cacheKey, string defaultValue, Guid languageKey, ContentFormat? contentType, string effectiveApplication)
+    private void StartBackgroundRefresh(string key, string cacheKey, string defaultValue, Guid languageKey, ContentFormat? contentType, string effectiveApplication, IReadOnlyDictionary<string, string> translations = null)
     {
         if (!_refreshInProgress.TryAdd(cacheKey, true)) return;
 
@@ -329,7 +330,8 @@ internal class RemoteContentCallService : IRemoteContentCallService
                     Environment = _environmentName.Name,
                     Instance = null,
                     DefaultValue = contentType == null ? null : $"{defaultValue}",
-                    ContentFormat = contentType
+                    ContentFormat = contentType,
+                    Translations = translations
                 };
                 var complexKey = BuildKey(request);
 

--- a/Quilt4Net.Toolkit/Features/FeatureToggle/GetContentRequest.cs
+++ b/Quilt4Net.Toolkit/Features/FeatureToggle/GetContentRequest.cs
@@ -1,4 +1,6 @@
-﻿namespace Quilt4Net.Toolkit.Features.FeatureToggle;
+﻿using System.Text.Json.Serialization;
+
+namespace Quilt4Net.Toolkit.Features.FeatureToggle;
 
 public record GetContentRequest : ILanguageKeyContext
 {
@@ -9,4 +11,16 @@ public record GetContentRequest : ILanguageKeyContext
     public required string Instance { get; init; }
     public required string DefaultValue { get; init; }
     public required ContentFormat? ContentFormat { get; init; }
+
+    /// <summary>
+    /// Optional developer-supplied exact translations for this key, keyed by <b>language name</b>
+    /// (as entered on the server), e.g. <c>{ ["Swedish"] = "Ärende" }</c>. When the key is first
+    /// materialized the server stores each of these verbatim as authoritative content for the
+    /// matching language and skips AI translation for it; the remaining AI-enabled languages are
+    /// translated as usual. A name matching no configured language is ignored. Null/empty (the
+    /// default) means "no direct translations" — fully backward compatible with older servers,
+    /// which simply ignore the field.
+    /// </summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public IReadOnlyDictionary<string, string> Translations { get; init; }
 }


### PR DESCRIPTION
Lets a developer supply, on the same content key, the default-language value **plus exact translations for one or more other languages**. Each supplied translation is stored on the server as **authoritative** when the key is first materialized, and AI translation is **skipped** for those languages; the remaining AI-enabled languages are machine-translated as usual (pairs with the server's translate-on-write queue, #133).

This is the wire/client half of #135's "authoritative per-language text". The server half (store-by-name + skip-AI) lands separately on the server, consuming this release.

## API

New overload on `IQuilt4ContentService`:

```csharp
Task<string> GetAsync(string key, string defaultValue, IReadOnlyDictionary<string, string> translations, string application = null);
```

- `translations` is keyed by **language name** exactly as entered on the server (e.g. `{ ["Swedish"] = "Ärende" }`). A name matching no configured language is ignored. Languages are identified by their existing display name — no culture code / no admin field needed.
- Pass null/empty for "default only" (equivalent to the two-argument overload).

## Wire

- New `GetContentRequest.Translations` field (`IReadOnlyDictionary<string,string>`), threaded from the facade through `IContentService` / `IRemoteContentCallService` into the request built by `RemoteContentCallService` (both the foreground fetch and the background-refresh paths).
- `[JsonIgnore(WhenWritingNull)]` so the field is **omitted** when unused — the request URL is byte-identical to before for every existing call, so older servers and existing consumers are unaffected.

## Notes

- Fully backward compatible; existing `GetAsync` overloads untouched. Older servers ignore the field.
- The 0.10.2 `Quilt4Text.Defaults` component parameter (ISO-code, resolved locally only) is left as-is; this PR adds the service-method path that actually sends values to the server. Aligning/retiring the component parameter can be a follow-up.

## Testing

- New `Quilt4ContentServiceTests` (2) — the overload forwards default + selected language + translations; the two-arg overload sends no translations.
- Existing `IContentService` fakes updated for the new optional parameter.
- Full solution green: **453 tests** (Toolkit 205, Blazor 143, Health 67, Api 23, Mcp 15).
