### PR TITLE
feat(content): report where each content value came from

### DIFF
--- a/Quilt4Net.Toolkit.Blazor.Tests/ComponentTranslationsTests.cs
+++ b/Quilt4Net.Toolkit.Blazor.Tests/ComponentTranslationsTests.cs
@@ -21,6 +21,7 @@ public class ComponentTranslationsTests : BunitContext
         JSInterop.Mode = JSRuntimeMode.Loose;
         Services.AddSingleton<IContentService>(_content);
         Services.AddSingleton<IEditContentService>(new StubEditContentService());
+        Services.AddSingleton<IContentSourceService>(new ContentSourceService());
         Services.AddSingleton<ILanguageStateService>(new StubLanguageState());
         Services.AddScoped<DialogService>();
     }

--- a/Quilt4Net.Toolkit.Blazor.Tests/ContentSourceIndicatorTests.cs
+++ b/Quilt4Net.Toolkit.Blazor.Tests/ContentSourceIndicatorTests.cs
@@ -1,0 +1,173 @@
+using Bunit;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Quilt4Net.Toolkit.Blazor;
+using Quilt4Net.Toolkit.Features.Content;
+using Quilt4Net.Toolkit.Features.FeatureToggle;
+using Radzen;
+using Xunit;
+
+namespace Quilt4Net.Toolkit.Blazor.Tests;
+
+// Content source indicator: when IContentSourceService.Enabled is set, content components annotate
+// each rendered value with its provenance (outline + tooltip). Off, markup must be unchanged.
+public class ContentSourceIndicatorTests : BunitContext
+{
+    [Fact]
+    public void Overlay_is_absent_when_mode_is_off()
+    {
+        var cut = RenderText(ContentSource.Server, sourceModeEnabled: false);
+
+        cut.Markup.Should().NotContain("outline: 2px solid",
+            "with the overlay off the component must render exactly as before");
+        cut.Markup.Should().NotContain("Source:");
+    }
+
+    [Fact]
+    public void A_fallback_default_is_flagged_as_default()
+    {
+        var cut = RenderText(ContentSource.Default, sourceModeEnabled: true);
+
+        cut.Markup.Should().Contain("#c62828", "a fallback default is the case being hunted, so it gets the red outline");
+        cut.Markup.Should().Contain("the server has no value for this key");
+    }
+
+    [Fact]
+    public void A_server_value_is_flagged_as_server()
+    {
+        var cut = RenderText(ContentSource.Server, sourceModeEnabled: true);
+
+        cut.Markup.Should().Contain("#2e7d32");
+        cut.Markup.Should().Contain("Source: server");
+    }
+
+    [Fact]
+    public void A_cache_hit_is_flagged_as_cache()
+    {
+        var cut = RenderText(ContentSource.Cache, sourceModeEnabled: true);
+
+        cut.Markup.Should().Contain("#1565c0");
+        cut.Markup.Should().Contain("Source: local cache (value from the server)");
+    }
+
+    [Fact]
+    public void Toggling_the_mode_restyles_an_already_rendered_component()
+    {
+        var sourceService = new ContentSourceService();
+        var cut = RenderText(ContentSource.Default, sourceModeEnabled: false, sourceService);
+
+        cut.Markup.Should().NotContain("outline: 2px solid");
+
+        sourceService.Enabled = true;
+
+        cut.Markup.Should().Contain("outline: 2px solid",
+            "components subscribe to SourceModeEvent, so toggling must restyle without a reload");
+    }
+
+    [Fact]
+    public void Quilt4Span_annotates_its_source()
+    {
+        Services.AddSingleton<IContentService>(new SourceContentService(ContentSource.StaleCache));
+        Services.AddSingleton<IEditContentService>(new StubEditContentService());
+        Services.AddSingleton<IContentSourceService>(new ContentSourceService { Enabled = true });
+        Services.AddSingleton<ILanguageStateService>(new StubLanguageState());
+
+        var cut = Render<Quilt4Span>(p => p.Add(x => x.Key, "a.key").Add(x => x.Default, "a-default"));
+
+        cut.Markup.Should().Contain("#ef6c00");
+        cut.Markup.Should().Contain("past its TTL");
+    }
+
+    // Quilt4Raw normally renders its value with no wrapping element. The overlay needs an element to
+    // hang the outline on, so it adds one — but only while the mode is on.
+    [Fact]
+    public void Quilt4Raw_only_wraps_its_value_while_the_mode_is_on()
+    {
+        Services.AddSingleton<IContentService>(new SourceContentService(ContentSource.Server));
+        Services.AddSingleton<IEditContentService>(new StubEditContentService());
+        var sourceService = new ContentSourceService();
+        Services.AddSingleton<IContentSourceService>(sourceService);
+        Services.AddSingleton<ILanguageStateService>(new StubLanguageState());
+
+        var cut = Render<Quilt4Raw>(p => p.Add(x => x.Key, "a.key").Add(x => x.Default, "a-default"));
+
+        cut.Markup.Should().NotContain("<span", "off, the value renders bare exactly as before");
+
+        sourceService.Enabled = true;
+
+        cut.Markup.Should().Contain("<span");
+        cut.Markup.Should().Contain("#2e7d32");
+    }
+
+    [Fact]
+    public void Edit_mode_takes_precedence_over_the_source_overlay()
+    {
+        Services.AddSingleton<IContentService>(new SourceContentService(ContentSource.Default));
+        Services.AddSingleton<IEditContentService>(new StubEditContentService { Enabled = true });
+        Services.AddSingleton<IContentSourceService>(new ContentSourceService { Enabled = true });
+        Services.AddSingleton<ILanguageStateService>(new StubLanguageState());
+        Services.AddScoped<DialogService>();
+
+        var cut = Render<Quilt4Text>(p => p.Add(x => x.Key, "a.key").Add(x => x.Default, "a-default"));
+
+        cut.Markup.Should().Contain("#ffc0cb",
+            "edit mode is interactive and its cursor affordance must survive; the read-only overlay yields");
+        cut.Markup.Should().NotContain("outline: 2px solid");
+    }
+
+    private IRenderedComponent<Quilt4Text> RenderText(ContentSource source, bool sourceModeEnabled, ContentSourceService sourceService = null)
+    {
+        Services.AddSingleton<IContentService>(new SourceContentService(source));
+        Services.AddSingleton<IEditContentService>(new StubEditContentService());
+        Services.AddSingleton<IContentSourceService>(sourceService ?? new ContentSourceService { Enabled = sourceModeEnabled });
+        Services.AddSingleton<ILanguageStateService>(new StubLanguageState());
+        Services.AddScoped<DialogService>();
+
+        return Render<Quilt4Text>(p => p.Add(x => x.Key, "a.key").Add(x => x.Default, "a-default"));
+    }
+
+    // Overrides GetContentResultAsync so the component sees a chosen provenance. Note the interface's
+    // default implementation would report Unknown — only implementations that genuinely know their
+    // source override it.
+    private sealed class SourceContentService : IContentService
+    {
+        private readonly ContentSource _source;
+        public SourceContentService(ContentSource source) => _source = source;
+
+        public Task<(string Value, bool Success)> GetContentAsync(string key, string defaultValue, Guid languageKey, ContentFormat? contentType, string application = null, IReadOnlyDictionary<string, string> translations = null)
+            => Task.FromResult((defaultValue ?? "value", true));
+
+        public Task<ContentResult> GetContentResultAsync(string key, string defaultValue, Guid languageKey, ContentFormat? contentType, string application = null, IReadOnlyDictionary<string, string> translations = null)
+            => Task.FromResult(new ContentResult { Value = defaultValue ?? "value", Success = true, Source = _source, Stale = false });
+
+        public Task SetContentAsync(string key, string value, Guid languageKey, ContentFormat contentType, string application = null) => Task.CompletedTask;
+        public Task ClearCacheAsync() => Task.CompletedTask;
+    }
+
+    private sealed class StubEditContentService : IEditContentService
+    {
+        public event EventHandler<EditModeEventArgs> EditModeEvent;
+        public bool Enabled { get; set; }
+        private void Unused() => EditModeEvent?.Invoke(this, null);
+    }
+
+    private sealed class StubLanguageState : ILanguageStateService
+    {
+        public event EventHandler<LanguageLoadedEventArgs> LanguageLoadedEvent;
+        public event EventHandler<LanguageChangedEventArgs> LanguageChangedEvent;
+        public event EventHandler<DeveloperModeEventArgs> DeveloperModeEvent;
+
+        public Language Selected { get; set; } = new() { Name = "English", Key = Guid.NewGuid() };
+        public Language[] Languages { get; set; } = [];
+        public bool DeveloperMode { get; set; }
+
+        public Task<Language[]> ReloadAsync() => Task.FromResult(Languages);
+
+        private void Unused()
+        {
+            LanguageLoadedEvent?.Invoke(this, null);
+            LanguageChangedEvent?.Invoke(this, null);
+            DeveloperModeEvent?.Invoke(this, null);
+        }
+    }
+}

--- a/Quilt4Net.Toolkit.Blazor.Tests/ContentWarmupTests.cs
+++ b/Quilt4Net.Toolkit.Blazor.Tests/ContentWarmupTests.cs
@@ -77,6 +77,8 @@ public class ContentWarmupTests
 
         public Task<(string Value, bool Success)> GetContentAsync(string key, string defaultValue, Guid languageKey, ContentFormat? contentType, string application = null, IReadOnlyDictionary<string, string> translations = null)
             => Task.FromResult((defaultValue, true));
