### PR TITLE
Content: optional per-language Translations on the commonly-used components (#141)

### DIFF
--- a/Quilt4Net.Toolkit.Blazor.Tests/ComponentTranslationsTests.cs
+++ b/Quilt4Net.Toolkit.Blazor.Tests/ComponentTranslationsTests.cs
@@ -1,0 +1,124 @@
+using Bunit;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Quilt4Net.Toolkit.Features.Content;
+using Quilt4Net.Toolkit.Features.FeatureToggle;
+using Radzen;
+using Xunit;
+
+namespace Quilt4Net.Toolkit.Blazor.Tests;
+
+// Issue #141: the commonly-used components accept an optional name-keyed Translations dictionary and
+// forward it to the content service (which sends it on the wire; the server applies it only on first
+// creation). These tests assert the forwarding for both integration paths (direct GetContentAsync
+// callers and PlaceholderResolver callers) and the split-button item model.
+public class ComponentTranslationsTests : BunitContext
+{
+    private readonly CapturingContentService _content = new();
+
+    public ComponentTranslationsTests()
+    {
+        JSInterop.Mode = JSRuntimeMode.Loose;
+        Services.AddSingleton<IContentService>(_content);
+        Services.AddSingleton<IEditContentService>(new StubEditContentService());
+        Services.AddSingleton<ILanguageStateService>(new StubLanguageState());
+        Services.AddScoped<DialogService>();
+    }
+
+    [Fact]
+    public void Quilt4Text_forwards_Translations_to_the_content_service()
+    {
+        var translations = new Dictionary<string, string> { ["Swedish"] = "Ärende" };
+
+        Render<Quilt4Text>(p => p
+            .Add(x => x.Key, "case.subject")
+            .Add(x => x.Default, "Case subject")
+            .Add(x => x.Translations, translations));
+
+        _content.TranslationsSeen.Should().Contain(translations);
+    }
+
+    [Fact]
+    public void Quilt4Text_without_Translations_forwards_null()
+    {
+        Render<Quilt4Text>(p => p
+            .Add(x => x.Key, "case.subject")
+            .Add(x => x.Default, "Case subject"));
+
+        _content.TranslationsSeen.Should().OnlyContain(t => t == null);
+    }
+
+    [Fact]
+    public void Quilt4RadzenPanelMenuItem_forwards_Translations()
+    {
+        var translations = new Dictionary<string, string> { ["Swedish"] = "Hem" };
+
+        Render<Quilt4RadzenPanelMenuItem>(p => p
+            .Add(x => x.TextKey, "menu.home")
+            .Add(x => x.DefaultText, "Home")
+            .Add(x => x.Translations, translations));
+
+        _content.TranslationsSeen.Should().Contain(translations);
+    }
+
+    [Fact]
+    public void Quilt4Tooltip_forwards_Translations_via_the_resolver()
+    {
+        var translations = new Dictionary<string, string> { ["Swedish"] = "Ta bort raden" };
+
+        Render<Quilt4Tooltip>(p => p
+            .Add(x => x.TooltipKey, "tip.delete")
+            .Add(x => x.DefaultTooltip, "Delete this row")
+            .Add(x => x.Translations, translations));
+
+        _content.TranslationsSeen.Should().Contain(translations);
+    }
+
+    [Fact]
+    public void Quilt4SplitButton_forwards_per_item_Translations()
+    {
+        var itemTranslations = new Dictionary<string, string> { ["Swedish"] = "Ta bort" };
+
+        Render<Quilt4SplitButton>(p => p
+            .Add(x => x.TextKey, "row.open")
+            .Add(x => x.DefaultText, "Open")
+            .Add(x => x.Items, new List<Quilt4SplitButtonItem>
+            {
+                new() { TextKey = "row.delete", DefaultText = "Delete", Value = "delete", Translations = itemTranslations },
+            }));
+
+        _content.TranslationsSeen.Should().Contain(itemTranslations);
+    }
+
+    private sealed class CapturingContentService : IContentService
+    {
+        public List<IReadOnlyDictionary<string, string>> TranslationsSeen { get; } = new();
+
+        public Task<(string Value, bool Success)> GetContentAsync(string key, string defaultValue, Guid languageKey, ContentFormat? contentType, string application = null, IReadOnlyDictionary<string, string> translations = null)
+        {
+            TranslationsSeen.Add(translations);
+            return Task.FromResult((defaultValue ?? "", false));
+        }
+        public Task SetContentAsync(string key, string value, Guid languageKey, ContentFormat contentType, string application = null) => Task.CompletedTask;
+        public Task ClearCacheAsync() => Task.CompletedTask;
+    }
+
+    private sealed class StubEditContentService : IEditContentService
+    {
+        public event EventHandler<EditModeEventArgs> EditModeEvent;
+        public bool Enabled { get; set; }
+        private void Unused() => EditModeEvent?.Invoke(this, null);
+    }
+
+    private sealed class StubLanguageState : ILanguageStateService
+    {
+        public event EventHandler<LanguageLoadedEventArgs> LanguageLoadedEvent;
+        public event EventHandler<LanguageChangedEventArgs> LanguageChangedEvent;
+        public event EventHandler<DeveloperModeEventArgs> DeveloperModeEvent;
+        public Language Selected { get; set; } = new() { Name = "Swedish", Key = Guid.NewGuid() };
+        public Language[] Languages { get; set; } = [];
+        public bool DeveloperMode { get; set; }
+        public Task<Language[]> ReloadAsync() => Task.FromResult(Languages);
+        private void Unused() { LanguageLoadedEvent?.Invoke(this, null); LanguageChangedEvent?.Invoke(this, null); DeveloperModeEvent?.Invoke(this, null); }
+    }
+}

--- a/Quilt4Net.Toolkit.Blazor/PlaceholderResolver.cs
+++ b/Quilt4Net.Toolkit.Blazor/PlaceholderResolver.cs
@@ -22,11 +22,12 @@ internal static class PlaceholderResolver
         IContentService contentService,
         ILanguageStateService languageState,
         string key,
-        string @default)
+        string @default,
+        IReadOnlyDictionary<string, string> translations = null)
     {
         if (string.IsNullOrEmpty(key)) return @default;
         var response = await contentService.GetContentAsync(
-            key, @default, languageState.Selected?.Key ?? Guid.Empty, ContentFormat.String);
+            key, @default, languageState.Selected?.Key ?? Guid.Empty, ContentFormat.String, application: null, translations: translations);
         return !string.IsNullOrEmpty(response.Value) ? response.Value : @default;
     }
 }

