### PR TITLE
chore(deps): update packages, drop net8/net9, prep 1.0 release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@ on:
     branches: [master]
 
 env:
-  MAJOR_MINOR: '0.10'
+  MAJOR_MINOR: '1.0'
 
 permissions:
   contents: write
@@ -75,7 +75,7 @@ jobs:
         id: version
         run: |
           LATEST_TAG=$(git tag -l "${MAJOR_MINOR}.*" --sort=-v:refname \
-            | grep -E "^${MAJOR_MINOR}\.[0-9]+$" \
+            | { grep -E "^${MAJOR_MINOR}\.[0-9]+$" || true; } \
             | head -1)
 
           if [ -z "$LATEST_TAG" ]; then
@@ -179,7 +179,7 @@ jobs:
         id: version
         run: |
           LATEST_TAG=$(git tag -l "${MAJOR_MINOR}.*" --sort=-v:refname \
-            | grep -E "^${MAJOR_MINOR}\.[0-9]+$" \
+            | { grep -E "^${MAJOR_MINOR}\.[0-9]+$" || true; } \
             | head -1)
 
           if [ -z "$LATEST_TAG" ]; then
@@ -321,7 +321,7 @@ jobs:
         id: version
         run: |
           LATEST_TAG=$(git tag -l "${MAJOR_MINOR}.*" --sort=-v:refname \
-            | grep -E "^${MAJOR_MINOR}\.[0-9]+$" \
+            | { grep -E "^${MAJOR_MINOR}\.[0-9]+$" || true; } \
             | head -1)
 
           if [ -z "$LATEST_TAG" ]; then

--- a/Quilt4Net.Toolkit.Api.Tests/Quilt4Net.Toolkit.Api.Tests.csproj
+++ b/Quilt4Net.Toolkit.Api.Tests/Quilt4Net.Toolkit.Api.Tests.csproj
@@ -9,9 +9,9 @@
 		<PackageReference Include="AutoFixture" Version="4.18.1" />
 		<PackageReference Include="FluentAssertions" Version="8.10.0" />
 		<PackageReference Include="JetBrains.Annotations" Version="2026.2.0" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
 		<PackageReference Include="Moq" Version="4.20.72" />
-		<PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.9" />
+		<PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.10" />
 		<PackageReference Include="OneOf" Version="3.0.271" />
 		<PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
 			<PrivateAssets>all</PrivateAssets>

--- a/Quilt4Net.Toolkit.Api/Quilt4Net.Toolkit.Api.csproj
+++ b/Quilt4Net.Toolkit.Api/Quilt4Net.Toolkit.Api.csproj
@@ -1,16 +1,16 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
 	<PropertyGroup>
-		<TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
+		<TargetFramework>net10.0</TargetFramework>
 		<OutputType>Library</OutputType>
 		<ImplicitUsings>enable</ImplicitUsings>
-		<Version>1.0.0</Version>
 		<Authors>Thargelion AB</Authors>
 		<Company>Thargelion AB</Company>
 		<Product>Quilt4Net Toolkit Api</Product>
 		<Tag>Api health liveness readiness</Tag>
 		<Description>Support for API health, liveness, readiness, startup, metrics, version and dependencies.</Description>
 		<PackageIconUrl>https://thargelion.net/assets/product-quilt4net.png</PackageIconUrl>
+		<PackageLicenseExpression>MIT</PackageLicenseExpression>
 		<GenerateDocumentationFile>True</GenerateDocumentationFile>
 		<PackageReadmeFile>README.md</PackageReadmeFile>
 		<PackageProjectUrl>https://github.com/Quilt4/Quilt4Net.Toolkit</PackageProjectUrl>
@@ -24,7 +24,10 @@
 	</PropertyGroup>
 
 	<PropertyGroup>