+        public Task<ContentResult> GetContentResultAsync(string key, string defaultValue, Guid languageKey, ContentFormat? contentType, string application = null, IReadOnlyDictionary<string, string> translations = null)
+            => Task.FromResult(new ContentResult { Value = defaultValue, Success = true, Source = ContentSource.Default, Stale = false });
         public Task SetContentAsync(string key, string defaultValue, Guid languageKey, ContentFormat contentType, string application = null) => Task.CompletedTask;
         public Task<Language[]> GetLanguagesAsync(bool forceReload) => Task.FromResult(Array.Empty<Language>());
         public Task ClearContentCacheAsync() => Task.CompletedTask;

--- a/Quilt4Net.Toolkit.Blazor.Tests/Quilt4ContentTests.cs
+++ b/Quilt4Net.Toolkit.Blazor.Tests/Quilt4ContentTests.cs
@@ -27,6 +27,7 @@ public class Quilt4ContentTests : BunitContext
 
         Services.AddSingleton<IContentService>(_contentService);
         Services.AddSingleton<IEditContentService>(new StubEditContentService());
+        Services.AddSingleton<IContentSourceService>(new ContentSourceService());
         Services.AddSingleton<ILanguageStateService>(new StubLanguageState());
         Services.AddScoped<DialogService>();
         Services.AddLogging(b => b.AddProvider(_loggerProvider));

--- a/Quilt4Net.Toolkit.Blazor.Tests/Quilt4TextDefaultsTests.cs
+++ b/Quilt4Net.Toolkit.Blazor.Tests/Quilt4TextDefaultsTests.cs
@@ -56,6 +56,7 @@ public class Quilt4TextDefaultsTests
             using var ctx = new BunitContext();
             ctx.Services.AddSingleton<IContentService>(new NotFoundContentService());
             ctx.Services.AddSingleton<IEditContentService>(new StubEditContentService());
+            ctx.Services.AddSingleton<IContentSourceService>(new ContentSourceService());
             ctx.Services.AddSingleton<ILanguageStateService>(new StubLanguageState());
             ctx.Services.AddScoped<DialogService>();
 
@@ -84,6 +85,7 @@ public class Quilt4TextDefaultsTests
             using var ctx = new BunitContext();
             ctx.Services.AddSingleton<IContentService>(new StoredValueContentService("Diarienummer (stored)"));
             ctx.Services.AddSingleton<IEditContentService>(new StubEditContentService());
+            ctx.Services.AddSingleton<IContentSourceService>(new ContentSourceService());
             ctx.Services.AddSingleton<ILanguageStateService>(new StubLanguageState());
             ctx.Services.AddScoped<DialogService>();
 

--- a/Quilt4Net.Toolkit.Blazor/ContentSourceDecoration.cs
+++ b/Quilt4Net.Toolkit.Blazor/ContentSourceDecoration.cs
@@ -1,0 +1,45 @@
+using Quilt4Net.Toolkit.Features.Content;
+
+namespace Quilt4Net.Toolkit.Blazor;
+
+/// <summary>
+/// Shared styling for the content source overlay, so every component annotates a given
+/// <see cref="ContentSource"/> the same way.
+/// </summary>
+/// <remarks>
+/// Colour carries meaning here: red marks a fallback default — the case you are usually hunting,
+/// because it means the server has no value for that key. Green is a fresh server value, blue a
+/// cache hit, amber a stale one. The outline shape matches the existing edit-mode decoration so the
+/// two modes look related.
+/// </remarks>
+internal static class ContentSourceDecoration
+{
+    public static string Style(ContentSource source)
+    {
+        var colour = source switch
+        {
+            ContentSource.Server => "#2e7d32",     // green — fetched now
+            ContentSource.Cache => "#1565c0",      // blue — cached server value
+            ContentSource.StaleCache => "#ef6c00", // amber — cached but past TTL
+            ContentSource.Default => "#c62828",    // red — fallback, server has no value
+            ContentSource.Developer => "#6a1b9a",  // purple — developer language active
+            ContentSource.NoApiKey => "#546e7a",   // grey — no lookup attempted
+            _ => "#546e7a"                         // grey — provenance not reported
+        };
+        return $"outline: 2px solid {colour}; outline-offset: -4px;";
+    }
+
+    public static string Tooltip(ContentSource source)
+    {
+        return source switch
+        {
+            ContentSource.Server => "Source: server (fetched on this render)",
+            ContentSource.Cache => "Source: local cache (value from the server)",
+            ContentSource.StaleCache => "Source: local cache, past its TTL (refreshing in the background)",
+            ContentSource.Default => "Source: fallback default — the server has no value for this key",
+            ContentSource.Developer => "Source: developer language placeholder",
+            ContentSource.NoApiKey => "Source: fallback default — no API key configured, no lookup attempted",
+            _ => "Source: not reported by this IContentService implementation"
+        };
+    }
+}

--- a/Quilt4Net.Toolkit.Blazor/ContentSourceService.cs
+++ b/Quilt4Net.Toolkit.Blazor/ContentSourceService.cs
@@ -1,0 +1,22 @@
+namespace Quilt4Net.Toolkit.Blazor;
+
+/// <inheritdoc cref="IContentSourceService"/>
+public class ContentSourceService : IContentSourceService
+{
+    private bool _enabled;
+
+    /// <inheritdoc />
+    public event EventHandler<SourceModeEventArgs> SourceModeEvent;
+
+    /// <inheritdoc />
+    public bool Enabled
+    {
+        get => _enabled;
+        set
+        {
+            if (_enabled == value) return;
+            _enabled = value;
+            SourceModeEvent?.Invoke(this, new SourceModeEventArgs(value));
+        }
+    }
+}

--- a/Quilt4Net.Toolkit.Blazor/Features/Language/LanguageSelector.razor
+++ b/Quilt4Net.Toolkit.Blazor/Features/Language/LanguageSelector.razor
@@ -4,6 +4,7 @@
 @inject ILanguageStateService LanguageStateService
 @inject IContentService ContentService
 @inject IEditContentService EditContentService
+@inject IContentSourceService ContentSourceService
 @inject IContentAdminService ContentAdminService
 @inject NavigationManager NavigationManager
 
@@ -25,6 +26,10 @@
                     <RadzenMenuItem Text="Debug mode" Icon="@devModeIcon" Click="@(_ => LanguageStateService.DeveloperMode = !LanguageStateService.DeveloperMode)" />
                     var editIcon = EditContentService.Enabled ? "check_box" : "check_box_outline_blank";
                     <RadzenMenuItem Text="Edit mode" Icon="@editIcon" Click="@(_ => EditContentService.Enabled = !EditContentService.Enabled)" />
+                    @* Deliberately NOT called "debug mode" — that label is already taken above by
+                       developer-language mode. This one annotates provenance, it does not swap text. *@
+                    var sourceIcon = ContentSourceService.Enabled ? "check_box" : "check_box_outline_blank";
+                    <RadzenMenuItem Text="Show content source" Icon="@sourceIcon" Click="@(_ => ContentSourceService.Enabled = !ContentSourceService.Enabled)" />
                 }
             </RadzenMenuItem>
         </RadzenMenu>

--- a/Quilt4Net.Toolkit.Blazor/IContentSourceService.cs
+++ b/Quilt4Net.Toolkit.Blazor/IContentSourceService.cs
@@ -1,0 +1,19 @@
+namespace Quilt4Net.Toolkit.Blazor;
+
+/// <summary>
+/// Toggles the content source overlay: when enabled, content components annotate each rendered
+/// value with where it came from — server, cache, stale cache or fallback default.
+/// </summary>
+/// <remarks>
+/// Distinct from <c>ILanguageStateService.DeveloperMode</c>, which the language selector labels
+/// "Debug mode" — that one swaps in the developer pseudo-language so every key renders as a
+/// placeholder. This one leaves the rendered text alone and only annotates its provenance.
+/// </remarks>
+public interface IContentSourceService
+{
+    /// <summary>Raised when <see cref="Enabled"/> changes, so rendered components can restyle.</summary>
+    event EventHandler<SourceModeEventArgs> SourceModeEvent;
+
+    /// <summary>Whether the source overlay is currently shown.</summary>
+    bool Enabled { get; set; }
+}

--- a/Quilt4Net.Toolkit.Blazor/Quilt4Content.razor
+++ b/Quilt4Net.Toolkit.Blazor/Quilt4Content.razor
@@ -6,11 +6,12 @@
 @inject IJSRuntime JsRuntime
 @inject IContentService ContentService
 @inject IEditContentService EditContentService
+@inject IContentSourceService ContentSourceService
 @inject ILanguageStateService LanguageStateService
 @inject DialogService DialogService
 @inject ILogger<Quilt4Content> Logger
 
-<span style="@(string.IsNullOrEmpty(_content) ? "display:none" : _edit)" @onclick="OpenDialog" role="button" tabindex="0" @onkeydown="OnKeyDown">
+<span style="@(string.IsNullOrEmpty(_content) ? "display:none" : GetStyle())" title="@GetTitle()" @onclick="OpenDialog" role="button" tabindex="0" @onkeydown="OnKeyDown">
     @((MarkupString)(_content ?? ""))
 </span>
 <div style="display:none" @ref="_holder">
@@ -26,7 +27,19 @@
     private IJSObjectReference _mod;
     private string _content;
     private string _edit = "";
-    private (string Value, bool Success) _response;
+    private bool _showSource;
+    private ContentResult _response;
+
+    // Edit mode wins when both are on — it carries the click-to-edit cursor affordance. Source mode
+    // is read-only annotation, so it yields.
+    private string GetStyle()
+    {
+        if (EditContentService.Enabled) return _edit;
+        if (_showSource && _response != null) return $"{_edit} {ContentSourceDecoration.Style(_response.Source)}";
+        return _edit;
+    }
+
+    private string GetTitle() => _showSource && _response != null ? ContentSourceDecoration.Tooltip(_response.Source) : null;
 
     [Parameter]
     public string Key { get; set; }