--- a/Quilt4Net.Toolkit.Blazor/Quilt4PageTitle.razor
+++ b/Quilt4Net.Toolkit.Blazor/Quilt4PageTitle.razor
@@ -12,6 +12,10 @@
     [Parameter]
     public string Default { get; set; }
 
+    /// <summary>Optional exact translations keyed by language name; applied only on first server creation (stored authoritative, AI skipped). See #141. Optional.</summary>
+    [Parameter]
+    public IReadOnlyDictionary<string, string> Translations { get; set; }
+
     internal string Title { get; private set; }
 
     protected override async Task OnInitializedAsync()
@@ -27,7 +31,7 @@
 
     private async Task LoadContentAsync()
     {
-        var response = await ContentService.GetContentAsync(Key, Default, LanguageStateService.Selected?.Key ?? Guid.Empty, ContentFormat.String);
+        var response = await ContentService.GetContentAsync(Key, Default, LanguageStateService.Selected?.Key ?? Guid.Empty, ContentFormat.String, application: null, translations: Translations);
         Title = !string.IsNullOrEmpty(response.Value) ? response.Value : Default;
     }
 }

--- a/Quilt4Net.Toolkit.Blazor/Quilt4RadzenPanelMenuItem.razor
+++ b/Quilt4Net.Toolkit.Blazor/Quilt4RadzenPanelMenuItem.razor
@@ -14,6 +14,10 @@
     [Parameter]
     public string DefaultText { get; set; }
 
