### PR TITLE
Test/CI hygiene: de-flake HostedServiceProbe test + clear test-fake warnings under the ratchet

### DIFF
--- a/Quilt4Net.Toolkit.Blazor.Tests/Quilt4Net.Toolkit.Blazor.Tests.csproj
+++ b/Quilt4Net.Toolkit.Blazor.Tests/Quilt4Net.Toolkit.Blazor.Tests.csproj
@@ -4,6 +4,10 @@
     <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <IsPackable>false</IsPackable>
+    <!-- Test fakes must implement every interface event (e.g. ILanguageStateService's), but a given
+         test only raises the one it needs; "event is never used" (CS0067) is expected in a stub and
+         is never a defect, so silence it project-wide rather than per-fake. -->
+    <NoWarn>$(NoWarn);CS0067</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Quilt4Net.Toolkit.Tests/HostedServiceProbeTests.cs
+++ b/Quilt4Net.Toolkit.Tests/HostedServiceProbeTests.cs
@@ -51,6 +51,10 @@ public class HostedServiceProbeTests
         probe.Register("test", plannedInterval: null, autoMaxInterval: true, pulseWindowSize: 50);
 
         using var cts = new CancellationTokenSource();
+        // Deliberately no cancellation token on Task.Run (hence the xUnit1051 suppression): passing one
+        // would let a canceled token mark the pulser task Canceled and reintroduce the exact
+        // TaskCanceledException flake this test removes. The loop exits purely on the flag.
+#pragma warning disable xUnit1051
         var pulser = Task.Run(() =>
         {
             while (!cts.IsCancellationRequested)
@@ -58,6 +62,7 @@ public class HostedServiceProbeTests
                 probe.Pulse();
             }
         });
+#pragma warning restore xUnit1051
 
         Action poll = () =>
         {

--- a/Quilt4Net.Toolkit.Tests/HostedServiceProbeTests.cs
+++ b/Quilt4Net.Toolkit.Tests/HostedServiceProbeTests.cs
@@ -38,7 +38,14 @@ public class HostedServiceProbeTests
     {
         // Issue #130 (secondary): GetHealth() enumerated _pulseTimes on the health thread while
         // Pulse() appended on the hosted-service thread with no synchronization, which could throw
-        // (concurrent enumerate/add). Access is now guarded by a lock.
+        // (concurrent enumerate/add). Access is now guarded by a lock — this exercises that.
+        //
+        // Hardened against a CI flake: the pulser carries NO Task.Run cancellation token (so it can
+        // only ever RanToCompletion, never Canceled), and the teardown is a plain `await pulser` once
+        // the stop flag is set. The previous version passed cts.Token to Task.Run and waited with
+        // WaitAsync(timeout, TestContext.Current.CancellationToken); under CI load that wait could
+        // surface a spurious TaskCanceledException unrelated to the concurrency being tested. The only
+        // thing asserted is that concurrent Pulse()/GetHealth() never throw.
         var registry = new HostedServiceProbeRegistry();
         var probe = new HostedServiceProbe(registry);
         probe.Register("test", plannedInterval: null, autoMaxInterval: true, pulseWindowSize: 50);
@@ -46,24 +53,24 @@ public class HostedServiceProbeTests
         using var cts = new CancellationTokenSource();
         var pulser = Task.Run(() =>
         {
-            while (!cts.Token.IsCancellationRequested)
+            while (!cts.IsCancellationRequested)
             {
                 probe.Pulse();
             }
-        }, cts.Token);
+        });
 
         Action poll = () =>
         {
-            for (var i = 0; i < 100_000; i++)
+            for (var i = 0; i < 20_000; i++)
             {
                 _ = probe.GetHealth();
             }
         };
 
-        poll.Should().NotThrow();
+        poll.Should().NotThrow("Pulse() and GetHealth() must be safe to call concurrently");
 
-        await cts.CancelAsync();
-        await pulser.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
+        cts.Cancel();
+        await pulser;
     }
 
     [Fact]


### PR DESCRIPTION
Two test/CI-hygiene fixes (test-only; **no production change**).

## 1. De-flake the HostedServiceProbe concurrency test
`HostedServiceProbeTests.Pulse_And_GetHealth_Run_Concurrently_Without_Throwing` intermittently failed CI with `TaskCanceledException` (it red-lit the master build for the 0.10.4 release). `Pulse()`/`GetHealth()` are already lock-guarded, so the concurrency is safe — the exception came from the test's orchestration: the pulser was started with `Task.Run(action, cts.Token)` and teardown waited with `WaitAsync(timeout, TestContext.Current.CancellationToken)`, which under CI load surfaced a spurious cancellation.

Fix: pulser started with **no** token (can only `RanToCompletion`); teardown is a plain `await pulser` after the stop flag; poll trimmed 100k→20k. Ran green 4× locally.

## 2. Clear the test-fake warnings that tripped the ratchet
The build's warning ratchet (`ceil(248×1.05)=261`) failed at **262**. Every excess warning is `CS0067` "event is never used" in test fakes implementing `ILanguageStateService`'s events (a stub only raises the one a test needs) — never a defect — so `NoWarn CS0067` in the Blazor test project clears all ~20. Also a single targeted `xUnit1051` suppression on this fix's deliberately-token-less `Task.Run` (passing a token would reintroduce the de-flaked `TaskCanceledException`).

Result: **262 → 240 warnings**, back under the baseline (248), so the ratchet passes and auto-lowers on merge.