@@ -48,14 +61,21 @@
         };
         _edit = EditContentService.Enabled ? EditStyle : "cursor: text;";
 
+        ContentSourceService.SourceModeEvent += async (_, e) =>
+        {
+            _showSource = e.Enabled;
+            await InvokeAsync(StateHasChanged);
+        };
+        _showSource = ContentSourceService.Enabled;
+
         await LoadContentAsync();
     }
 
     private async Task LoadContentAsync()
     {
         //NOTE: Provide empty string as default here, because default needs to be loaded after render. (null would give an answer that we do not want.)
-        _response = await ContentService.GetContentAsync(Key, "", LanguageStateService.Selected?.Key ?? Guid.Empty, null);
-        if (_response.Success) _content = _response.Value;
+        _response = await ContentService.GetContentResultAsync(Key, "", LanguageStateService.Selected?.Key ?? Guid.Empty, null);
+        if (_response?.Success == true) _content = _response.Value;
     }
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
@@ -81,7 +101,7 @@
             {
                 var defaultHtml = await _mod.InvokeAsync<string>("getInnerHtml", _holder);
 
-                if (_response.Success)
+                if (_response?.Success == true)
                 {
                     // Auto-registering the default value is best-effort: a transient HTTP failure
                     // (401, server unreachable, etc.) must not crash the consuming page — the
@@ -113,7 +133,7 @@
     private async Task OpenDialog()
     {
         if (!EditContentService.Enabled) return;
-        if (!_response.Success) return;
+        if (_response?.Success != true) return;
 
         var response = await DialogService.OpenAsync<ContentEditDialog>($"Edit {Key}",
             new Dictionary<string, object>
@@ -124,7 +144,7 @@
             }, new DialogOptions { Resizable = true, Draggable = true });
         if (response != true) return;
 
-        _response = await ContentService.GetContentAsync(Key, null, LanguageStateService.Selected?.Key ?? Guid.Empty, null);
+        _response = await ContentService.GetContentResultAsync(Key, null, LanguageStateService.Selected?.Key ?? Guid.Empty, null);
         _content = _response.Value;
         StateHasChanged();
     }

--- a/Quilt4Net.Toolkit.Blazor/Quilt4ContentRegistration.cs
+++ b/Quilt4Net.Toolkit.Blazor/Quilt4ContentRegistration.cs
@@ -29,6 +29,7 @@ public static class Quilt4ContentRegistration
     public static IServiceCollection AddQuilt4NetBlazorContent(this IServiceCollection services, IConfiguration configuration, Action<ContentOptions> options = null)
     {
         services.AddScoped<IEditContentService, EditContentService>();
+        services.AddScoped<IContentSourceService, ContentSourceService>();
         services.AddScoped<ILanguageStateService, LanguageStateService>();
         services.AddScoped<IQuilt4ContentService, Quilt4ContentService>();
         services.AddScoped<IContentAdminService, ContentAdminService>();

--- a/Quilt4Net.Toolkit.Blazor/Quilt4Raw.razor
+++ b/Quilt4Net.Toolkit.Blazor/Quilt4Raw.razor
@@ -2,13 +2,24 @@
 @using Quilt4Net.Toolkit.Features.FeatureToggle
 @inject IContentService ContentService
 @inject IEditContentService EditContentService
+@inject IContentSourceService ContentSourceService
 @inject ILanguageStateService LanguageStateService
 
-@_content
+@if (_showSource && _response != null)
+{
+    @* Source mode needs an element to carry the outline + tooltip. Off, this component renders the
+       value bare exactly as before — no wrapper, no markup change. *@
+    <span style="@ContentSourceDecoration.Style(_response.Source)" title="@ContentSourceDecoration.Tooltip(_response.Source)">@_content</span>
+}
+else
+{
+    @_content
+}
 
 @code {
     private string _content;
-    private (string Value, bool Success) _response;
+    private bool _showSource;
+    private ContentResult _response;
 
     [Parameter]
     public string Key { get; set; }
@@ -31,13 +42,19 @@
         {
             StateHasChanged();
         };
+        ContentSourceService.SourceModeEvent += async (s, e) =>
+        {
+            _showSource = e.Enabled;
+            await InvokeAsync(StateHasChanged);
+        };
+        _showSource = ContentSourceService.Enabled;
 
         await LoadContentAsync();
     }
 
     private async Task LoadContentAsync()
     {
-        _response = await ContentService.GetContentAsync(Key, Default, LanguageStateService.Selected?.Key ?? Guid.Empty, ContentFormat.String, application: null, translations: Translations);
+        _response = await ContentService.GetContentResultAsync(Key, Default, LanguageStateService.Selected?.Key ?? Guid.Empty, ContentFormat.String, application: null, translations: Translations);
         _content = _response.Value;
     }
 }

--- a/Quilt4Net.Toolkit.Blazor/Quilt4Span.razor
+++ b/Quilt4Net.Toolkit.Blazor/Quilt4Span.razor
@@ -2,13 +2,19 @@
 @using Quilt4Net.Toolkit.Features.FeatureToggle
 @inject IContentService ContentService
 @inject IEditContentService EditContentService
+@inject IContentSourceService ContentSourceService
 @inject ILanguageStateService LanguageStateService
 
-<span>@_content</span>
+<span style="@GetStyle()" title="@GetTitle()">@_content</span>
 
 @code {
     private string _content;
-    private (string Value, bool Success) _response;
+    private bool _showSource;
+    private ContentResult _response;
+
+    private string GetStyle() => _showSource && _response != null ? ContentSourceDecoration.Style(_response.Source) : null;
+
+    private string GetTitle() => _showSource && _response != null ? ContentSourceDecoration.Tooltip(_response.Source) : null;
 
     [Parameter]
     public string Key { get; set; }
@@ -31,13 +37,19 @@
         {
             StateHasChanged();
         };
+        ContentSourceService.SourceModeEvent += async (s, e) =>
+        {
+            _showSource = e.Enabled;
+            await InvokeAsync(StateHasChanged);
+        };
+        _showSource = ContentSourceService.Enabled;
 
         await LoadContentAsync();
     }
 
     private async Task LoadContentAsync()
     {
-        _response = await ContentService.GetContentAsync(Key, Default, LanguageStateService.Selected?.Key ?? Guid.Empty, ContentFormat.String, application: null, translations: Translations);
+        _response = await ContentService.GetContentResultAsync(Key, Default, LanguageStateService.Selected?.Key ?? Guid.Empty, ContentFormat.String, application: null, translations: Translations);
         _content = _response.Value;
     }
 }

--- a/Quilt4Net.Toolkit.Blazor/Quilt4Text.razor
+++ b/Quilt4Net.Toolkit.Blazor/Quilt4Text.razor
@@ -3,16 +3,18 @@
 @using Quilt4Net.Toolkit.Features.FeatureToggle
 @inject IContentService ContentService
 @inject IEditContentService EditContentService
+@inject IContentSourceService ContentSourceService
 @inject ILanguageStateService LanguageStateService
 @inject Radzen.DialogService DialogService
 
-<RadzenText Text="@_content" TextStyle="@TextStyle" Attributes="@(new Dictionary<string, object> { { "onclick", EventCallback.Factory.Create<MouseEventArgs>(this, OpenDialog) } })" style="@GetStyle()" Visible="@Visible" />
+<RadzenText Text="@_content" TextStyle="@TextStyle" Attributes="@GetAttributes()" style="@GetStyle()" Visible="@Visible" />
 
 @code {
     private const string EditStyle = "outline: 2px dotted #ffc0cb; outline-offset: -4px; cursor: pointer;";
     private string _content;
     private string _edit = null;
-    private (string Value, bool Success) _response;
+    private bool _showSource;
+    private ContentResult _response;
 
     [Parameter]
     public string Key { get; set; }
@@ -48,7 +50,26 @@
     [Parameter]
     public string Style { get; set; }
 
-    private string GetStyle() => _edit ?? Style;
+    // Edit mode wins when both are on — it is interactive (click-to-edit) and its cursor affordance
+    // must survive. Source mode is read-only annotation, so it yields.
+    private string GetStyle()
+    {
+        if (_edit != null) return _edit;
+        // _response is null until the first load completes, so fall back to Unknown rather than
+        // faulting on an early render.
+        if (_showSource && _response != null) return $"{Style}{(string.IsNullOrEmpty(Style) ? "" : " ")}{ContentSourceDecoration.Style(_response.Source)}";
+        return Style;
+    }
+
+    private Dictionary<string, object> GetAttributes()
+    {
+        var attributes = new Dictionary<string, object>
+        {
+            { "onclick", EventCallback.Factory.Create<MouseEventArgs>(this, OpenDialog) }
+        };
+        if (_showSource && _response != null) attributes["title"] = ContentSourceDecoration.Tooltip(_response.Source);
+        return attributes;
+    }
 
     protected override async Task OnInitializedAsync()
     {
@@ -64,6 +85,15 @@
         };
         _edit = EditContentService.Enabled ? EditStyle : null;
 
+        // InvokeAsync so the toggle works from any thread, not just a UI click — matches the
+        // LanguageChangedEvent handler above.
+        ContentSourceService.SourceModeEvent += async (s, e) =>
+        {
+            _showSource = e.Enabled;
+            await InvokeAsync(StateHasChanged);
+        };
+        _showSource = ContentSourceService.Enabled;
+
         await LoadContentAsync();
     }
 