+    /// <summary>Optional exact translations keyed by language name; applied only on first server creation (stored authoritative, AI skipped). See #141. Optional.</summary>
+    [Parameter]
+    public IReadOnlyDictionary<string, string> Translations { get; set; }
+
     [Parameter]
     public string Icon { get; set; }
 
@@ -65,7 +69,7 @@
 
     private async Task LoadContentAsync()
     {
-        var response = await ContentService.GetContentAsync(TextKey, DefaultText, LanguageStateService.Selected?.Key ?? Guid.Empty, ContentFormat.String);
+        var response = await ContentService.GetContentAsync(TextKey, DefaultText, LanguageStateService.Selected?.Key ?? Guid.Empty, ContentFormat.String, application: null, translations: Translations);
         LoadedText = !string.IsNullOrEmpty(response.Value) ? response.Value : DefaultText;
     }
 }

--- a/Quilt4Net.Toolkit.Blazor/Quilt4RadzenTabsItem.razor
+++ b/Quilt4Net.Toolkit.Blazor/Quilt4RadzenTabsItem.razor
@@ -23,6 +23,9 @@
     /// <summary>Fallback tab label used when the key isn't set or the lookup yields nothing.</summary>
     [Parameter] public string DefaultText { get; set; }
 
+    /// <summary>Optional exact translations keyed by language name; applied only on first server creation (stored authoritative, AI skipped). See #141. Optional.</summary>
+    [Parameter] public IReadOnlyDictionary<string, string> Translations { get; set; }
+
     [Parameter] public string Icon { get; set; }
     [Parameter] public bool Disabled { get; set; }
     [Parameter] public bool Visible { get; set; } = true;
@@ -41,5 +44,5 @@
     }
 
     private async Task LoadContentAsync()
-        => LoadedText = await PlaceholderResolver.ResolveAsync(ContentService, LanguageStateService, TextKey, DefaultText);
+        => LoadedText = await PlaceholderResolver.ResolveAsync(ContentService, LanguageStateService, TextKey, DefaultText, Translations);
 }

--- a/Quilt4Net.Toolkit.Blazor/Quilt4Raw.razor
+++ b/Quilt4Net.Toolkit.Blazor/Quilt4Raw.razor
@@ -16,6 +16,10 @@
     [Parameter]
     public string Default { get; set; }
 
+    /// <summary>Optional exact translations keyed by language name; applied only on first server creation (stored authoritative, AI skipped). See #141. Optional.</summary>
+    [Parameter]
+    public IReadOnlyDictionary<string, string> Translations { get; set; }
+
     protected override async Task OnInitializedAsync()
     {
         LanguageStateService.LanguageChangedEvent += async (_, e) =>
@@ -33,7 +37,7 @@
 
     private async Task LoadContentAsync()
     {
-        _response = await ContentService.GetContentAsync(Key, Default, LanguageStateService.Selected?.Key ?? Guid.Empty, ContentFormat.String);
+        _response = await ContentService.GetContentAsync(Key, Default, LanguageStateService.Selected?.Key ?? Guid.Empty, ContentFormat.String, application: null, translations: Translations);
         _content = _response.Value;
     }
 }

--- a/Quilt4Net.Toolkit.Blazor/Quilt4Span.razor
+++ b/Quilt4Net.Toolkit.Blazor/Quilt4Span.razor
@@ -16,6 +16,10 @@
     [Parameter]
     public string Default { get; set; }
 