-		<NoWarn>1701;1702;CS1591;CS0809</NoWarn>
+		<!-- NU5048: PackageIconUrl is deprecated in favour of an embedded <PackageIcon>, but the icon is
+		     referenced from thargelion.net on purpose (maintained centrally, changeable without republishing
+		     every package). Suppress rather than switch. -->
+		<NoWarn>1701;1702;CS1591;CS0809;NU5048</NoWarn>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/Quilt4Net.Toolkit.Api/Quilt4Net.Toolkit.Api.csproj
+++ b/Quilt4Net.Toolkit.Api/Quilt4Net.Toolkit.Api.csproj
@@ -40,7 +40,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-	  <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.300">
+	  <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.301">
 		  <PrivateAssets>all</PrivateAssets>
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 	  </PackageReference>

--- a/Quilt4Net.Toolkit.Blazor.Server.Sample/Quilt4Net.Toolkit.Blazor.Server.Sample.csproj
+++ b/Quilt4Net.Toolkit.Blazor.Server.Sample/Quilt4Net.Toolkit.Blazor.Server.Sample.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Serilog.AspNetCore" Version="9.0.0" />
+    <PackageReference Include="Serilog.AspNetCore" Version="10.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Quilt4Net.Toolkit.Blazor.Tests/Quilt4Net.Toolkit.Blazor.Tests.csproj
+++ b/Quilt4Net.Toolkit.Blazor.Tests/Quilt4Net.Toolkit.Blazor.Tests.csproj
@@ -11,7 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="bunit" Version="2.7.2" />
+    <PackageReference Include="bunit" Version="2.8.6" />
     <PackageReference Include="FluentAssertions" Version="8.10.0" />
     <PackageReference Include="coverlet.collector" Version="10.0.1">
       <PrivateAssets>all</PrivateAssets>

--- a/Quilt4Net.Toolkit.Blazor.Tests/Quilt4Net.Toolkit.Blazor.Tests.csproj
+++ b/Quilt4Net.Toolkit.Blazor.Tests/Quilt4Net.Toolkit.Blazor.Tests.csproj
@@ -17,7 +17,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>

--- a/Quilt4Net.Toolkit.Blazor.Wasm.Sample/Quilt4Net.Toolkit.Blazor.Wasm.Sample.csproj
+++ b/Quilt4Net.Toolkit.Blazor.Wasm.Sample/Quilt4Net.Toolkit.Blazor.Wasm.Sample.csproj
@@ -8,8 +8,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.9" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="10.0.9" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.10" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="10.0.10" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Quilt4Net.Toolkit.Blazor/Quilt4Net.Toolkit.Blazor.csproj
+++ b/Quilt4Net.Toolkit.Blazor/Quilt4Net.Toolkit.Blazor.csproj
@@ -25,9 +25,9 @@
        add). With those removed, dotnet pack now produces a nupkg with staticwebassets/, and
        consumers can fetch _content/Quilt4Net.Toolkit.Blazor/<asset> at runtime. -->
   <ItemGroup>
-    <PackageReference Include="Microsoft.Authentication.WebAssembly.Msal" Version="10.0.9" />
-    <PackageReference Include="Microsoft.Identity.Client" Version="4.86.0" />
-    <PackageReference Include="Tharga.Blazor" Version="2.2.1" />
+    <PackageReference Include="Microsoft.Authentication.WebAssembly.Msal" Version="10.0.10" />
+    <PackageReference Include="Microsoft.Identity.Client" Version="4.86.1" />
+    <PackageReference Include="Tharga.Blazor" Version="2.2.2" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Quilt4Net.Toolkit\Quilt4Net.Toolkit.csproj" />
@@ -36,6 +36,6 @@
     <PackageReference Include="Microsoft.AspNetCore.Components.Authorization" Version="9.0.17" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
-    <PackageReference Include="Microsoft.AspNetCore.Components.Authorization" Version="10.0.9" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.Authorization" Version="10.0.10" />
   </ItemGroup>
 </Project>