@@ -74,14 +104,14 @@
         var effectiveDefault = Defaults is { Count: > 0 }
             ? LanguageDefaultResolver.Resolve(Defaults, Default, Key)
             : Default;
-        _response = await ContentService.GetContentAsync(Key, effectiveDefault, LanguageStateService.Selected?.Key ?? Guid.Empty, ContentFormat.String, application: null, translations: Translations);
+        _response = await ContentService.GetContentResultAsync(Key, effectiveDefault, LanguageStateService.Selected?.Key ?? Guid.Empty, ContentFormat.String, application: null, translations: Translations);
         _content = _response.Value;
     }
 
     private async Task OpenDialog()
     {
         if (!EditContentService.Enabled) return;
-        if (!_response.Success) return;
+        if (_response?.Success != true) return;
 
         var result = await DialogService.OpenAsync<ContentEditDialog>($"Edit {Key}",
             new Dictionary<string, object>
@@ -92,7 +122,7 @@
             }, new DialogOptions { Resizable = true, Draggable = true });
         if (result != true) return;
 
-        _response = await ContentService.GetContentAsync(Key, null, LanguageStateService.Selected?.Key ?? Guid.Empty, null);
+        _response = await ContentService.GetContentResultAsync(Key, null, LanguageStateService.Selected?.Key ?? Guid.Empty, null);
         _content = _response.Value;
         StateHasChanged();
     }

--- a/Quilt4Net.Toolkit.Blazor/README.md
+++ b/Quilt4Net.Toolkit.Blazor/README.md
@@ -540,6 +540,43 @@ Or use the built-in admin component.
 
 The `ContentAdmin` component provides toggle switches for edit mode and developer mode, plus a button to reload content.
 
+## Content source
+
+Enable the source overlay by setting `Enabled` on `IContentSourceService`, or from the
+`LanguageSelector` menu (**Show content source**, admin only). Each rendered value is outlined and
+gets a tooltip naming where it came from.
+
+```csharp
+@inject IContentSourceService ContentSourceService
+
+<button @onclick="() => ContentSourceService.Enabled = !ContentSourceService.Enabled">
+    Toggle content source
+</button>
+```
+
+| Colour | Source | Meaning |
+|---|---|---|
+| Red | `Default` | The server has no value for this key — the hard-coded default is rendering. |
+| Green | `Server` | Fetched on this render. |
+| Blue | `Cache` | Cached value that came from the server. |
+| Amber | `StaleCache` | Cached, past TTL, refreshing in the background. |
+| Purple | `Developer` | Developer-language placeholder. |
+| Grey | `NoApiKey` / `Unknown` | No lookup attempted, or provenance not reported. |
+
+Red is the one to look for: it means the text you are seeing is not managed by Quilt4Net.
+
+Supported on `Quilt4Text`, `Quilt4Span`, `Quilt4Raw` and `Quilt4Content`. `Quilt4PageTitle` is not
+included — it renders into `<PageTitle>`, which has no on-page surface to annotate.
+
+Notes:
+
+- **Edit mode wins.** With both enabled, the edit outline is shown, since it carries the
+  click-to-edit affordance.
+- **`Quilt4Raw` normally renders with no wrapping element.** It adds a `<span>` only while the
+  overlay is on; with it off, markup is unchanged.
+- This is distinct from **developer mode** (labelled "Debug mode" in the language menu), which
+  replaces every value with a placeholder. The source overlay leaves the text alone.
+
 ## Languages
 
 Content supports multiple languages managed at [Quilt4Net Web](https://quilt4net.com).

--- a/Quilt4Net.Toolkit.Blazor/SourceModeEventArgs.cs
+++ b/Quilt4Net.Toolkit.Blazor/SourceModeEventArgs.cs
@@ -1,0 +1,14 @@
+namespace Quilt4Net.Toolkit.Blazor;
+
+/// <summary>Carries the new state of the content source overlay.</summary>
+public class SourceModeEventArgs : EventArgs
+{
+    /// <summary>Creates the event args.</summary>
+    public SourceModeEventArgs(bool enabled)
+    {
+        Enabled = enabled;
+    }
+
+    /// <summary>Whether the source overlay is now enabled.</summary>
+    public bool Enabled { get; }
+}

--- a/Quilt4Net.Toolkit.Tests/ContentDiagnosticsLoggingTests.cs
+++ b/Quilt4Net.Toolkit.Tests/ContentDiagnosticsLoggingTests.cs
@@ -56,6 +56,25 @@ public class ContentDiagnosticsLoggingTests
             "the per-resolution Debug line must carry the resolved language so a slow/looping load is traceable by key + language");
     }
 