+    /// <summary>Optional exact translations keyed by language name; applied only on first server creation (stored authoritative, AI skipped). See #141. Optional.</summary>
+    [Parameter]
+    public IReadOnlyDictionary<string, string> Translations { get; set; }
+
     protected override async Task OnInitializedAsync()
     {
         LanguageStateService.LanguageChangedEvent += async (_, e) =>
@@ -33,7 +37,7 @@
 
     private async Task LoadContentAsync()
     {
-        _response = await ContentService.GetContentAsync(Key, Default, LanguageStateService.Selected?.Key ?? Guid.Empty, ContentFormat.String);
+        _response = await ContentService.GetContentAsync(Key, Default, LanguageStateService.Selected?.Key ?? Guid.Empty, ContentFormat.String, application: null, translations: Translations);
         _content = _response.Value;
     }
 }

--- a/Quilt4Net.Toolkit.Blazor/Quilt4SplitButton.razor
+++ b/Quilt4Net.Toolkit.Blazor/Quilt4SplitButton.razor
@@ -31,6 +31,10 @@
     [Parameter]
     public string DefaultText { get; set; }
 
+    /// <summary>Optional exact translations for the primary label, keyed by language name; applied only on first server creation (stored authoritative, AI skipped). See #141. Optional.</summary>
+    [Parameter]
+    public IReadOnlyDictionary<string, string> Translations { get; set; }
+
     /// <summary>Optional Radzen icon name for the primary button.</summary>
     [Parameter]
     public string Icon { get; set; }
@@ -88,7 +92,7 @@
 
     private async Task LoadContentAsync()
     {
-        _text = await PlaceholderResolver.ResolveAsync(ContentService, LanguageStateService, TextKey, DefaultText);
+        _text = await PlaceholderResolver.ResolveAsync(ContentService, LanguageStateService, TextKey, DefaultText, Translations);
         _busyText = await PlaceholderResolver.ResolveAsync(ContentService, LanguageStateService, BusyTextKey, DefaultBusyText);
 
         var resolved = new List<ResolvedItem>();
@@ -96,7 +100,7 @@
         {
             foreach (var item in Items)
             {
-                var text = await PlaceholderResolver.ResolveAsync(ContentService, LanguageStateService, item.TextKey, item.DefaultText);
+                var text = await PlaceholderResolver.ResolveAsync(ContentService, LanguageStateService, item.TextKey, item.DefaultText, item.Translations);
                 resolved.Add(new ResolvedItem(item, text));
             }
         }

--- a/Quilt4Net.Toolkit.Blazor/Quilt4SplitButtonItem.cs
+++ b/Quilt4Net.Toolkit.Blazor/Quilt4SplitButtonItem.cs
@@ -22,4 +22,11 @@ public sealed class Quilt4SplitButtonItem
 
     /// <summary>When <c>true</c> the item renders disabled and cannot be chosen.</summary>
     public bool Disabled { get; init; }
+
+    /// <summary>
+    /// Optional exact translations for this item's label, keyed by <b>language name</b> (e.g.
+    /// <c>{ ["Swedish"] = "Ta bort" }</c>). Applied only the first time the key is created on the
+    /// server: stored as authoritative for the matching language, AI skipped (issue #141). Optional.
+    /// </summary>
+    public IReadOnlyDictionary<string, string> Translations { get; init; }
 }

--- a/Quilt4Net.Toolkit.Blazor/Quilt4Text.razor
+++ b/Quilt4Net.Toolkit.Blazor/Quilt4Text.razor
@@ -30,6 +30,15 @@
     [Parameter]
     public IReadOnlyDictionary<string, string> Defaults { get; set; }
 
+    /// <summary>
+    /// Optional exact translations for this key, keyed by <b>language name</b> exactly as entered on
+    /// the server (e.g. <c>{ ["Swedish"] = "Ärende" }</c>). Applied only the first time the key is
+    /// created on the server: each is stored as authoritative for the matching language and AI
+    /// translation is skipped for it (issue #141). Optional — omit for the ordinary key + default flow.
+    /// </summary>
+    [Parameter]
+    public IReadOnlyDictionary<string, string> Translations { get; set; }
+
     [Parameter]
     public TextStyle TextStyle { get; set; } = TextStyle.Body1;
 
