### PR TITLE
docs(blazor): document startup warm-up / hot-load (follow-up to #146)

### DIFF
--- a/Quilt4Net.Toolkit.Blazor/README.md
+++ b/Quilt4Net.Toolkit.Blazor/README.md
@@ -577,6 +577,33 @@ Notes:
 - This is distinct from **developer mode** (labelled "Debug mode" in the language menu), which
   replaces every value with a placeholder. The source overlay leaves the text alone.
 
+## Startup warm-up (hot-load)
+
+On a cold cache each content component issues its own lookup, so a content-heavy page fans out into
+dozens of requests. `AddQuilt4NetBlazorContent` registers a background startup warm-up that pre-fills
+the cache with a **single bulk call per language**, so the first render serves warm.
+
+- The **default language** is always warmed at startup (non-blocking).
+- List **additional languages** to warm at startup — by name — via `ContentOptions.WarmUpLanguages`.
+  Without this, non-default languages warm lazily on first selection, so the first render in that
+  language pays a per-key fan-out.
+- **Reload Content** (in `LanguageSelector`, admin) clears the cache and then **re-warms** the same
+  set — a true hot-load, not just a flush.
+- Best-effort: against a server without the bulk endpoint, or on any failure, it falls back to lazy
+  per-key fetching.
+
+```csharp
+builder.AddQuilt4NetBlazorContent(o =>
+{
+    o.WarmUpLanguages = ["English", "Svenska"]; // hot-load these at startup, plus the default
+    // o.WarmUpEnabled = false;                 // or disable warm-up entirely
+});
+```
+
+`WarmUpLanguages` names must match the languages configured on the Quilt4Net server; an unmatched
+name is skipped with a `Warning`. See the
+[ContentOptions reference](https://github.com/Quilt4/Quilt4Net.Toolkit/blob/master/Quilt4Net.Toolkit/README.md#contentoptions).
+
 ## Languages
 
 Content supports multiple languages managed at [Quilt4Net Web](https://quilt4net.com).


### PR DESCRIPTION
Follow-up to #146, which merged before this doc commit was included.

The warm-up feature is registered by `AddQuilt4NetBlazorContent`, but its own package README
(`Quilt4Net.Toolkit.Blazor`) had no warm-up section — neither the original default-language
hot-load nor the new `WarmUpLanguages`. A consumer looking there found nothing.

Adds a "Startup warm-up (hot-load)" section covering `WarmUpLanguages`, `WarmUpEnabled`, and the
Reload-Content re-warm, cross-linked to the core `ContentOptions` reference.

Docs only — no code change.