+    // Content was registered but no API key was supplied, so every value silently falls back to its
+    // default. Warning, not Error — nothing failed and a key-less setup is valid for local dev — and
+    // once per process, because the check runs on every single read.
+    [Fact]
+    public async Task Missing_api_key_logs_a_warning_once_not_per_read()
+    {
+        using var listener = StartListener(out var prefix, HttpStatusCode.NotFound, TimeSpan.Zero);
+        var recorder = new RecordingLoggerProvider();
+        var service = BuildContentService(prefix, recorder, o => o.ApiKey = "");
+
+        for (var i = 0; i < 5; i++)
+            await service.GetContentAsync("Some.Key", "the-default", Guid.NewGuid(), ContentFormat.String, application: "App");
+
+        var warnings = recorder.Entries.Count(e => e.Level == LogLevel.Warning && e.Message.Contains("API key"));
+        warnings.Should().Be(1, "a missing API key is a startup misconfiguration, not a per-read event");
+        recorder.Entries.Should().NotContain(e => e.Level == LogLevel.Error,
+            "no API key is a misconfiguration, not a failure — the app still renders from defaults");
+    }
+
     private static IContentService BuildContentService(string baseAddress, ILoggerProvider loggerProvider, Action<ContentOptions> configure)
     {
         var host = Host.CreateDefaultBuilder()

--- a/Quilt4Net.Toolkit.Tests/ContentNotFoundLoggingTests.cs
+++ b/Quilt4Net.Toolkit.Tests/ContentNotFoundLoggingTests.cs
@@ -12,11 +12,16 @@ namespace Quilt4Net.Toolkit.Tests;
 
 // Issue #131: RemoteContentCallService logged an Error for every missing-key fallback, flooding
 // logs/telemetry. A key with no override (404) is the designed "use the caller's Default" path and
-// must log at Debug; genuinely unexpected failures (5xx) must still log Error.
+// must not log at Error; genuinely unexpected failures (5xx) must still log Error.
+//
+// Level revised from Debug to Information: an unseeded key is actionable (someone should seed it)
+// and Debug is not enabled in practice, so it was effectively invisible. This does not reintroduce
+// the #131 flood — the negative cache means it fires once per key per FailureCacheDuration rather
+// than once per render (pinned by Missing_Key_404_Is_Negative_Cached_And_Not_Re_Requested below).
 public class ContentNotFoundLoggingTests
 {
     [Fact]
-    public async Task Missing_Key_404_Is_Logged_At_Debug_Not_Error()
+    public async Task Missing_Key_404_Is_Logged_At_Information_Not_Error()
     {
         using var listener = StartListener(out var prefix, out var requestCount, HttpStatusCode.NotFound);
         var recorder = new RecordingLoggerProvider();
@@ -29,8 +34,25 @@ public class ContentNotFoundLoggingTests
 
         recorder.Entries.Should().NotContain(e => e.Level == LogLevel.Error,
             "a missing key (404) is the designed fallback path and must not be logged at Error");
-        recorder.Entries.Should().Contain(e => e.Level == LogLevel.Debug && e.Message.Contains("Missing.Key"),
-            "the miss should still be traceable at Debug");
+        recorder.Entries.Should().Contain(e => e.Level == LogLevel.Information && e.Message.Contains("Missing.Key"),
+            "an unseeded key is actionable, and Debug is not enabled in practice — it must be visible at Information");
+    }
+
+    // The safety property that makes Information an acceptable level here. If this regresses, #131's
+    // flood is back — a line per unseeded key per render, which is what FortDocs hit at ~290/session.
+    [Fact]
+    public async Task Missing_Key_404_Is_Logged_Once_Not_Once_Per_Render()
+    {
+        using var listener = StartListener(out var prefix, out _, HttpStatusCode.NotFound);
+        var recorder = new RecordingLoggerProvider();
+        var service = BuildContentService(prefix, recorder);
+        var languageKey = Guid.NewGuid();
+
+        for (var i = 0; i < 5; i++)
+            await service.GetContentAsync("Missing.Key", "the-default", languageKey, ContentFormat.String, application: "App");
+
+        recorder.Entries.Count(e => e.Level == LogLevel.Information && e.Message.Contains("Missing.Key"))
+            .Should().Be(1, "the negative cache must keep this to once per key per FailureCacheDuration, not once per render");
     }
 
     [Fact]

--- a/Quilt4Net.Toolkit.Tests/ContentSourceTests.cs
+++ b/Quilt4Net.Toolkit.Tests/ContentSourceTests.cs
@@ -1,0 +1,185 @@
+using System.Net;
+using System.Text;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Quilt4Net.Toolkit.Features.Content;
+using Quilt4Net.Toolkit.Features.FeatureToggle;
+using Xunit;
+
+namespace Quilt4Net.Toolkit.Tests;
+
+// Content source indicator: GetContentResultAsync reports where a value actually came from, so a
+// consumer can tell real server content apart from a cache hit or a fallback default. The
+// distinction already existed inside RemoteContentCallService but was only written to the Debug log.
+public class ContentSourceTests
+{
+    [Fact]
+    public async Task Fresh_fetch_reports_server()
+    {
+        using var listener = StartListener(out var prefix, found: true);
+        var service = BuildContentService(prefix);
+
+        var result = await service.GetContentResultAsync("Some.Key", "the-default", Guid.NewGuid(), ContentFormat.String, application: "App");
+
+        result.Source.Should().Be(ContentSource.Server);
+        result.Value.Should().Be("from-server");
+        result.Stale.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task Second_read_of_server_content_reports_cache()
+    {
+        using var listener = StartListener(out var prefix, found: true);
+        var service = BuildContentService(prefix);
+        var languageKey = Guid.NewGuid();
+
+        await service.GetContentResultAsync("Some.Key", "the-default", languageKey, ContentFormat.String, application: "App");
+        var second = await service.GetContentResultAsync("Some.Key", "the-default", languageKey, ContentFormat.String, application: "App");
+
+        second.Source.Should().Be(ContentSource.Cache);
+        second.Value.Should().Be("from-server");
+        second.Stale.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task Unseeded_key_reports_default()
+    {
+        using var listener = StartListener(out var prefix, found: false);
+        var service = BuildContentService(prefix);
+
+        var result = await service.GetContentResultAsync("Missing.Key", "the-default", Guid.NewGuid(), ContentFormat.String, application: "App");
+
+        result.Source.Should().Be(ContentSource.Default);
+        result.Value.Should().Be("the-default");
+        result.Stale.Should().BeTrue();
+    }
+
+    // The trap this feature exists to avoid. CacheFailure writes the caller's default into the local
+    // cache after a 404 so the key isn't re-requested every render. Without provenance stored on the
+    // cache entry, that default comes back through the cache branch and would be reported as a
+    // genuine cache hit from the second render onwards — lying in exactly the case the indicator is
+    // meant to diagnose.
+    [Fact]
+    public async Task Cached_default_still_reports_default_on_second_read()
+    {
+        using var listener = StartListener(out var prefix, found: false);
+        var service = BuildContentService(prefix);
+        var languageKey = Guid.NewGuid();
+
+        await service.GetContentResultAsync("Missing.Key", "the-default", languageKey, ContentFormat.String, application: "App");
+        var second = await service.GetContentResultAsync("Missing.Key", "the-default", languageKey, ContentFormat.String, application: "App");
+
+        second.Source.Should().Be(ContentSource.Default,
+            "a negative-cache entry holds the caller's default, not server content, so it must never report as Cache");
+        second.Value.Should().Be("the-default");
+        second.Stale.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task Missing_api_key_reports_noapikey()
+    {
+        using var listener = StartListener(out var prefix, found: true);
+        var service = BuildContentService(prefix, o => o.ApiKey = "");
+
+        var result = await service.GetContentResultAsync("Some.Key", "the-default", Guid.NewGuid(), ContentFormat.String, application: "App");
+
+        result.Source.Should().Be(ContentSource.NoApiKey);
+        result.Value.Should().Be("the-default");
+    }
+
+    [Fact]
+    public async Task Developer_language_reports_developer()
+    {
+        using var listener = StartListener(out var prefix, found: true);
+        var service = BuildContentService(prefix);
+
+        var result = await service.GetContentResultAsync("Some.Key", "the-default", Language.DeveloperLanguageKey, ContentFormat.String, application: "App");
+
+        result.Source.Should().Be(ContentSource.Developer);
+    }
+
+    // Regression guard: the legacy tuple must keep its exact behaviour. A cached default previously
+    // returned Success = true, and consumers may branch on that.
+    [Fact]
+    public async Task Legacy_tuple_keeps_success_true_for_a_cached_default()
+    {
+        using var listener = StartListener(out var prefix, found: false);
+        var service = BuildContentService(prefix);
+        var languageKey = Guid.NewGuid();
+
+        await service.GetContentAsync("Missing.Key", "the-default", languageKey, ContentFormat.String, application: "App");
+        var second = await service.GetContentAsync("Missing.Key", "the-default", languageKey, ContentFormat.String, application: "App");
+
+        second.Success.Should().BeTrue("the legacy tuple's Success semantics must not change");
+        second.Value.Should().Be("the-default");
+    }
+
+    private static IContentService BuildContentService(string baseAddress, Action<ContentOptions> configure = null)
+    {
+        var host = Host.CreateDefaultBuilder()
+            .ConfigureServices(services =>
+            {
+                services.AddQuilt4NetContent(null, o =>
+                {
+                    o.Quilt4NetAddress = baseAddress;
+                    o.ApiKey = "test-key";
+                    o.SlowLogThreshold = TimeSpan.Zero;
+                    // Keep the negative-cache entry fresh for the duration of a test so the second
+                    // read takes the cache branch rather than re-fetching.
+                    o.FailureCacheDuration = TimeSpan.FromMinutes(5);
+                    configure?.Invoke(o);
+                });
+                services.AddLogging(b => b.ClearProviders());
+            })
+            .Build();
+
+        return host.Services.GetRequiredService<IContentService>();
+    }
+
+    private static HttpListener StartListener(out string prefix, bool found)
+    {
+        var port = GetFreePort();
+        prefix = $"http://127.0.0.1:{port}/";
+        var listener = new HttpListener();
+        listener.Prefixes.Add(prefix);
+        listener.Start();
+
+        _ = Task.Run(async () =>
+        {
+            while (listener.IsListening)
+            {
+                HttpListenerContext ctx;
+                try { ctx = await listener.GetContextAsync(); }
+                catch { return; }
+
+                if (!found)
+                {
+                    ctx.Response.StatusCode = (int)HttpStatusCode.NotFound;
+                    ctx.Response.Close();
+                    continue;
+                }
+
+                var validTo = DateTime.UtcNow.AddMinutes(10).ToString("O");
+                var json = $"{{\"value\":\"from-server\",\"validTo\":\"{validTo}\"}}";
+                var bytes = Encoding.UTF8.GetBytes(json);
+                ctx.Response.StatusCode = (int)HttpStatusCode.OK;
+                ctx.Response.ContentType = "application/json";
+                await ctx.Response.OutputStream.WriteAsync(bytes);
+                ctx.Response.Close();
+            }
+        });
+
+        return listener;
+    }
+
+    private static int GetFreePort()
+    {
+        using var l = new System.Net.Sockets.TcpListener(IPAddress.Loopback, 0);
+        l.Start();
+        var port = ((IPEndPoint)l.LocalEndpoint).Port;
+        l.Stop();
+        return port;
+    }
+}

--- a/Quilt4Net.Toolkit/Features/Content/CachedContent.cs
+++ b/Quilt4Net.Toolkit/Features/Content/CachedContent.cs
@@ -1,0 +1,24 @@
+namespace Quilt4Net.Toolkit.Features.Content;
+
+/// <summary>
+/// A local cache entry. Distinct from the wire DTO <c>GetContentResponse</c> because the cache also
+/// holds negative entries — the caller's default written after a 404, a timeout or an error, so the
+/// key isn't re-requested (and re-logged) on every render.
+/// </summary>
+/// <remarks>
+/// <see cref="IsDefault"/> is what stops a negative entry being reported as a genuine cache hit on
+/// the next read. Without it, an unseeded key looks identical to real server content from the
+/// second render onwards — which would make the source indicator lie in exactly the case it exists
+/// to diagnose.
+/// </remarks>
+internal record CachedContent
+{
+    /// <summary>The cached value.</summary>
+    public required string Value { get; init; }
+
+    /// <summary>When this entry stops being fresh.</summary>
+    public required DateTime ValidTo { get; init; }
+
+    /// <summary>True when this entry holds a fallback default rather than a value from the server.</summary>
+    public bool IsDefault { get; init; }
+}

--- a/Quilt4Net.Toolkit/Features/Content/ContentResult.cs
+++ b/Quilt4Net.Toolkit/Features/Content/ContentResult.cs
@@ -1,0 +1,31 @@
+namespace Quilt4Net.Toolkit.Features.Content;
+
+/// <summary>
+/// A resolved content value together with its provenance.
+/// </summary>
+/// <remarks>
+/// The older <c>(string Value, bool Success)</c> tuple is kept for backward compatibility, but its
+/// <c>Success</c> flag is not a source discriminator — it is <c>true</c> for a cache hit, a stale
+/// cache hit and a fresh server fetch alike, and <c>false</c> for a missing API key, a 404, a
+/// timeout and an exception alike. Use <see cref="Source"/> when the distinction matters.
+/// </remarks>
+public record ContentResult
+{
+    /// <summary>The resolved value. Never null — falls back to the caller's default.</summary>
+    public required string Value { get; init; }
+
+    /// <summary>
+    /// Whether the lookup path completed without falling back. Retained to match the legacy tuple;
+    /// prefer <see cref="Source"/> for anything finer-grained.
+    /// </summary>
+    public required bool Success { get; init; }
+
+    /// <summary>Where <see cref="Value"/> came from.</summary>
+    public required ContentSource Source { get; init; }
+
+    /// <summary>
+    /// True when the value is not known to be current — a stale cache entry, or a default standing
+    /// in for a value the server never confirmed.
+    /// </summary>
+    public required bool Stale { get; init; }
+}

--- a/Quilt4Net.Toolkit/Features/Content/ContentService.cs
+++ b/Quilt4Net.Toolkit/Features/Content/ContentService.cs
@@ -16,6 +16,11 @@ internal class ContentService : IContentService
         return _remoteContentCallService.GetContentAsync(key, defaultValue, languageKey, contentType, application, translations);
     }
 
+    public Task<ContentResult> GetContentResultAsync(string key, string defaultValue, Guid languageKey, ContentFormat? contentType, string application = null, IReadOnlyDictionary<string, string> translations = null)
+    {
+        return _remoteContentCallService.GetContentResultAsync(key, defaultValue, languageKey, contentType, application, translations);
+    }
+
     public Task SetContentAsync(string key, string value, Guid languageKey, ContentFormat contentType, string application = null)
     {
         return _remoteContentCallService.SetContentAsync(key, value, languageKey, contentType, application);

--- a/Quilt4Net.Toolkit/Features/Content/ContentSource.cs
+++ b/Quilt4Net.Toolkit/Features/Content/ContentSource.cs
@@ -1,0 +1,41 @@
+namespace Quilt4Net.Toolkit.Features.Content;
+
+/// <summary>
+/// Where a resolved content value actually came from. Surfaced so a consumer can tell a real
+/// server value apart from a fallback — the distinction the toolkit has always resolved
+/// internally but previously only wrote to the Debug log.
+/// </summary>
+public enum ContentSource
+{
+    /// <summary>
+    /// The caller's default value was used — the server had no override for the key (404), was
+    /// unreachable, or timed out. Also reported for a cached entry that holds a default rather
+    /// than server content, so a negative-cache hit is never mistaken for a real cache hit.
+    /// </summary>
+    Default,
+
+    /// <summary>Served from the local cache, within its TTL, from a value the server supplied.</summary>
+    Cache,
+
+    /// <summary>
+    /// Served from the local cache after its TTL expired, with a background refresh started
+    /// (stale-while-revalidate). The value came from the server, but may be out of date.
+    /// </summary>
+    StaleCache,
+
+    /// <summary>Fetched from Quilt4Net.Server on this call.</summary>
+    Server,
+
+    /// <summary>Developer language is active — every key resolves to the placeholder text.</summary>
+    Developer,
+
+    /// <summary>No API key is configured, so no lookup was attempted and the default was used.</summary>
+    NoApiKey,
+
+    /// <summary>
+    /// The <see cref="IContentService"/> implementation does not report provenance. Returned by the
+    /// default interface implementation, so a custom or test implementation that only overrides
+    /// <c>GetContentAsync</c> reports "unknown" rather than guessing.
+    /// </summary>
+    Unknown
+}

--- a/Quilt4Net.Toolkit/Features/Content/IContentService.cs
+++ b/Quilt4Net.Toolkit/Features/Content/IContentService.cs
@@ -5,6 +5,22 @@ namespace Quilt4Net.Toolkit.Features.Content;
 public interface IContentService
 {
     Task<(string Value, bool Success)> GetContentAsync(string key, string defaultValue, Guid languageKey, ContentFormat? contentType, string application = null, IReadOnlyDictionary<string, string> translations = null);
+
+    /// <summary>
+    /// As <see cref="GetContentAsync"/>, but also reports where the value came from
+    /// (<see cref="ContentSource"/>) — server, cache, stale cache or fallback default.
+    /// </summary>
+    /// <remarks>
+    /// A default implementation is provided so adding this member does not break existing
+    /// implementers of this public interface. It delegates to <see cref="GetContentAsync"/> and
+    /// reports <see cref="ContentSource.Unknown"/> rather than inventing a provenance it cannot
+    /// know. The built-in implementation overrides it with the real source.
+    /// </remarks>
+    async Task<ContentResult> GetContentResultAsync(string key, string defaultValue, Guid languageKey, ContentFormat? contentType, string application = null, IReadOnlyDictionary<string, string> translations = null)
+    {
+        var (value, success) = await GetContentAsync(key, defaultValue, languageKey, contentType, application, translations);
+        return new ContentResult { Value = value, Success = success, Source = ContentSource.Unknown, Stale = !success };
+    }
     Task SetContentAsync(string key, string value, Guid languageKey, ContentFormat contentType, string application = null);
     Task ClearCacheAsync();
 }

--- a/Quilt4Net.Toolkit/Features/Content/IRemoteContentCallService.cs
+++ b/Quilt4Net.Toolkit/Features/Content/IRemoteContentCallService.cs
@@ -5,6 +5,12 @@ namespace Quilt4Net.Toolkit.Features.Content;
 public interface IRemoteContentCallService
 {
     Task<(string Value, bool Success)> GetContentAsync(string key, string defaultValue, Guid languageKey, ContentFormat? contentType, string application = null, IReadOnlyDictionary<string, string> translations = null);
+
+    /// <summary>
+    /// As <see cref="GetContentAsync"/>, but also reports where the value came from. Prefer this
+    /// when the caller needs to tell a server value apart from a cached one or a fallback default.
+    /// </summary>
+    Task<ContentResult> GetContentResultAsync(string key, string defaultValue, Guid languageKey, ContentFormat? contentType, string application = null, IReadOnlyDictionary<string, string> translations = null);
     Task SetContentAsync(string key, string defaultValue, Guid languageKey, ContentFormat contentType, string application = null);
     Task<Language[]> GetLanguagesAsync(bool forceReload);
     Task ClearContentCacheAsync();

--- a/Quilt4Net.Toolkit/Features/Content/RemoteContentCallService.cs
+++ b/Quilt4Net.Toolkit/Features/Content/RemoteContentCallService.cs
@@ -18,7 +18,7 @@ internal class RemoteContentCallService : IRemoteContentCallService
     private readonly EnvironmentName _environmentName;
     private readonly ContentOptions _contentOptions;
     private readonly ILogger<RemoteContentCallService> _logger;
-    private readonly ConcurrentDictionary<string, GetContentResponse> _localCache = new();
+    private readonly ConcurrentDictionary<string, CachedContent> _localCache = new();
     private readonly ConcurrentDictionary<string, TimeSpan> _lastKnownTtl = new();
     private readonly ConcurrentDictionary<string, bool> _refreshInProgress = new();
     private Language[] _languages;
@@ -40,11 +40,17 @@ internal class RemoteContentCallService : IRemoteContentCallService
 
     public async Task<(string Value, bool Success)> GetContentAsync(string key, string defaultValue, Guid languageKey, ContentFormat? contentType, string application = null, IReadOnlyDictionary<string, string> translations = null)
     {
-        if (languageKey == Language.DeveloperLanguageKey) return ("X", true);
+        var result = await GetContentResultAsync(key, defaultValue, languageKey, contentType, application, translations);
+        return (result.Value, result.Success);
+    }
+
+    public async Task<ContentResult> GetContentResultAsync(string key, string defaultValue, Guid languageKey, ContentFormat? contentType, string application = null, IReadOnlyDictionary<string, string> translations = null)
+    {
+        if (languageKey == Language.DeveloperLanguageKey) return Result("X", true, ContentSource.Developer, false);
 
         defaultValue ??= $"No content for '{key}'.";
 
-        if (languageKey == Language.NoApiKeyLanguageKey || string.IsNullOrEmpty(_contentOptions.ApiKey)) return (defaultValue, false);
+        if (languageKey == Language.NoApiKeyLanguageKey || string.IsNullOrEmpty(_contentOptions.ApiKey)) return Result(defaultValue, false, ContentSource.NoApiKey, true);
 
         var sw = Stopwatch.StartNew();
         // Resolve effective application up front so cache key + request share the same value.
@@ -63,8 +69,12 @@ internal class RemoteContentCallService : IRemoteContentCallService
             // at their original levels. Matches RemoteConfigCallService.
             if (!needRefresh)
             {
-                LogResolved(key, languageKey, effectiveApplication, sw.ElapsedMilliseconds, "Cache", stale: false);
-                return (cached.Value ?? defaultValue, true);
+                // A negative-cache entry holds the caller's default, not server content. Report it as
+                // Default so an unseeded key is never mistaken for a genuine cache hit from the second
+                // render onwards. Success stays true either way — unchanged from the legacy tuple.
+                var source = cached.IsDefault ? ContentSource.Default : ContentSource.Cache;
+                LogResolved(key, languageKey, effectiveApplication, sw.ElapsedMilliseconds, source, stale: cached.IsDefault);
+                return Result(cached.Value ?? defaultValue, true, source, cached.IsDefault);
             }
 
             // Stale-while-revalidate: return stale value immediately, refresh in background.
@@ -72,8 +82,9 @@ internal class RemoteContentCallService : IRemoteContentCallService
             if (cached != null && _contentOptions.StaleWhileRevalidate)
             {
                 StartBackgroundRefresh(key, cacheKey, defaultValue, languageKey, contentType, effectiveApplication, translations);
-                LogResolved(key, languageKey, effectiveApplication, sw.ElapsedMilliseconds, "StaleCache", stale: true);
-                return (cached.Value ?? defaultValue, true);
+                var source = cached.IsDefault ? ContentSource.Default : ContentSource.StaleCache;
+                LogResolved(key, languageKey, effectiveApplication, sw.ElapsedMilliseconds, source, stale: true);
+                return Result(cached.Value ?? defaultValue, true, source, true);
             }
 
             // No cache (or stale-while-revalidate disabled) — fetch with timeout; the catch below
@@ -86,9 +97,15 @@ internal class RemoteContentCallService : IRemoteContentCallService
             var staleValue = stale?.Value ?? defaultValue;
             _logger.LogError(e, "{Message} Using stale cache or fallback for key {Key}.", e.Message, key);
             CacheFailure(cacheKey, staleValue);
-            LogResolved(key, languageKey, effectiveApplication, sw.ElapsedMilliseconds, stale != null ? "StaleCache" : "Default", stale: true);
-            return (staleValue, false);
+            var source = stale is { IsDefault: false } ? ContentSource.StaleCache : ContentSource.Default;
+            LogResolved(key, languageKey, effectiveApplication, sw.ElapsedMilliseconds, source, stale: true);
+            return Result(staleValue, false, source, true);
         }
+    }
+
+    private static ContentResult Result(string value, bool success, ContentSource source, bool stale)
+    {
+        return new ContentResult { Value = value, Success = success, Source = source, Stale = stale };
     }
 
     public async Task SetContentAsync(string key, string value, Guid languageKey, ContentFormat contentType, string application = null)
@@ -223,7 +240,7 @@ internal class RemoteContentCallService : IRemoteContentCallService
             foreach (var item in result.Items)
             {
                 var cacheKey = BuildCacheKey(item.Key, languageKey, effectiveApplication);
-                var cached = new GetContentResponse { Value = item.Value, ValidTo = result.ValidTo };
+                var cached = new CachedContent { Value = item.Value, ValidTo = result.ValidTo };
                 _localCache.AddOrUpdate(cacheKey, cached, (_, _) => cached);
                 if (ttl > TimeSpan.Zero) _lastKnownTtl[cacheKey] = ttl;
             }
@@ -242,7 +259,7 @@ internal class RemoteContentCallService : IRemoteContentCallService
         }
     }
 
-    private async Task<(string Value, bool Success)> FetchContentWithTimeout(string key, string cacheKey, string defaultValue, Guid languageKey, ContentFormat? contentType, Stopwatch sw, string effectiveApplication, IReadOnlyDictionary<string, string> translations = null)
+    private async Task<ContentResult> FetchContentWithTimeout(string key, string cacheKey, string defaultValue, Guid languageKey, ContentFormat? contentType, Stopwatch sw, string effectiveApplication, IReadOnlyDictionary<string, string> translations = null)
     {
         try
         {
@@ -282,8 +299,8 @@ internal class RemoteContentCallService : IRemoteContentCallService
                 }
                 // Negative-cache either way so the key isn't re-requested (and re-logged) every render.
                 CacheFailure(cacheKey, defaultValue);
-                LogResolved(key, languageKey, effectiveApplication, sw.ElapsedMilliseconds, "Default", stale: true);
-                return (defaultValue, false);
+                LogResolved(key, languageKey, effectiveApplication, sw.ElapsedMilliseconds, ContentSource.Default, stale: true);
+                return Result(defaultValue, false, ContentSource.Default, true);
             }
 
             var result = await response.Content.ReadFromJsonAsync<GetContentResponse>(cancellationToken: cts.Token);
@@ -292,25 +309,26 @@ internal class RemoteContentCallService : IRemoteContentCallService
             if (interval > TimeSpan.Zero)
                 _lastKnownTtl[cacheKey] = interval;
 
-            _localCache.AddOrUpdate(cacheKey, result, (_, _) => result);
+            var cached = new CachedContent { Value = result.Value, ValidTo = result.ValidTo };
+            _localCache.AddOrUpdate(cacheKey, cached, (_, _) => cached);
 
-            LogResolved(key, languageKey, effectiveApplication, sw.ElapsedMilliseconds, "Server", stale: false);
-            return (result.Value ?? defaultValue, true);
+            LogResolved(key, languageKey, effectiveApplication, sw.ElapsedMilliseconds, ContentSource.Server, stale: false);
+            return Result(result.Value ?? defaultValue, true, ContentSource.Server, false);
         }
         catch (OperationCanceledException)
         {
             _logger.LogWarning("HTTP request timed out for content '{Key}' after {Timeout}ms. Using default value.",
                 key, _contentOptions.HttpTimeout.TotalMilliseconds);
             CacheFailure(cacheKey, defaultValue);
-            LogResolved(key, languageKey, effectiveApplication, sw.ElapsedMilliseconds, "Default", stale: true);
-            return (defaultValue, false);
+            LogResolved(key, languageKey, effectiveApplication, sw.ElapsedMilliseconds, ContentSource.Default, stale: true);
+            return Result(defaultValue, false, ContentSource.Default, true);
         }
         catch (Exception e)
         {
             _logger.LogError(e, "{Message} Using default for content key {Key}.", e.Message, key);
             CacheFailure(cacheKey, defaultValue);
-            LogResolved(key, languageKey, effectiveApplication, sw.ElapsedMilliseconds, "Default", stale: true);
-            return (defaultValue, false);
+            LogResolved(key, languageKey, effectiveApplication, sw.ElapsedMilliseconds, ContentSource.Default, stale: true);
+            return Result(defaultValue, false, ContentSource.Default, true);
         }
     }
 
@@ -363,7 +381,8 @@ internal class RemoteContentCallService : IRemoteContentCallService
                 if (interval > TimeSpan.Zero)
                     _lastKnownTtl[cacheKey] = interval;
 
-                _localCache.AddOrUpdate(cacheKey, result, (_, _) => result);
+                var refreshed = new CachedContent { Value = result.Value, ValidTo = result.ValidTo };
+                _localCache.AddOrUpdate(cacheKey, refreshed, (_, _) => refreshed);
                 _logger.LogInformation("Background refresh for content '{Key}' completed. ValidTo: {ValidTo}.",
                     key, result.ValidTo);
             }