@@ -65,7 +74,7 @@
         var effectiveDefault = Defaults is { Count: > 0 }
             ? LanguageDefaultResolver.Resolve(Defaults, Default, Key)
             : Default;
-        _response = await ContentService.GetContentAsync(Key, effectiveDefault, LanguageStateService.Selected?.Key ?? Guid.Empty, ContentFormat.String);
+        _response = await ContentService.GetContentAsync(Key, effectiveDefault, LanguageStateService.Selected?.Key ?? Guid.Empty, ContentFormat.String, application: null, translations: Translations);
         _content = _response.Value;
     }
 

--- a/Quilt4Net.Toolkit.Blazor/Quilt4Tooltip.razor
+++ b/Quilt4Net.Toolkit.Blazor/Quilt4Tooltip.razor
@@ -34,6 +34,9 @@
     /// <summary>Optional inline style on the wrapping span (display: inline-block / flex / etc.).</summary>
     [Parameter] public string Style { get; set; }
 
+    /// <summary>Optional exact translations keyed by language name; applied only on first server creation (stored authoritative, AI skipped). See #141. Optional.</summary>
+    [Parameter] public IReadOnlyDictionary<string, string> Translations { get; set; }
+
     internal string LoadedTooltip { get; private set; }
 
     protected override async Task OnInitializedAsync()
@@ -47,5 +50,5 @@
     }
 
     private async Task LoadContentAsync()
-        => LoadedTooltip = await PlaceholderResolver.ResolveAsync(ContentService, LanguageStateService, TooltipKey, DefaultTooltip);
+        => LoadedTooltip = await PlaceholderResolver.ResolveAsync(ContentService, LanguageStateService, TooltipKey, DefaultTooltip, Translations);
 }

