### PR TITLE
feat(content): warm configured languages at startup + on reload; sample diagnostics

### DIFF
--- a/Quilt4Net.Toolkit.Blazor.Server.Sample/Components/Layout/NavMenu.razor
+++ b/Quilt4Net.Toolkit.Blazor.Server.Sample/Components/Layout/NavMenu.razor
@@ -20,6 +20,7 @@
     <RadzenPanelMenu DisplayStyle="@(_menuExpanded ? MenuItemDisplayStyle.IconAndText : MenuItemDisplayStyle.Icon)" ShowArrow="true">
         <Quilt4RadzenPanelMenuItem TextKey="menu.home" DefaultText="Home" Icon="home" Path="/" />
         <Quilt4RadzenPanelMenuItem TextKey="menu.content" DefaultText="Content" Icon="article" Path="/content" />
+        <Quilt4RadzenPanelMenuItem TextKey="menu.content-diagnostics" DefaultText="Content diagnostics" Icon="fact_check" Path="/content-diagnostics" />
         <Quilt4RadzenPanelMenuItem TextKey="menu.configuration" DefaultText="Configuration" Icon="tune" Path="/configuration" />
         <Quilt4RadzenPanelMenuItem TextKey="menu.log" DefaultText="Log" Icon="description" Path="/log" />
         <Quilt4RadzenPanelMenuItem TextKey="menu.admin" DefaultText="Content Admin" Icon="admin_panel_settings" Path="/admin" />