@@ -391,7 +410,7 @@ internal class RemoteContentCallService : IRemoteContentCallService
     // language + application so a slow or looping content load can be traced by key+language.
     // These fire on every read (typically a 0ms cache hit) so they stay at Debug — opt-in via the
     // category Quilt4Net.Toolkit.Features.Content.RemoteContentCallService at Debug.
-    private void LogResolved(string key, Guid languageKey, string application, long elapsedMs, string source, bool stale)
+    private void LogResolved(string key, Guid languageKey, string application, long elapsedMs, ContentSource source, bool stale)
     {
         _logger.LogDebug(
             "Content '{Key}' (language {LanguageKey}, application '{Application}') resolved in {Elapsed}ms. Source: {Source}, Stale: {Stale}.",
@@ -410,13 +429,16 @@ internal class RemoteContentCallService : IRemoteContentCallService
             what, elapsedMs, statusCode, reasonPhrase, (long)threshold.TotalMilliseconds);
     }
 
+    // Negative cache. IsDefault marks the entry as a fallback rather than server content, so a later
+    // hit reports ContentSource.Default instead of masquerading as a cache hit.
     private void CacheFailure(string cacheKey, string value)
     {
         var duration = _lastKnownTtl.GetValueOrDefault(cacheKey, _contentOptions.FailureCacheDuration);
-        var failureResponse = new GetContentResponse
+        var failureResponse = new CachedContent
         {
             Value = value,
-            ValidTo = DateTime.UtcNow.Add(duration)
+            ValidTo = DateTime.UtcNow.Add(duration),
+            IsDefault = true
         };
         _localCache.AddOrUpdate(cacheKey, failureResponse, (_, _) => failureResponse);
     }