--- a/Quilt4Net.Toolkit.Blazor/Quilt4Net.Toolkit.Blazor.csproj
+++ b/Quilt4Net.Toolkit.Blazor/Quilt4Net.Toolkit.Blazor.csproj
@@ -1,19 +1,22 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
-    <Version>1.0.0</Version>
     <Authors>Thargelion AB</Authors>
     <Company>Thargelion AB</Company>
     <Product>Quilt4Net Blazor Toolkit</Product>
     <PackageIconUrl>https://thargelion.net/assets/product-quilt4net.png</PackageIconUrl>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/Quilt4/Quilt4Net.Toolkit</PackageProjectUrl>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <PropertyGroup>
-    <NoWarn>1701;1702;CS1591;CS0809</NoWarn>
+    <!-- NU5048: PackageIconUrl is deprecated in favour of an embedded <PackageIcon>, but the icon is
+         referenced from thargelion.net on purpose (maintained centrally, changeable without republishing
+         every package). Suppress rather than switch. -->
+    <NoWarn>1701;1702;CS1591;CS0809;NU5048</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <InternalsVisibleTo Include="Quilt4Net.Toolkit.Blazor.Tests" />
@@ -26,16 +29,13 @@
        consumers can fetch _content/Quilt4Net.Toolkit.Blazor/<asset> at runtime. -->
   <ItemGroup>
     <PackageReference Include="Microsoft.Authentication.WebAssembly.Msal" Version="10.0.10" />
-    <PackageReference Include="Microsoft.Identity.Client" Version="4.86.1" />
-    <PackageReference Include="Tharga.Blazor" Version="2.2.2" />
+    <PackageReference Include="Microsoft.Identity.Client" Version="4.87.0" />
+    <PackageReference Include="Tharga.Blazor" Version="2.2.3" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Quilt4Net.Toolkit\Quilt4Net.Toolkit.csproj" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
-    <PackageReference Include="Microsoft.AspNetCore.Components.Authorization" Version="9.0.17" />
-  </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
+  <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Components.Authorization" Version="10.0.10" />
   </ItemGroup>
 </Project>

--- a/Quilt4Net.Toolkit.Console.Sample/Quilt4Net.Toolkit.Console.Sample.csproj
+++ b/Quilt4Net.Toolkit.Console.Sample/Quilt4Net.Toolkit.Console.Sample.csproj
@@ -12,7 +12,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.10" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Quilt4Net.Toolkit.Health.Tests/Quilt4Net.Toolkit.Health.Tests.csproj
+++ b/Quilt4Net.Toolkit.Health.Tests/Quilt4Net.Toolkit.Health.Tests.csproj
@@ -9,8 +9,8 @@
 		<PackageReference Include="AutoBogus" Version="2.13.1" />
 		<PackageReference Include="FluentAssertions" Version="8.10.0" />
 		<PackageReference Include="JetBrains.Annotations" Version="2026.2.0" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
-		<PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.9" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
+		<PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.10" />
 		<PackageReference Include="Moq" Version="4.20.72" />
 		<PackageReference Include="OneOf" Version="3.0.271" />
 		<PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">

--- a/Quilt4Net.Toolkit.Health/Quilt4Net.Toolkit.Health.csproj
+++ b/Quilt4Net.Toolkit.Health/Quilt4Net.Toolkit.Health.csproj
@@ -41,7 +41,7 @@
 
 	<ItemGroup>
 	  <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="3.1.2" />
-	  <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.300">
+	  <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.301">
 		  <PrivateAssets>all</PrivateAssets>
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 	  </PackageReference>

--- a/Quilt4Net.Toolkit.Health/Quilt4Net.Toolkit.Health.csproj
+++ b/Quilt4Net.Toolkit.Health/Quilt4Net.Toolkit.Health.csproj
@@ -1,16 +1,16 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
 	<PropertyGroup>
-		<TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
+		<TargetFramework>net10.0</TargetFramework>
 		<OutputType>Library</OutputType>
 		<ImplicitUsings>enable</ImplicitUsings>