--- a/Quilt4Net.Toolkit.Blazor.Server.Sample/Components/Pages/ContentDiagnostics.razor
+++ b/Quilt4Net.Toolkit.Blazor.Server.Sample/Components/Pages/ContentDiagnostics.razor
@@ -1,0 +1,216 @@
+@page "/content-diagnostics"
+@rendermode InteractiveServer
+@using System.Diagnostics
+@using Quilt4Net.Toolkit.Features.Content
+@using Quilt4Net.Toolkit.Features.FeatureToggle
+@inject IContentService ContentService
+@inject ILanguageStateService LanguageStateService
+
+<PageTitle>Content diagnostics</PageTitle>
+
+<h1>Content diagnostics</h1>
+
+<p>
+    Resolves each key below in <strong>every configured language</strong> and reports where the value
+    came from. This is how you verify AI translation and spot the outage gap from the client side:
+    a non-default language that resolves to <span style="color:#c62828;font-weight:600">Default</span>
+    has <em>no translated value on the server</em> — the translation was never produced (or was lost).
+    <span style="color:#2e7d32;font-weight:600">Server</span> / <span style="color:#1565c0;font-weight:600">Cache</span>
+    means a real value came back.
+</p>
+
+<RadzenAlert AlertStyle="AlertStyle.Info" Variant="Variant.Flat" ShowIcon="true" AllowClose="false" class="rz-my-2">
+    This observes the <strong>client-visible symptom</strong> only. A true audit of the translation
+    <em>queue</em> (requests created during the outage but never drained) needs a server-side endpoint —
+    the client cannot see the <code>TranslationRequest</code> collection. Also: probing a key the server
+    has never seen can cause it to <strong>seed the key on read</strong>. Use known keys when pointing at
+    production.
+</RadzenAlert>
+
+<div class="rz-my-3">
+    <RadzenText TextStyle="TextStyle.Subtitle2">Application</RadzenText>
+    <RadzenTextBox @bind-Value="_application" Placeholder="(blank = this sample's own application)"
+                   class="rz-w-100" aria-label="Application" />
+    <RadzenText TextStyle="TextStyle.Caption" class="rz-mb-2">
+        Set this to the application whose content you want to inspect — e.g.
+        <code>Eplicta.FortDocs.Web</code> to audit FortDocs. Leave blank to use the sample's own.
+    </RadzenText>
+</div>
+
+<div class="rz-my-3">
+    <RadzenText TextStyle="TextStyle.Subtitle2">Keys to probe (one per line)</RadzenText>
+    <RadzenTextArea @bind-Value="_keysText" Rows="6" class="rz-w-100" aria-label="Keys to probe" />
+    <div class="rz-mt-2">
+        <RadzenButton Text="Probe" Icon="search" Click="@(() => ProbeAsync(clearCache: false))" Disabled="@_running" />
+        <RadzenButton Text="Clear cache & re-probe" Icon="refresh" ButtonStyle="ButtonStyle.Light"
+                      Click="@(() => ProbeAsync(clearCache: true))" Disabled="@_running" class="rz-ml-2" />
+        @if (_running)
+        {
+            <span class="rz-ml-2">Probing…</span>
+        }
+    </div>
+</div>
+
+@if (_languages is { Length: > 0 } && _results.Count > 0)
+{
+    <h3>Per-language summary</h3>
+    <p style="color:gray">Each language across the @_results.Count probed key(s). Defaults in a
+        non-default language are the translation gap.</p>
+    <table class="diag-table">
+        <thead>
+            <tr><th>Language</th><th>Server</th><th>Cache</th><th>Stale</th><th>Default (fallback)</th><th>Other</th></tr>
+        </thead>
+        <tbody>
+            @foreach (var lang in _languages)
+            {
+                var cells = _results.Values.Select(r => r[lang.Key].Source).ToArray();
+                var fallbacks = cells.Count(s => s == ContentSource.Default);
+                <tr>
+                    <td><strong>@lang.Name</strong></td>
+                    <td>@cells.Count(s => s == ContentSource.Server)</td>
+                    <td>@cells.Count(s => s == ContentSource.Cache)</td>
+                    <td>@cells.Count(s => s == ContentSource.StaleCache)</td>
+                    <td style="@(fallbacks > 0 ? "color:#c62828;font-weight:600" : "")">@fallbacks</td>
+                    <td>@cells.Count(s => s is not (ContentSource.Server or ContentSource.Cache or ContentSource.StaleCache or ContentSource.Default))</td>
+                </tr>
+            }
+        </tbody>
+    </table>
+
+    <h3 class="rz-mt-4">Key × language matrix</h3>
+    <div style="overflow-x:auto">
+        <table class="diag-table">
+            <thead>
+                <tr>
+                    <th>Key</th>
+                    @foreach (var lang in _languages)
+                    {
+                        <th>@lang.Name</th>
+                    }
+                </tr>
+            </thead>
+            <tbody>
+                @foreach (var (key, byLang) in _results)
+                {
+                    <tr>
+                        <td><code>@key</code></td>
+                        @foreach (var lang in _languages)
+                        {
+                            var cell = byLang[lang.Key];
+                            <td style="@CellStyle(cell.Source)" title="@Tooltip(cell)">
+                                @SourceLabel(cell.Source)
+                            </td>
+                        }
+                    </tr>
+                }
+            </tbody>
+        </table>
+    </div>
+}
+else if (_probed)
+{
+    <RadzenAlert AlertStyle="AlertStyle.Warning" Variant="Variant.Flat" ShowIcon="true" AllowClose="false">
+        No languages returned from the server. Confirm the sample's <code>Quilt4Net:ApiKey</code> and
+        <code>Quilt4Net:Quilt4NetAddress</code> point at a running Quilt4Net server.
+    </RadzenAlert>
+}
+
+<style>
+    .diag-table { border-collapse: collapse; }
+    .diag-table th, .diag-table td { border: 1px solid var(--rz-base-300, #ccc); padding: 4px 10px; text-align: left; }
+    .diag-table thead th { background: var(--rz-base-200, #f0f0f0); }
+</style>
+
+@code {
+    private string _keysText = string.Join("\n", DefaultKeys);
+    private string _application = string.Empty;
+    private bool _running;
+    private bool _probed;
+    private Language[] _languages = [];
+
+    // key -> (languageKey -> result)
+    private readonly Dictionary<string, Dictionary<Guid, ContentResult>> _results = new();
+
+    // The keys the sample's own Content.razor renders — safe to probe against any server.
+    private static readonly string[] DefaultKeys =
+    [
+        "sample-h1", "sample-h3", "sample-body", "sample-rich",
+        "inline-label", "inline-value",
+        "menu.home", "menu.content", "menu.settings",
+        "col.name", "col.description", "col.status",
+    ];
+
+    protected override async Task OnInitializedAsync()
+    {
+        // Populate the language list up front so the matrix has its columns.
+        _languages = await LanguageStateService.ReloadAsync() ?? [];
+    }
+
+    private async Task ProbeAsync(bool clearCache)
+    {
+        _running = true;
+        _probed = true;
+        _results.Clear();
+        StateHasChanged();
+
+        try
+        {
+            if (clearCache) await ContentService.ClearCacheAsync();
+
+            // Refresh languages in case they changed since page load.
+            _languages = await LanguageStateService.ReloadAsync() ?? [];
+
+            var keys = _keysText
+                .Split('\n', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+                .Distinct()
+                .ToArray();
+
+            foreach (var key in keys)
+            {
+                var byLang = new Dictionary<Guid, ContentResult>();
+                // null application → the client resolves the sample's own; a non-empty box targets
+                // another app's content (e.g. Eplicta.FortDocs.Web).
+                var application = string.IsNullOrWhiteSpace(_application) ? null : _application.Trim();
+                foreach (var lang in _languages)
+                {
+                    byLang[lang.Key] = await ContentService.GetContentResultAsync(
+                        key, "(no server value)", lang.Key, ContentFormat.String, application);
+                }
+                _results[key] = byLang;
+            }
+        }
+        finally
+        {
+            _running = false;
+            StateHasChanged();
+        }
+    }
+
+    private static string SourceLabel(ContentSource source) => source switch
+    {
+        ContentSource.Server => "Server",
+        ContentSource.Cache => "Cache",
+        ContentSource.StaleCache => "Stale",
+        ContentSource.Default => "Default",
+        ContentSource.Developer => "Developer",
+        ContentSource.NoApiKey => "No API key",
+        _ => source.ToString(),
+    };
+
+    private static string CellStyle(ContentSource source)
+    {
+        var colour = source switch
+        {
+            ContentSource.Server => "#2e7d32",
+            ContentSource.Cache => "#1565c0",
+            ContentSource.StaleCache => "#ef6c00",
+            ContentSource.Default => "#c62828",
+            ContentSource.Developer => "#6a1b9a",
+            _ => "#546e7a",
+        };
+        return $"color:{colour};font-weight:600";
+    }
+
+    private static string Tooltip(ContentResult r)
+        => $"Source: {r.Source}, Stale: {r.Stale}\nValue: {r.Value}";
+}

--- a/Quilt4Net.Toolkit.Blazor.Server.Sample/Program.cs
+++ b/Quilt4Net.Toolkit.Blazor.Server.Sample/Program.cs
@@ -51,6 +51,9 @@ builder.Services.AddThargaBlazor(o =>
 builder.AddQuilt4NetBlazorContent(o =>
 {
     o.AssumeAdmin = true;
+    // Hot-load English + Svenska at startup (and on "Reload Content"), on top of the always-warmed
+    // default language. Names must match the languages configured on the target Quilt4Net server.
+    o.WarmUpLanguages = ["English", "Svenska"];
 });
 
 builder.AddQuilt4NetApplicationInsightsClient();

--- a/Quilt4Net.Toolkit.Blazor.Server.Sample/Program.cs
+++ b/Quilt4Net.Toolkit.Blazor.Server.Sample/Program.cs
@@ -3,9 +3,35 @@ using Quilt4Net.Toolkit.Api;
 using Quilt4Net.Toolkit.Blazor;
 using Quilt4Net.Toolkit.Blazor.Server.Sample.Components;
 using Radzen;
+using Serilog;
+using Serilog.Events;
 using Tharga.Blazor.Framework;
+// `using Serilog;` also brings Serilog.ILogger into scope, which collides with the
+// Microsoft.Extensions.Logging.ILogger used by the correlation-demo endpoint below. Alias the
+// unqualified name back to the MS type; Serilog is referenced via its own qualified names.
+using ILogger = Microsoft.Extensions.Logging.ILogger;
 
 var builder = WebApplication.CreateBuilder(args);
+
+// Serilog file sink — a plain, tailable log on disk so you can see exactly what the content client
+// is doing (which key resolved from where, when it fell back to a default, when translation is
+// missing) without an App Insights round-trip. Added as an ADDITIONAL logging provider via
+// builder.Logging.AddSerilog (not builder.Host.UseSerilog, which would clear the existing OTel/AI
+// providers that AddQuilt4NetLogging sets up). Both sinks receive every log line.
+// The content categories are raised to Debug in appsettings.Development.json so the per-resolution
+// source lines reach this file. logs/ is git-ignored (*.log).
+Log.Logger = new LoggerConfiguration()
+    .MinimumLevel.Debug()
+    .MinimumLevel.Override("Microsoft", LogEventLevel.Warning)
+    .MinimumLevel.Override("Microsoft.Hosting.Lifetime", LogEventLevel.Information)
+    .Enrich.FromLogContext()
+    .WriteTo.File(
+        "logs/sample-.log",
+        rollingInterval: RollingInterval.Day,
+        outputTemplate: "{Timestamp:yyyy-MM-dd HH:mm:ss.fff} [{Level:u3}] {SourceContext}: {Message:lj}{NewLine}{Exception}")
+    .CreateLogger();
+
+builder.Logging.AddSerilog(Log.Logger, dispose: true);
 
 builder.Services.AddRazorComponents()
     .AddInteractiveServerComponents();

--- a/Quilt4Net.Toolkit.Blazor.Server.Sample/Quilt4Net.Toolkit.Blazor.Server.Sample.csproj
+++ b/Quilt4Net.Toolkit.Blazor.Server.Sample/Quilt4Net.Toolkit.Blazor.Server.Sample.csproj
@@ -9,6 +9,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Serilog.AspNetCore" Version="9.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\Quilt4Net.Toolkit.Api\Quilt4Net.Toolkit.Api.csproj" />
     <ProjectReference Include="..\Quilt4Net.Toolkit.Blazor\Quilt4Net.Toolkit.Blazor.csproj" />
   </ItemGroup>

--- a/Quilt4Net.Toolkit.Blazor.Server.Sample/appsettings.Development.json
+++ b/Quilt4Net.Toolkit.Blazor.Server.Sample/appsettings.Development.json
@@ -3,7 +3,9 @@
   "Logging": {
     "LogLevel": {
       "Default": "Information",
-      "Microsoft.AspNetCore": "Warning"
+      "Microsoft.AspNetCore": "Warning",
+      "Quilt4Net.Toolkit.Features.Content.RemoteContentCallService": "Debug",
+      "Quilt4Net.Toolkit.Blazor.LanguageStateService": "Debug"
     },
     "ApplicationInsights": {
       "LogLevel": {

--- a/Quilt4Net.Toolkit.Blazor.Tests/ContentWarmupTests.cs
+++ b/Quilt4Net.Toolkit.Blazor.Tests/ContentWarmupTests.cs
@@ -75,6 +75,9 @@ public class ContentWarmupTests
             return Task.CompletedTask;
         }
 
+        // Mirrors the real service with no WarmUpLanguages configured: warm the default language.
+        public Task WarmConfiguredLanguagesAsync(string application = null) => WarmCacheAsync(Guid.Empty, application);
+
         public Task<(string Value, bool Success)> GetContentAsync(string key, string defaultValue, Guid languageKey, ContentFormat? contentType, string application = null, IReadOnlyDictionary<string, string> translations = null)
             => Task.FromResult((defaultValue, true));
         public Task<ContentResult> GetContentResultAsync(string key, string defaultValue, Guid languageKey, ContentFormat? contentType, string application = null, IReadOnlyDictionary<string, string> translations = null)

--- a/Quilt4Net.Toolkit.Blazor/ContentWarmupHostedService.cs
+++ b/Quilt4Net.Toolkit.Blazor/ContentWarmupHostedService.cs
@@ -6,11 +6,12 @@ using Quilt4Net.Toolkit.Features.Content;
 namespace Quilt4Net.Toolkit.Blazor;
 
 /// <summary>
-/// Pre-fills the content cache with the default language at application startup via one bulk call,
-/// so the first page render serves from a warm cache instead of fanning out a request per key.
-/// Runs in the background (does not block startup) and is best-effort — any failure is swallowed by
-/// the warm-up call, leaving the normal per-key path intact. Disabled via <see cref="ContentOptions.WarmUpEnabled"/>.
-/// The selected (non-default) language is warmed per-circuit by <see cref="LanguageStateService"/>.
+/// Pre-fills the content cache at application startup via one bulk call per language, so the first
+/// page render serves from a warm cache instead of fanning out a request per key. Warms the default
+/// language plus any listed in <see cref="ContentOptions.WarmUpLanguages"/>. Runs in the background
+/// (does not block startup) and is best-effort — any failure is swallowed, leaving the normal
+/// per-key path intact. Disabled via <see cref="ContentOptions.WarmUpEnabled"/>. Languages selected
+/// at runtime but not pre-warmed are warmed per-circuit by <see cref="LanguageStateService"/>.
 /// </summary>
 internal sealed class ContentWarmupHostedService : IHostedService
 {
@@ -29,12 +30,13 @@ internal sealed class ContentWarmupHostedService : IHostedService
     {
         if (!_options.WarmUpEnabled) return Task.CompletedTask;
 
-        // Background so app startup isn't blocked by the bulk fetch. Guid.Empty = default language.
+        // Background so app startup isn't blocked by the bulk fetch. Warms the default language plus
+        // any configured in ContentOptions.WarmUpLanguages.
         _ = Task.Run(async () =>
         {
             try
             {
-                await _callService.WarmCacheAsync(Guid.Empty);
+                await _callService.WarmConfiguredLanguagesAsync();
             }
             catch (Exception e)
             {

--- a/Quilt4Net.Toolkit.Blazor/Features/Language/LanguageSelector.razor
+++ b/Quilt4Net.Toolkit.Blazor/Features/Language/LanguageSelector.razor
@@ -3,6 +3,7 @@
 @using Quilt4Net.Toolkit.Framework
 @inject ILanguageStateService LanguageStateService
 @inject IContentService ContentService
+@inject IRemoteContentCallService RemoteContentCallService
 @inject IEditContentService EditContentService
 @inject IContentSourceService ContentSourceService
 @inject IContentAdminService ContentAdminService
@@ -52,6 +53,16 @@
     {
         await LanguageStateService.ReloadAsync();
         await ContentService.ClearCacheAsync();
+        // Re-warm before the forced reload so the new circuit renders from a warm cache (the singleton
+        // cache persists across circuits). Best-effort — a warm failure must not block the reload.
+        try
+        {
+            await RemoteContentCallService.WarmConfiguredLanguagesAsync();
+        }
+        catch
+        {
+            // Ignored: the per-key path still serves content on the reload.
+        }
         NavigationManager.NavigateTo(NavigationManager.Uri, true);
     }
 }

--- a/Quilt4Net.Toolkit.Tests/ContentWarmUpLanguagesTests.cs
+++ b/Quilt4Net.Toolkit.Tests/ContentWarmUpLanguagesTests.cs
@@ -1,0 +1,161 @@
+using System.Collections.Concurrent;
+using System.Net;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Quilt4Net.Toolkit.Features.Content;
+using Xunit;
+
+namespace Quilt4Net.Toolkit.Tests;
+
+// WarmUpLanguages: WarmConfiguredLanguagesAsync warms the default language plus each language named
+// in ContentOptions.WarmUpLanguages (resolved name -> key against the server's language list), so a
+// site can hot-load e.g. English + Svenska at startup instead of only the default.
+public class ContentWarmUpLanguagesTests
+{
+    private static readonly Guid SvenskaKey = Guid.Parse("11111111-1111-1111-1111-111111111111");
+
+    [Fact]
+    public async Task Warms_default_plus_each_named_language()
+    {
+        using var listener = StartListener(out var prefix, out var warmed, out _);
+        var warm = Build(prefix, warmUpLanguages: ["Svenska"]);
+
+        await warm.WarmConfiguredLanguagesAsync();
+
+        warmed.Should().Contain(Guid.Empty, "the default language is always warmed");
+        warmed.Should().Contain(SvenskaKey, "a configured language is resolved by name and warmed");
+    }
+
+    [Fact]
+    public async Task Default_only_when_no_languages_configured()
+    {
+        using var listener = StartListener(out var prefix, out var warmed, out _);
+        var warm = Build(prefix, warmUpLanguages: []);
+
+        await warm.WarmConfiguredLanguagesAsync();
+
+        warmed.Should().ContainSingle().Which.Should().Be(Guid.Empty,
+            "with no WarmUpLanguages, only the default language warms — the previous behaviour");
+    }
+
+    [Fact]
+    public async Task Unknown_language_name_is_skipped_with_a_warning()
+    {
+        using var listener = StartListener(out var prefix, out var warmed, out _);
+        var recorder = new RecordingLoggerProvider();
+        var warm = Build(prefix, warmUpLanguages: ["Klingon"], recorder);
+
+        await warm.WarmConfiguredLanguagesAsync();
+
+        warmed.Should().ContainSingle().Which.Should().Be(Guid.Empty, "an unmatched name warms nothing extra");
+        recorder.Entries.Should().Contain(e => e.Level == LogLevel.Warning && e.Message.Contains("Klingon"),
+            "a configured name with no matching server language must be reported");
+    }
+
+    private static IRemoteContentCallService Build(string baseAddress, IReadOnlyList<string> warmUpLanguages, ILoggerProvider loggerProvider = null)
+    {
+        var host = Host.CreateDefaultBuilder()
+            .ConfigureServices(services =>
+            {
+                services.AddQuilt4NetContent(null, o =>
+                {
+                    o.Quilt4NetAddress = baseAddress;
+                    o.ApiKey = "test-key";
+                    o.WarmUpLanguages = warmUpLanguages;
+                });
+                if (loggerProvider != null)
+                    services.AddLogging(b => { b.ClearProviders(); b.SetMinimumLevel(LogLevel.Debug); b.AddProvider(loggerProvider); });
+            })
+            .Build();
+
+        return host.Services.GetRequiredService<IRemoteContentCallService>();
+    }
+
+    private static HttpListener StartListener(out string prefix, out ConcurrentBag<Guid> warmedLanguages, out ConcurrentBag<string> languageCalls)
+    {
+        var port = GetFreePort();
+        prefix = $"http://127.0.0.1:{port}/";
+        var listener = new HttpListener();
+        listener.Prefixes.Add(prefix);
+        listener.Start();
+
+        var warmed = new ConcurrentBag<Guid>();
+        var langCalls = new ConcurrentBag<string>();
+        warmedLanguages = warmed;
+        languageCalls = langCalls;
+
+        _ = Task.Run(async () =>
+        {
+            while (listener.IsListening)
+            {
+                HttpListenerContext ctx;
+                try { ctx = await listener.GetContextAsync(); }
+                catch { return; }
+
+                var segments = ctx.Request.Url!.AbsolutePath.Split('/', StringSplitOptions.RemoveEmptyEntries);
+                string body;
+
+                if (segments.Length >= 2 && segments[1].Equals("Language", StringComparison.OrdinalIgnoreCase))
+                {
+                    // Api/Language/{app}/{env} — return the server's language list (LanguageResponse
+                    // wrapper: { languages, validTo }, not a bare array).
+                    langCalls.Add(ctx.Request.Url.AbsolutePath);
+                    body = $$"""{"languages":[{"key":"{{Guid.Empty}}","name":"English"},{"key":"{{SvenskaKey}}","name":"Svenska"}],"validTo":"{{DateTime.UtcNow.AddHours(1):o}}"}""";
+                }
+                else if (segments.Length >= 3 && segments[1].Equals("Content", StringComparison.OrdinalIgnoreCase)
+                         && segments[2].Equals("all", StringComparison.OrdinalIgnoreCase))
+                {
+                    // Api/Content/all/{app}/{env}/{languageKey} — record which language was warmed.
+                    if (Guid.TryParse(segments[^1], out var langKey)) warmed.Add(langKey);
+                    body = $$"""{"items":[],"validTo":"{{DateTime.UtcNow.AddHours(1):o}}"}""";
+                }
+                else
+                {
+                    body = "{}";
+                }
+
+                ctx.Response.StatusCode = 200;
+                ctx.Response.ContentType = "application/json";
+                var buf = System.Text.Encoding.UTF8.GetBytes(body);
+                await ctx.Response.OutputStream.WriteAsync(buf);
+                ctx.Response.Close();
+            }
+        });
+
+        return listener;
+    }
+
+    private static int GetFreePort()
+    {
+        using var l = new System.Net.Sockets.TcpListener(IPAddress.Loopback, 0);
+        l.Start();
+        var port = ((IPEndPoint)l.LocalEndpoint).Port;
+        l.Stop();
+        return port;
+    }
+
+    private sealed class RecordingLoggerProvider : ILoggerProvider
+    {
+        public List<(LogLevel Level, string Message)> Entries { get; } = new();
+        public ILogger CreateLogger(string categoryName) => new RecordingLogger(Entries);
+        public void Dispose() { }
+
+        private sealed class RecordingLogger(List<(LogLevel, string)> entries) : ILogger
+        {
+            public IDisposable BeginScope<TState>(TState state) where TState : notnull => NullScope.Instance;
+            public bool IsEnabled(LogLevel logLevel) => true;
+            public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter)
+            {
+                lock (entries) entries.Add((logLevel, formatter(state, exception)));
+            }
+        }
+
+        private sealed class NullScope : IDisposable
+        {
+            public static readonly NullScope Instance = new();
+            public void Dispose() { }
+        }
+    }
+}

--- a/Quilt4Net.Toolkit/ContentOptions.cs
+++ b/Quilt4Net.Toolkit/ContentOptions.cs
@@ -60,6 +60,17 @@ public record ContentOptions
     public bool WarmUpEnabled { get; set; } = true;
 
     /// <summary>
+    /// Additional languages to warm at startup (and on "Reload Content"), on top of the default
+    /// language which is always warmed. Identified by <b>language name</b> exactly as entered on the
+    /// server (e.g. <c>["English", "Svenska"]</c>), matching the naming convention used elsewhere in
+    /// the content API. A name with no matching server language is skipped with a <c>Warning</c>.
+    /// Empty (the default) preserves the previous behaviour — only the default language is warmed at
+    /// startup, and other languages warm per-circuit when first selected. Ignored when
+    /// <see cref="WarmUpEnabled"/> is false.
+    /// </summary>
+    public IReadOnlyList<string> WarmUpLanguages { get; set; } = [];
+
+    /// <summary>
     /// Roles that grant content admin access (edit, debug, reload).
     /// Checked against the authenticated user's claim roles (e.g. Entra ID).
     /// Default is ["ContentAdmin", "Developer"].

--- a/Quilt4Net.Toolkit/Features/Content/IRemoteContentCallService.cs
+++ b/Quilt4Net.Toolkit/Features/Content/IRemoteContentCallService.cs
@@ -24,6 +24,14 @@ public interface IRemoteContentCallService
     Task WarmCacheAsync(Guid languageKey, string application = null);
 
     /// <summary>
+    /// Warm the default language plus every language named in
+    /// <see cref="ContentOptions.WarmUpLanguages"/> in one bulk call each. Used by the startup
+    /// warm-up and by "Reload Content". A configured name with no matching server language is
+    /// skipped with a <c>Warning</c>. Best-effort throughout, like <see cref="WarmCacheAsync"/>.
+    /// </summary>
+    Task WarmConfiguredLanguagesAsync(string application = null);
+
+    /// <summary>
     /// Number of currently-cached content entries grouped by language key — i.e. how much content
     /// has been loaded so far per language (warm-up + lazy loads). For diagnostics/admin display.
     /// </summary>

--- a/Quilt4Net.Toolkit/Features/Content/RemoteContentCallService.cs
+++ b/Quilt4Net.Toolkit/Features/Content/RemoteContentCallService.cs
@@ -275,6 +275,32 @@ internal class RemoteContentCallService : IRemoteContentCallService
         }
     }
 
+    public async Task WarmConfiguredLanguagesAsync(string application = null)
+    {
+        if (string.IsNullOrEmpty(_contentOptions.ApiKey)) return;
+
+        // The default language (Guid.Empty) is always warmed — this is the pre-existing behaviour.
+        await WarmCacheAsync(Guid.Empty, application);
+
+        if (_contentOptions.WarmUpLanguages is not { Count: > 0 }) return;
+
+        // Configured languages are named; resolve names -> keys against the server's language list.
+        var languages = await GetLanguagesAsync(forceReload: false);
+        var warmed = new HashSet<Guid> { Guid.Empty };
+        foreach (var name in _contentOptions.WarmUpLanguages)
+        {
+            if (string.IsNullOrWhiteSpace(name)) continue;
+            var language = languages.FirstOrDefault(l => string.Equals(l.Name, name, StringComparison.OrdinalIgnoreCase));
+            if (language == null)
+            {
+                _logger.LogWarning("WarmUpLanguages: no language named '{Name}' on the server; skipping.", name);
+                continue;
+            }
+            if (!warmed.Add(language.Key)) continue; // already warmed (e.g. the default) — don't double-fetch
+            await WarmCacheAsync(language.Key, application);
+        }
+    }
+
     private async Task<ContentResult> FetchContentWithTimeout(string key, string cacheKey, string defaultValue, Guid languageKey, ContentFormat? contentType, Stopwatch sw, string effectiveApplication, IReadOnlyDictionary<string, string> translations = null)
     {
         try

--- a/Quilt4Net.Toolkit/README.md
+++ b/Quilt4Net.Toolkit/README.md
@@ -148,6 +148,8 @@ if (result.Source == ContentSource.Default)
 | `ApiKey` | `null` | API key from [Quilt4Net Web](https://quilt4net.com). |
 | `StaleWhileRevalidate` | `true` | When `true`, an expired value is returned immediately and refreshed in the background. Set `false` to refresh synchronously so callers always get a fresh value (subject to `HttpTimeout`). |
 | `SlowLogThreshold` | `3s` | When a content fetch or language-list load from the server takes at least this long, a single `Warning` is logged (endpoint, elapsed, HTTP status) — so slow loads surface even with `Debug` off. Set `TimeSpan.Zero` to disable. |
+| `WarmUpEnabled` | `true` | Pre-fill the cache at startup with one bulk call per language (Blazor). Set `false` for lazy per-key loading only. |
+| `WarmUpLanguages` | `[]` | Extra languages to warm at startup and on "Reload Content", by **name** (e.g. `["English", "Svenska"]`), on top of the always-warmed default. Empty = only the default warms at startup; others warm per-circuit on first selection. |
 
 Configuration path: `Quilt4Net:Content`
 

--- a/docs/articles/content-components.md
+++ b/docs/articles/content-components.md
@@ -305,13 +305,32 @@ call per language**:
 
 - The **default language** is warmed in the background at application start (non-blocking — startup
   is not delayed).
-- The user's **selected language** is warmed per circuit as soon as it's known, and again whenever
-  they switch language. The cache is process-wide, so the first user on a language pays the one bulk
-  call and everyone after hits the warm cache.
+- **Additional languages** can be warmed at startup too, by name, via `WarmUpLanguages` — see below.
+- The user's **selected language** is warmed per circuit as soon as it's known (if not already
+  pre-warmed), and again whenever they switch language. The cache is process-wide, so the first user
+  on a language pays the one bulk call and everyone after hits the warm cache.
 - Warming is **best-effort and backward-compatible**: against a server that doesn't expose the bulk
   endpoint (404), or on any failure/timeout, it silently falls back to the existing per-key fetching.
 
-Disable it to rely purely on lazy per-key loading:
+### Warming specific languages at startup
+
+By default only the default language is warmed at start; other languages warm lazily when first
+selected — so the first render in, say, Swedish pays a per-key fan-out. To hot-load a fixed set at
+startup, list them by **name** (matching the server's language names):
+
+```csharp
+builder.AddQuilt4NetBlazorContent(o =>
+{
+    o.WarmUpLanguages = ["English", "Svenska"];
+});
+```
+
+Each named language is resolved against the server's language list and warmed with its own bulk
+call; a name with no match is skipped with a `Warning`. The default language is always warmed
+regardless. The admin **Reload Content** action (in `LanguageSelector`) clears the cache and then
+re-warms this same set, so it is a true hot-load rather than just a cache flush.
+
+Disable warm-up entirely to rely purely on lazy per-key loading:
 
 ```json
 {


### PR DESCRIPTION
Two related content changes plus a sample diagnostics aid.

## WarmUpLanguages — hot-load a fixed set at startup

Startup warm-up previously pre-filled only the **default** language; every other language warmed
lazily on first selection, so the first render in (say) Swedish paid a per-key fan-out. And **Reload
Content** cleared the cache without re-warming, so it was never actually a hot-load.

- New `ContentOptions.WarmUpLanguages` — language **names** (e.g. `["English", "Svenska"]`), matching
  the naming convention used across the content API. Default `[]` = the previous behaviour.
- The default language is always warmed; each configured name is resolved against the server's
  language list and warmed with its own bulk call. An unmatched name is skipped with a `Warning`.
- New `IRemoteContentCallService.WarmConfiguredLanguagesAsync` centralises this. The startup hosted
  service calls it, and `LanguageSelector`'s **Reload Content** now clears **then re-warms** the same
  set — a true hot-load (the singleton cache persists across the forced circuit reload).

Backward-compatible: empty list = today's behaviour; a server without the bulk endpoint still falls
back to per-key fetching.

## Sample: content diagnostics + Serilog file sink

- **Serilog file sink** in `Quilt4Net.Toolkit.Blazor.Server.Sample` (`logs/sample-<date>.log`,
  git-ignored), added *additively* via `builder.Logging.AddSerilog` so it coexists with the existing
  OpenTelemetry/AI logging. Content categories raised to `Debug` so per-resolution source lines and
  the new `Information`/`Warning` content lines land in the file.
- **`/content-diagnostics` page** — probes given keys across every configured language and shows a
  `ContentSource` matrix + per-language tally. A non-default language resolving to `Default` = no
  server value = the client-visible symptom of a missing translation (e.g. the audit after the Atlas
  outage). Has an Application box to target another app's content (e.g. `Eplicta.FortDocs.Web`), and
  states plainly that it sees the *symptom*, not the server's translation queue.

## Verification

- 473 → 478 tests, all green
- 166 warnings vs baseline 248
- README + `docs/articles/content-components.md` updated

Note: running the sample to confirm the sink writes was blocked by the local tooling sandbox — that
end-to-end check is for the reviewer (`dotnet run`, hit `/content-diagnostics`, `logs/` appears).