--- a/Quilt4Net.Toolkit/Features/Content/RemoteContentCallService.cs
+++ b/Quilt4Net.Toolkit/Features/Content/RemoteContentCallService.cs
@@ -21,6 +21,7 @@ internal class RemoteContentCallService : IRemoteContentCallService
     private readonly ConcurrentDictionary<string, CachedContent> _localCache = new();
     private readonly ConcurrentDictionary<string, TimeSpan> _lastKnownTtl = new();
     private readonly ConcurrentDictionary<string, bool> _refreshInProgress = new();
+    private int _missingApiKeyWarned;
     private Language[] _languages;
     private DateTime _languagesValidTo;
     private TimeSpan _lastKnownLanguageTtl;
@@ -50,7 +51,11 @@ internal class RemoteContentCallService : IRemoteContentCallService
 
         defaultValue ??= $"No content for '{key}'.";
 
-        if (languageKey == Language.NoApiKeyLanguageKey || string.IsNullOrEmpty(_contentOptions.ApiKey)) return Result(defaultValue, false, ContentSource.NoApiKey, true);
+        if (languageKey == Language.NoApiKeyLanguageKey || string.IsNullOrEmpty(_contentOptions.ApiKey))
+        {
+            WarnMissingApiKeyOnce();
+            return Result(defaultValue, false, ContentSource.NoApiKey, true);
+        }
 
         var sw = Stopwatch.StartNew();
         // Resolve effective application up front so cache key + request share the same value.
@@ -106,6 +111,17 @@ internal class RemoteContentCallService : IRemoteContentCallService
     private static ContentResult Result(string value, bool success, ContentSource source, bool stale)
     {
         return new ContentResult { Value = value, Success = success, Source = source, Stale = stale };
+    }
+
+    // Content was registered but cannot reach the server, so every value silently falls back to its
+    // default. Warning rather than Error: nothing failed — the app renders correctly, and a key-less
+    // setup is a legitimate local/dev state (hence Language.NoApiKeyLanguageKey). Logged once per
+    // process: this is a startup misconfiguration, and the check runs on every single read.
+    private void WarnMissingApiKeyOnce()
+    {
+        if (Interlocked.Exchange(ref _missingApiKeyWarned, 1) != 0) return;
+        _logger.LogWarning(
+            "No Quilt4Net content API key is configured. Every content value will fall back to its default and no lookups will be attempted. Set ContentOptions.ApiKey to enable content.");
     }
 
     public async Task SetContentAsync(string key, string value, Guid languageKey, ContentFormat contentType, string application = null)