-		<Version>1.0.0</Version>
 		<Authors>Thargelion AB</Authors>
 		<Company>Thargelion AB</Company>
 		<Product>Quilt4Net Toolkit Health</Product>
 		<Tag>health liveness readiness</Tag>
 		<Description>Features for health, liveness, readiness, startup, metrics, version and dependencies. Adds a health API.</Description>
 		<PackageIconUrl>https://thargelion.net/assets/product-quilt4net.png</PackageIconUrl>
+		<PackageLicenseExpression>MIT</PackageLicenseExpression>
 		<GenerateDocumentationFile>True</GenerateDocumentationFile>
 		<PackageReadmeFile>README.md</PackageReadmeFile>
 		<PackageProjectUrl>https://github.com/Quilt4/Quilt4Net.Toolkit</PackageProjectUrl>
@@ -24,7 +24,10 @@
 	</PropertyGroup>
 
 	<PropertyGroup>
-		<NoWarn>1701;1702;CS1591;CS0809</NoWarn>
+		<!-- NU5048: PackageIconUrl is deprecated in favour of an embedded <PackageIcon>, but the icon is
+		     referenced from thargelion.net on purpose (maintained centrally, changeable without republishing
+		     every package). Suppress rather than switch. -->
+		<NoWarn>1701;1702;CS1591;CS0809;NU5048</NoWarn>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/Quilt4Net.Toolkit.Mcp.Tests/Quilt4Net.Toolkit.Mcp.Tests.csproj
+++ b/Quilt4Net.Toolkit.Mcp.Tests/Quilt4Net.Toolkit.Mcp.Tests.csproj
@@ -7,7 +7,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="FluentAssertions" Version="8.10.0" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
 		<PackageReference Include="Moq" Version="4.20.72" />
 		<PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
 			<PrivateAssets>all</PrivateAssets>

--- a/Quilt4Net.Toolkit.Mcp/Quilt4Net.Toolkit.Mcp.csproj
+++ b/Quilt4Net.Toolkit.Mcp/Quilt4Net.Toolkit.Mcp.csproj
@@ -33,7 +33,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Tharga.Mcp" Version="0.1.6" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.300">
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.301">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/Quilt4Net.Toolkit.Mcp/Quilt4Net.Toolkit.Mcp.csproj
+++ b/Quilt4Net.Toolkit.Mcp/Quilt4Net.Toolkit.Mcp.csproj
@@ -1,14 +1,14 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
-    <Version>1.0.0</Version>
     <Authors>Thargelion AB</Authors>
     <Company>Thargelion AB</Company>
     <Product>Quilt4Net Toolkit MCP</Product>
     <Tag>MCP ApplicationInsights</Tag>
     <Description>MCP (Model Context Protocol) provider for Quilt4Net.Toolkit. Exposes Application Insights query operations as MCP tools and resources, plugging into the Tharga.Mcp ecosystem so AI agents can look up incidents and correlate logs.</Description>
     <PackageIconUrl>https://thargelion.net/assets/product-quilt4net.png</PackageIconUrl>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageProjectUrl>https://github.com/Quilt4/Quilt4Net.Toolkit</PackageProjectUrl>
@@ -19,7 +19,10 @@
     <IncludeSymbols>true</IncludeSymbols>
   </PropertyGroup>
   <PropertyGroup>
-    <NoWarn>1701;1702;CS1591;CS0809</NoWarn>
+    <!-- NU5048: PackageIconUrl is deprecated in favour of an embedded <PackageIcon>, but the icon is
+         referenced from thargelion.net on purpose (maintained centrally, changeable without republishing
+         every package). Suppress rather than switch. -->
+    <NoWarn>1701;1702;CS1591;CS0809;NU5048</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <None Include="README.md">
@@ -32,7 +35,7 @@
     <InternalsVisibleTo Include="DynamicProxyGenAssembly2" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Tharga.Mcp" Version="0.1.6" />