--- a/Quilt4Net.Toolkit.Blazor/README.md
+++ b/Quilt4Net.Toolkit.Blazor/README.md
@@ -505,6 +505,15 @@ var subject = await ContentService.GetAsync(
 
 Use it for domain-critical vocabulary (e.g. legal/archival terms) whose wording must be exact rather than machine-translated. Available from Quilt4Net.Toolkit.Blazor >= 0.10.3. (Requires a server that understands the field; older servers ignore it.)
 
+The same capability is available **on the components** (>= 0.10.4) via an optional `Translations` parameter (name-keyed) — on the basic-text components (`Quilt4Text`, `Quilt4Span`, `Quilt4Raw`, `Quilt4PageTitle`, `Quilt4Tooltip`) and the menu-item components (`Quilt4RadzenPanelMenuItem`, `Quilt4RadzenTabsItem`, `Quilt4SplitButton` + its items):
+
+```razor
+<Quilt4Text Key="case.subject" Default="Case subject"
+            Translations="@(new Dictionary<string,string> { ["Swedish"] = "Ärende" })" />
+```
+
+It's optional — every component behaves exactly as before when it's omitted. (Note: this is distinct from `Quilt4Text.Defaults`, which is ISO-code-keyed and resolved locally only; `Translations` is language-name-keyed and stored server-authoritative on first creation.)
+
 For advanced scenarios (specific language, HTML format), inject `IContentService` directly:
 
 ```csharp

--- a/docs/articles/content-components.md
+++ b/docs/articles/content-components.md
@@ -25,7 +25,8 @@ Plain text inside a Radzen `<RadzenText>` with a `TextStyle`.
 |---|---|---|
 | `Key` | — | Content key. |
 | `Default` | — | Fallback text (treated as the English/default-language default). |
-| `Defaults` | `null` | Optional authoritative default text per language, keyed by two-letter ISO code (`"en"`, `"sv"`, …). Resolution chain: active-UI-culture code default → English (`"en"` or `Default`) → key. For domain-critical vocabulary whose wording must be correct before any translation exists. |
+| `Defaults` | `null` | Optional authoritative default text per language, keyed by two-letter ISO code (`"en"`, `"sv"`, …), resolved **locally**. Resolution chain: active-UI-culture code default → English (`"en"` or `Default`) → key. For correct wording before any translation exists. |
+| `Translations` | `null` | Optional exact per-language values keyed by **language name** (e.g. `["Swedish"]="Ärende"`). Sent to the server and applied **only on first creation**: stored authoritative, AI skipped (0.10.4, #141). Distinct from `Defaults` (which is ISO-code + local-only). |
 | `TextStyle` | `Body1` | Radzen text style. |
 | `Visible` | `true` | Show or hide. |
 | `Style` | `null` | Inline CSS. |
@@ -36,7 +37,7 @@ Plain text inside a Radzen `<RadzenText>` with a `TextStyle`.
             Defaults="@(new Dictionary<string,string> { ["en"] = "Case subject", ["sv"] = "Ärendemening" })" />
 ```
 
-Also available on the service: `IQuilt4ContentService.GetAsync(key, IReadOnlyDictionary<string,string> defaultsByLanguage, application)`.
+Also on the service: `IQuilt4ContentService.GetAsync(key, IReadOnlyDictionary<string,string> defaultsByLanguage, application)` (local per-language default, ISO-code keyed) and `GetAsync(key, defaultValue, IReadOnlyDictionary<string,string> translations, application)` (server-authoritative per-language values, language-name keyed; 0.10.3). The components' `Translations` parameter uses the latter. `Quilt4Span`, `Quilt4Raw`, `Quilt4PageTitle`, `Quilt4Tooltip` and the menu-item components (`Quilt4RadzenPanelMenuItem`, `Quilt4RadzenTabsItem`, `Quilt4SplitButton` + items) accept the same `Translations` parameter.
 
 ### `<Quilt4Content>`
 


### PR DESCRIPTION
Closes #141.

Brings the per-language authoritative default-text mechanism (shipped for the service method in 0.10.3, `GetAsync(key, defaultValue, translations)`) to the **commonly-used components**, so a host can supply exact translations for a component's text — not just via the service.

## What

An **optional** `Translations` parameter (keyed by **language name**, e.g. `{ ["Swedish"] = "Ärende" }`) on:

- **Basic text:** `Quilt4Text`, `Quilt4Span`, `Quilt4Raw`, `Quilt4PageTitle`, `Quilt4Tooltip`
- **Menu items:** `Quilt4RadzenPanelMenuItem`, `Quilt4RadzenTabsItem`, `Quilt4SplitButton` (+ per-item `Quilt4SplitButtonItem.Translations`)

```razor
<Quilt4Text Key="case.subject" Default="Case subject"
            Translations="@(new Dictionary<string,string> { ["Swedish"] = "Ärende" })" />
```

Each component forwards `Translations` to `IContentService.GetContentAsync(..., translations)`; the server applies them **only on first creation** — stored verbatim as authoritative for the name-matched language, AI translation skipped — then ignores them. `PlaceholderResolver.ResolveAsync` gained an optional `translations` param so the resolver-based components forward it too.

## Compatibility

- **Fully optional** — every component behaves exactly as before when `Translations` is omitted (always: key + default-language default; the server decides the default language).
- `Quilt4Text.Defaults` (0.10.2, ISO-code, resolved **locally**) is **unchanged**. It's distinct from `Translations` (language-name, **server-authoritative**); if you set both, `Defaults` still picks the local fallback string and `Translations` seeds the server.
- `Quilt4Content` (HTML `ChildContent`, no string default) is out of scope.

## Testing

- New `ComponentTranslationsTests` (5): Quilt4Text forwards / omits→null, PanelMenuItem forwards, Tooltip forwards via the resolver, SplitButton forwards per-item.
- Full solution green: **458 tests** (Blazor 148, Toolkit 205, Health 67, Api 23, Mcp 15).
- Docs updated: `Quilt4Net.Toolkit.Blazor/README.md` + `docs/articles/content-components.md`.