@@ -287,10 +303,12 @@ internal class RemoteContentCallService : IRemoteContentCallService
             {
                 if (response.StatusCode == HttpStatusCode.NotFound)
                 {
-                    // A key with no override on the server is the designed fallback path — the caller's
-                    // Default is used. Expected and non-fatal, so log at Debug (not Error) to avoid
-                    // flooding logs/telemetry with a line per unseeded key on every render.
-                    _logger.LogDebug("No content override for key '{Key}' (404). Using default value.", key);
+                    // Information, not Debug: an unseeded key is actionable — someone should seed it —
+                    // and Debug is not enabled in practice, so it was effectively invisible. Safe to
+                    // raise because CacheFailure() below negative-caches the key, so this fires once
+                    // per key per FailureCacheDuration rather than once per render. Still not a
+                    // Warning: falling back to the caller's Default is the designed behaviour.
+                    _logger.LogInformation("No content override for key '{Key}' (404). Using default value.", key);
                 }
                 else
                 {
@@ -362,8 +380,9 @@ internal class RemoteContentCallService : IRemoteContentCallService
                 {
                     if (response.StatusCode == HttpStatusCode.NotFound)
                     {
-                        // No override on the server — the designed fallback path, not a failure. Debug only.
-                        _logger.LogDebug("Background refresh for content '{Key}': no override (404). Keeping default value.", key);
+                        // Same reasoning as the foreground 404 above: actionable, and deduped by the
+                        // negative cache to once per key per refresh cycle.
+                        _logger.LogInformation("Background refresh for content '{Key}': no override (404). Keeping default value.", key);
                     }
                     else
                     {

--- a/Quilt4Net.Toolkit/README.md
+++ b/Quilt4Net.Toolkit/README.md
@@ -111,6 +111,34 @@ Inject `IContentService` to retrieve and manage content.
 var (value, success) = await _contentService.GetContentAsync("welcome-message", "Hello!", languageKey, ContentFormat.String);
 ```
 
+#### Knowing where a value came from
+
+`GetContentResultAsync` returns the same value plus its provenance, so you can tell a real server
+value apart from a cache hit or a hard-coded fallback.
+
+```csharp
+var result = await _contentService.GetContentResultAsync("welcome-message", "Hello!", languageKey, ContentFormat.String);
+
+if (result.Source == ContentSource.Default)
+{
+    // The server has no value for this key — the caller's default is being rendered.
+}
+```
+
+| `ContentSource` | Meaning |
+|---|---|
+| `Server` | Fetched from Quilt4Net.Server on this call. |
+| `Cache` | Served from the local cache, within TTL, from a value the server supplied. |
+| `StaleCache` | Served from the local cache past its TTL; a background refresh was started. |
+| `Default` | The caller's default was used — no override on the server (404), unreachable, or timed out. Also reported for a cached *default*, so a negative-cache hit is never mistaken for a real cache hit. |
+| `Developer` | Developer language is active; every key resolves to a placeholder. |
+| `NoApiKey` | No API key configured, so no lookup was attempted. |
+| `Unknown` | The `IContentService` implementation does not report provenance (custom or test implementations that only override `GetContentAsync`). |
+
+> `Success` on the legacy tuple is **not** a source discriminator — it is `true` for a cache hit, a
+> stale hit and a fresh fetch alike, and `false` for a missing API key, a 404, a timeout and an
+> error alike. Use `Source` when the distinction matters.
+
 ### ContentOptions
 
 | Property | Default | Description |
@@ -125,6 +153,19 @@ Configuration path: `Quilt4Net:Content`
 
 #### Diagnostic logging
 
+Content logging is split by whether a condition is **actionable**. These fire without any log
+configuration:
+
+| Condition | Level | Frequency |
+|---|---|---|
+| A key has no value on the server (404) | `Information` | Once per key per `FailureCacheDuration` — the negative cache stops it repeating per render. |
+| No `ApiKey` configured, so content can never load | `Warning` | Once per process. |
+| Server round-trip slower than `SlowLogThreshold` | `Warning` | Per slow call. |
+| Timeout, or a non-404 failure response | `Warning` / `Error` | Per occurrence. |
+
+A normal server fetch stays at `Debug` — it is the designed happy path, and at cold start it is one
+line per key.
+
 To diagnose slow or looping content/language loads, enable `Debug` logging for the content categories — no code change required:
 
 ```json
@@ -138,7 +179,10 @@ To diagnose slow or looping content/language loads, enable `Debug` logging for t
 }
 ```
 
-At `Debug` you get, per content read, the key, resolved language + application, cache hit/miss (`Cache` / `StaleCache` / `Server` / `Default`) and elapsed time; per language load, the source (cache vs server), count and elapsed time; and, in Blazor, each language reload (with timing) and every selected-language change that triggers a content reload. Genuinely slow server round-trips are logged at `Warning` regardless (see `SlowLogThreshold`).
+At `Debug` you get, per content read, the key, resolved language + application, the resolved
+`ContentSource` and elapsed time; per language load, the source (cache vs server), count and elapsed
+time; and, in Blazor, each language reload (with timing) and every selected-language change that
+triggers a content reload. Genuinely slow server round-trips are logged at `Warning` regardless (see `SlowLogThreshold`).
 
 ## Health check client
 

--- a/docs/articles/content-components.md
+++ b/docs/articles/content-components.md
@@ -329,6 +329,36 @@ The content admin panel (`<ContentAdmin>`) shows content admins a **Loaded conte
 list — the number of cached content entries per language, with a Refresh button — so you can confirm
 the warm-up populated the cache as expected.
 
+## Seeing where each value came from
+
+A rendered string gives no clue whether it is real content or the hard-coded fallback the component
+was written with. Turning on **Show content source** (in the `LanguageSelector` menu, admin only, or
+`IContentSourceService.Enabled` from code) outlines every value and adds a tooltip naming its origin.
+
+```csharp
+@inject IContentSourceService ContentSourceService
+
+ContentSourceService.Enabled = true;
+```
+
+Red means the server has no value for that key, so what you are reading is the component's default —
+usually the thing you are looking for. Green is a fresh server fetch, blue a cache hit, amber a stale
+cache entry being refreshed in the background.
+
+Supported on `<Quilt4Text>`, `<Quilt4Span>`, `<Quilt4Raw>` and `<Quilt4Content>`. Edit mode takes
+precedence when both are on, and `<Quilt4Raw>` gains a wrapping `<span>` only while the overlay is
+enabled — with it off, markup is exactly as before.
+
+For the same information without a browser — aggregated across an environment rather than per render
+— see the content log levels in the
+[Quilt4Net.Toolkit README](https://github.com/Quilt4/Quilt4Net.Toolkit/blob/master/Quilt4Net.Toolkit/README.md#diagnostic-logging):
+an unseeded key logs at `Information` once per key, and a missing API key logs a `Warning` once per
+process.
+
+> Not to be confused with **developer mode**, labelled "Debug mode" in the same menu, which swaps
+> every value for a placeholder to reveal unmanaged text. The source overlay leaves the text alone
+> and only annotates it.
+
 ## Where next
 
 - **[Log views](log-views.md)** — content-aware host of the AI log surface.


### PR DESCRIPTION
Lets a consumer tell a real server value apart from a cache hit or a hard-coded fallback — the
distinction `RemoteContentCallService` has always resolved internally but only ever wrote to a
`Debug` log line.

## ⚠️ Behaviour change — read before merging

Two log levels change. Consumers with log-based alerting or ingestion budgets will see new lines
where there were none:

| Condition | Before | After | Frequency |
|---|---|---|---|
| A key has no value on the server (404) | `Debug` | **`Information`** | Once per key per `FailureCacheDuration` |
| No `ApiKey` configured | *(silent)* | **`Warning`** | Once per process |

`Debug` is not enabled in practice, so the diagnostics added in #132 were effectively invisible.
Only *actionable* conditions were raised — a normal server fetch stays at `Debug`, because it is the
designed happy path and at cold start it is one line per key.

This does not reintroduce the #131/#132 flood. The negative cache means an unseeded key logs once
per `FailureCacheDuration`, not once per render, and a test pins that (5 reads → 1 line) so it fails
loudly if the negative cache ever regresses.

## API

New `ContentSource` (`Server` / `Cache` / `StaleCache` / `Default` / `Developer` / `NoApiKey` /
`Unknown`) and `ContentResult`, returned by a new `GetContentResultAsync`.

Non-breaking. The `(string Value, bool Success)` tuple stays and now delegates to the new method,
and `IContentService` gained a **default interface implementation** rather than a required member —
a required member broke 17 existing implementations in this repo alone, which is a fair proxy for
what it would do to consumers. The default reports `Unknown` rather than inventing a provenance it
cannot know.

`Success` semantics are deliberately unchanged: a cached default still returns `true`. A regression
test pins that.

## Bug found and fixed on the way

`CacheFailure()` writes the caller's default into the local cache after a 404 or timeout, so from
the second render onwards an unseeded key came back through the cache branch. Reported naively it
would have been labelled a genuine cache hit — lying in exactly the case this feature exists to
diagnose. A new internal `CachedContent` record carries `IsDefault` so those entries report
`Default`.

Verified by mutation rather than assumed: flipping the flag makes the test fail with
`found ContentSource.Cache`.

## UI

An admin-gated **Show content source** toggle outlines each value and adds a tooltip. Red marks a
fallback default — the case usually being hunted.

Deliberately *not* called "debug mode": that label already exists in the same menu for
developer-language mode, which does something entirely different.

Scope notes:

- `Quilt4PageTitle` is **excluded**, not deferred — it renders into `<PageTitle>`, which has no DOM
  surface to annotate. Doing so would mean mutating the browser tab title.
- `Quilt4Raw` gains a wrapping `<span>` only while the overlay is on; markup is unchanged when off
  (test-guarded).
- Edit mode wins when both are enabled — it carries the click-to-edit affordance.
- The remaining ~12 `PlaceholderResolver`-family components are **not** being swept. Aggregate
  metrics are a better answer to "is content loading healthy" than annotating every component, and
  that work is tracked separately.

## Verification

- 458 → 475 tests, all green
- 166 warnings vs baseline 248
- README (both packages) + `docs/articles/content-components.md` updated