+    <PackageReference Include="Tharga.Mcp" Version="1.0.0" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.301">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Quilt4Net.Toolkit.Tests/Quilt4Net.Toolkit.Tests.csproj
+++ b/Quilt4Net.Toolkit.Tests/Quilt4Net.Toolkit.Tests.csproj
@@ -9,9 +9,9 @@
 		<PackageReference Include="AutoFixture" Version="4.18.1" />
 		<PackageReference Include="FluentAssertions" Version="8.10.0" />
 		<PackageReference Include="JetBrains.Annotations" Version="2026.2.0" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
 		<PackageReference Include="Moq" Version="4.20.72" />
-		<PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.9" />
+		<PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.10" />
 		<PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Quilt4Net.Toolkit/Quilt4Net.Toolkit.csproj
+++ b/Quilt4Net.Toolkit/Quilt4Net.Toolkit.csproj
@@ -39,18 +39,18 @@
   <ItemGroup>
     <PackageReference Include="Azure.Identity" Version="1.21.0" />
     <PackageReference Include="Microsoft.ApplicationInsights" Version="3.1.2" />
-    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.16.0" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.17.0" />
     <PackageReference Include="Azure.Monitor.Query.Logs" Version="1.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.9" />
-    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.9" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.9" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.9" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.9" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.300">
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.10" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.10" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.10" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.10" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.10" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.301">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="System.Management" Version="10.0.9" />
+    <PackageReference Include="System.Management" Version="10.0.10" />
     <PackageReference Include="System.Linq.Async" Version="7.0.1" />
     <PackageReference Include="Tharga.Cache" Version="0.4.9" />
   </ItemGroup>

--- a/Quilt4Net.Toolkit/Quilt4Net.Toolkit.csproj
+++ b/Quilt4Net.Toolkit/Quilt4Net.Toolkit.csproj
@@ -1,14 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
-    <Version>1.0.0</Version>
     <Authors>Thargelion AB</Authors>
     <Company>Thargelion AB</Company>
     <Product>Quilt4Net Toolkit Client</Product>
     <Tag>Health ApplicationInsights</Tag>
     <Description>Tools for Health checks via Quilt4Net.Toolkit.Api and Application Insigts.</Description>
     <PackageIconUrl>https://thargelion.net/assets/product-quilt4net.png</PackageIconUrl>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageProjectUrl>https://github.com/Quilt4/Quilt4Net.Toolkit</PackageProjectUrl>
@@ -20,7 +20,10 @@
     <IncludeSymbols>true</IncludeSymbols>
   </PropertyGroup>
   <PropertyGroup>
-    <NoWarn>1701;1702;CS1591;CS0809</NoWarn>
+    <!-- NU5048: PackageIconUrl is deprecated in favour of an embedded <PackageIcon>, but the icon is
+         referenced from thargelion.net on purpose (maintained centrally, changeable without republishing
+         every package). Suppress rather than switch. -->
+    <NoWarn>1701;1702;CS1591;CS0809;NU5048</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <None Include="README.md">
@@ -52,6 +55,6 @@
     </PackageReference>
     <PackageReference Include="System.Management" Version="10.0.10" />
     <PackageReference Include="System.Linq.Async" Version="7.0.1" />
-    <PackageReference Include="Tharga.Cache" Version="0.4.9" />
+    <PackageReference Include="Tharga.Cache" Version="1.0.0" />
   </ItemGroup>
 </Project>

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,7 +4,7 @@ _layout: landing
 
 # Quilt4Net.Toolkit
 
-A toolkit for **.NET 8 / 9 / 10** that adds health checks, observability, remote configuration, feature toggles, content / language management, and a drop-in Application Insights UI to your application. Self-host the admin pieces or pair with [Quilt4Net Web](https://quilt4net.com).
+A toolkit for **.NET 10** that adds health checks, observability, remote configuration, feature toggles, content / language management, and a drop-in Application Insights UI to your application. Self-host the admin pieces or pair with [Quilt4Net Web](https://quilt4net.com).
 
 ## Packages
 


### PR DESCRIPTION
## Summary

Package-update + framework-cleanup pass on the Toolkit (two commits), adapted from Tharga's
`package-cleanup-process.md`. **Breaking:** the shipped libraries drop `net8.0`/`net9.0` and become
`net10.0`-only, so this moves the packages from the `0.10.x` series to **`1.0.x`**.

> ⚠️ **Release impact:** on merge to `master`, `build.yml` publishes **1.0.0** to nuget.org and cuts a
> GitHub release (needs the `release` environment approval). This is the public 0.10.x → 1.0.0 cutover
> — not the routine "next after 0.10.7" release the branch started as.

## Framework drop (breaking)
- `Quilt4Net.Toolkit`, `.Api`, `.Health`, `.Mcp`: `net8.0;net9.0;net10.0` → `net10.0`
- `Quilt4Net.Toolkit.Blazor`: `net9.0;net10.0` → `net10.0`; the net9/net10 conditional `ItemGroup`s
  collapse into one `Microsoft.AspNetCore.Components.Authorization` 10.0.10 reference

## Package updates
**Libraries:**
| Package | From | To |
|---|---|---|
| `Microsoft.Extensions.*`, `System.Management`, `Microsoft.AspNetCore.*` (net10), `Microsoft.Authentication.WebAssembly.Msal` | 10.0.9 | 10.0.10 |
| `Microsoft.SourceLink.GitHub` | 10.0.300 | 10.0.301 |
| `OpenTelemetry.Extensions.Hosting` | 1.16.0 | 1.17.0 |
| `Microsoft.Identity.Client` | 4.86.0 | 4.87.0 |
| `Tharga.Blazor` | 2.2.1 | 2.2.3 |
| `Tharga.Cache` | 0.4.9 | **1.0.0** |
| `Tharga.Mcp` | 0.1.6 | **1.0.0** |

The `Tharga.Cache` 1.0.0 bump also unblocks the Server adopting `Tharga.Cache.Blazor` 1.0.0.

**Tests/samples:** `Microsoft.NET.Test.Sdk` 18.7.0 → 18.8.1 · `bunit` 2.7.2 → 2.8.6 (also clears the
`AngleSharp` NU1902 moderate vuln transitively) · `Serilog.AspNetCore` 9.0.0 → 10.0.0

## Metadata / CI cleanup
- Add `<PackageLicenseExpression>MIT</PackageLicenseExpression>` to all 5 shipped libs — a `LICENSE`
  existed but none declared it, so every pack logged "License missing" and shipped without licence
  metadata
- Suppress `NU5048` with an explanatory comment — the deprecated `PackageIconUrl` is a deliberate
  central-icon choice (`thargelion.net`), not an oversight
- Remove the dead `<Version>1.0.0>` (CI stamps the real version via `-p:PackageVersion`)
- `build.yml`: `MAJOR_MINOR` 0.10 → **1.0**, and guard the version-tag `grep` for the new series
- `docs/index.md`: framework claim `.NET 8 / 9 / 10` → `.NET 10`

## Verification
- `dotnet test` — **478 passed**, 0 failed (net10)
- `dotnet pack` (all 5 libs) — MIT licence lands in every nupkg, version stamps correctly, **zero**
  NU5048 / "License missing" warnings

## Follow-up (separate PRs, not here)
- **Server adoption** once 1.0.x is live: `Quilt4Net.Toolkit.*` → 1.0.x, `Tharga.Cache.Blazor`
  0.4.9 → 1.0.0, `Tharga.MongoDB{,.Blazor,.Mcp}` 2.14.1 → 2.14.2
- Deferred: branch audit, ReSharper pass, FluentAssertions 8.x licensing review
