### PR TITLE
Add Translations to Quilt4Button and Quilt4RadzenDataGridColumn (#149)

### DIFF
--- a/Quilt4Net.Toolkit.Blazor.Tests/ComponentTranslationsTests.cs
+++ b/Quilt4Net.Toolkit.Blazor.Tests/ComponentTranslationsTests.cs
@@ -91,13 +91,97 @@ public class ComponentTranslationsTests : BunitContext
         _content.TranslationsSeen.Should().Contain(itemTranslations);
     }
 
+    // Issue #149: three components were missing Translations entirely — Quilt4Button and
+    // Quilt4RadzenDataGridColumn covered 128 of the 129 unreachable usages FortDocs measured.
+    // Passing Translations to a component that does not declare it compiles cleanly and throws at
+    // render, so these tests exist as much to pin the parameter's existence as its forwarding.
+
+    [Fact]
+    public void Quilt4RadzenDataGridColumn_forwards_Translations()
+    {
+        var translations = new Dictionary<string, string> { ["Svenska"] = "Ärendenummer" };
+
+        Render<Quilt4RadzenDataGridColumn<string>>(p => p
+            .Add(x => x.TitleKey, "col.case.number")
+            .Add(x => x.DefaultTitle, "Case number")
+            .Add(x => x.Translations, translations));
+
+        _content.TranslationsFor("col.case.number").Should().BeSameAs(translations);
+    }
+
+    [Fact]
+    public void Quilt4RadzenDataGridColumn_without_Translations_forwards_null()
+    {
+        Render<Quilt4RadzenDataGridColumn<string>>(p => p
+            .Add(x => x.TitleKey, "col.case.number")
+            .Add(x => x.DefaultTitle, "Case number"));
+
+        _content.TranslationsFor("col.case.number").Should().BeNull();
+    }
+
+    // The button resolves three separate keys, so it takes three separate dictionaries. A single
+    // shared one could not distinguish "Spara" (label) from "Sparar…" (busy) from "Spara
+    // dokumentet" (tooltip). The issue called out that a translated label with an untranslated
+    // tooltip is worse than nothing, so all three are asserted together.
+    [Fact]
+    public void Quilt4Button_forwards_Translations_for_all_three_text_surfaces()
+    {
+        var text = new Dictionary<string, string> { ["Svenska"] = "Spara" };
+        var busy = new Dictionary<string, string> { ["Svenska"] = "Sparar…" };
+        var tooltip = new Dictionary<string, string> { ["Svenska"] = "Spara dokumentet" };
+
+        Render<Quilt4Button>(p => p
+            .Add(x => x.TextKey, "btn.save")
+            .Add(x => x.DefaultText, "Save")
+            .Add(x => x.Translations, text)
+            .Add(x => x.BusyTextKey, "btn.save.busy")
+            .Add(x => x.DefaultBusyText, "Saving…")
+            .Add(x => x.BusyTextTranslations, busy)
+            .Add(x => x.TooltipKey, "btn.save.tooltip")
+            .Add(x => x.DefaultTooltip, "Save the document")
+            .Add(x => x.TooltipTranslations, tooltip));
+
+        _content.TranslationsFor("btn.save").Should().BeSameAs(text);
+        _content.TranslationsFor("btn.save.busy").Should().BeSameAs(busy);
+        _content.TranslationsFor("btn.save.tooltip").Should().BeSameAs(tooltip);
+    }
+
+    [Fact]
+    public void Quilt4Button_keeps_the_three_dictionaries_separate()
+    {
+        var text = new Dictionary<string, string> { ["Svenska"] = "Spara" };
+
+        Render<Quilt4Button>(p => p
+            .Add(x => x.TextKey, "btn.save")
+            .Add(x => x.DefaultText, "Save")
+            .Add(x => x.Translations, text)
+            .Add(x => x.BusyTextKey, "btn.save.busy")
+            .Add(x => x.DefaultBusyText, "Saving…")
+            .Add(x => x.TooltipKey, "btn.save.tooltip")
+            .Add(x => x.DefaultTooltip, "Save the document"));
+
+        // Only the label was given translations — the other two surfaces must not inherit it.
+        _content.TranslationsFor("btn.save").Should().BeSameAs(text);
+        _content.TranslationsFor("btn.save.busy").Should().BeNull();
+        _content.TranslationsFor("btn.save.tooltip").Should().BeNull();
+    }
+
     private sealed class CapturingContentService : IContentService
     {
         public List<IReadOnlyDictionary<string, string>> TranslationsSeen { get; } = new();
 
+        /// <summary>Per-call (key, translations) pairs. Needed by the multi-surface components — a
+        /// button resolves three different keys, so "which dictionary went with which key" is the
+        /// assertion that matters, and an order-independent lookup keeps the test honest.</summary>
+        public List<(string Key, IReadOnlyDictionary<string, string> Translations)> Calls { get; } = new();
+
+        public IReadOnlyDictionary<string, string> TranslationsFor(string key)
+            => Calls.Single(c => c.Key == key).Translations;
+
         public Task<(string Value, bool Success)> GetContentAsync(string key, string defaultValue, Guid languageKey, ContentFormat? contentType, string application = null, IReadOnlyDictionary<string, string> translations = null)
         {
             TranslationsSeen.Add(translations);
+            Calls.Add((key, translations));
             return Task.FromResult((defaultValue ?? "", false));
         }
         public Task SetContentAsync(string key, string value, Guid languageKey, ContentFormat contentType, string application = null) => Task.CompletedTask;

--- a/Quilt4Net.Toolkit.Blazor/Quilt4Button.razor
+++ b/Quilt4Net.Toolkit.Blazor/Quilt4Button.razor
@@ -28,6 +28,15 @@
     [Parameter]
     public string DefaultText { get; set; }
 
+    /// <summary>Optional exact translations for <see cref="TextKey"/> (the button label), keyed by
+    /// <b>language name</b> exactly as entered on the server (e.g. <c>{ ["Svenska"] = "Spara" }</c>).
+    /// Applied only the first time the key is created on the server: each is stored as authoritative
+    /// for the matching language and AI translation is skipped for it (issue #141). The button's other
+    /// two text surfaces have their own dictionaries — see <see cref="BusyTextTranslations"/> and
+    /// <see cref="TooltipTranslations"/> — because each resolves a different key.</summary>
+    [Parameter]
+    public IReadOnlyDictionary<string, string> Translations { get; set; }
+
     [Parameter]
     public string Icon { get; set; }
 
@@ -61,6 +70,12 @@
     [Parameter]
     public string DefaultBusyText { get; set; }
 
+    /// <summary>Optional exact translations for <see cref="BusyTextKey"/>, keyed by <b>language
+    /// name</b> as entered on the server (e.g. <c>{ ["Svenska"] = "Sparar…" }</c>). Separate from
+    /// <see cref="Translations"/> because the busy label is its own content key. See #141.</summary>
+    [Parameter]
+    public IReadOnlyDictionary<string, string> BusyTextTranslations { get; set; }
+
     /// <summary>Optional content key resolved for the button's hover tooltip (HTML
     /// <c>title</c> attribute). Falls back to <see cref="DefaultTooltip"/> on miss / empty /
     /// lookup failure. Most useful on icon-only buttons; leave unset for buttons whose
@@ -73,6 +88,12 @@
     /// tooltip; set both for localised content with a sane fallback.</summary>
     [Parameter]
     public string DefaultTooltip { get; set; }
+
+    /// <summary>Optional exact translations for <see cref="TooltipKey"/>, keyed by <b>language
+    /// name</b> as entered on the server (e.g. <c>{ ["Svenska"] = "Spara dokumentet" }</c>). Separate
+    /// from <see cref="Translations"/> because the tooltip is its own content key. See #141.</summary>
+    [Parameter]
+    public IReadOnlyDictionary<string, string> TooltipTranslations { get; set; }
 
     protected override async Task OnInitializedAsync()
     {
@@ -89,9 +110,9 @@
 
     private async Task LoadContentAsync()
     {
-        _text = (await ContentService.GetContentAsync(TextKey, DefaultText, LanguageStateService.Selected.Key, ContentFormat.String)).Value;
-        _busyText = await PlaceholderResolver.ResolveAsync(ContentService, LanguageStateService, BusyTextKey, DefaultBusyText);
-        var tooltip = await PlaceholderResolver.ResolveAsync(ContentService, LanguageStateService, TooltipKey, DefaultTooltip);
+        _text = (await ContentService.GetContentAsync(TextKey, DefaultText, LanguageStateService.Selected.Key, ContentFormat.String, application: null, translations: Translations)).Value;
+        _busyText = await PlaceholderResolver.ResolveAsync(ContentService, LanguageStateService, BusyTextKey, DefaultBusyText, BusyTextTranslations);
+        var tooltip = await PlaceholderResolver.ResolveAsync(ContentService, LanguageStateService, TooltipKey, DefaultTooltip, TooltipTranslations);
         _attributes = string.IsNullOrEmpty(tooltip)
             ? null
             : new Dictionary<string, object> { ["title"] = tooltip };

--- a/Quilt4Net.Toolkit.Blazor/Quilt4RadzenDataGridColumn.razor
+++ b/Quilt4Net.Toolkit.Blazor/Quilt4RadzenDataGridColumn.razor
@@ -13,6 +13,14 @@
     [Parameter]
     public string DefaultTitle { get; set; }
 
+    /// <summary>Optional exact translations for <see cref="TitleKey"/>, keyed by <b>language name</b>
+    /// exactly as entered on the server (e.g. <c>{ ["Svenska"] = "Ärende" }</c>). Applied only the
+    /// first time the key is created on the server: each is stored as authoritative for the matching
+    /// language and AI translation is skipped for it (issue #141). Optional — omit for the ordinary
+    /// key + default flow.</summary>
+    [Parameter]
+    public IReadOnlyDictionary<string, string> Translations { get; set; }
+
     [Parameter]
     public string Property { get; set; }
 
@@ -55,7 +63,7 @@
 
     private async Task LoadContentAsync()
     {
-        var response = await ContentService.GetContentAsync(TitleKey, DefaultTitle, LanguageStateService.Selected?.Key ?? Guid.Empty, ContentFormat.String);
+        var response = await ContentService.GetContentAsync(TitleKey, DefaultTitle, LanguageStateService.Selected?.Key ?? Guid.Empty, ContentFormat.String, application: null, translations: Translations);
         LoadedTitle = !string.IsNullOrEmpty(response.Value) ? response.Value : DefaultTitle;
     }
 }

--- a/Quilt4Net.Toolkit.Blazor/README.md
+++ b/Quilt4Net.Toolkit.Blazor/README.md
@@ -514,6 +514,29 @@ The same capability is available **on the components** (>= 0.10.4) via an option
 
 It's optional — every component behaves exactly as before when it's omitted. (Note: this is distinct from `Quilt4Text.Defaults`, which is ISO-code-keyed and resolved locally only; `Translations` is language-name-keyed and stored server-authoritative on first creation.)
 
+`Quilt4RadzenDataGridColumn` and `Quilt4Button` also take `Translations`. Because a button resolves **three separate content keys**, it takes three separate dictionaries — one shared dictionary could not tell a label from a busy label from a tooltip:
+
+```razor
+<Quilt4RadzenDataGridColumn TItem="Case" Property="Number"
+                            TitleKey="col.case.number" DefaultTitle="Case number"
+                            Translations="@(new Dictionary<string,string> { ["Swedish"] = "Ärendenummer" })" />
+
+<Quilt4Button TextKey="btn.save"              DefaultText="Save"
+              Translations="@(new Dictionary<string,string> { ["Swedish"] = "Spara" })"
+              BusyTextKey="btn.save.busy"      DefaultBusyText="Saving…"
+              BusyTextTranslations="@(new Dictionary<string,string> { ["Swedish"] = "Sparar…" })"
+              TooltipKey="btn.save.tooltip"    DefaultTooltip="Save the document"
+              TooltipTranslations="@(new Dictionary<string,string> { ["Swedish"] = "Spara dokumentet" })" />
+```
+
+Each dictionary is independent — supplying only `Translations` leaves the busy label and tooltip untranslated rather than reusing the label's text.
+
+> **`Quilt4Content` does not take `Translations`, by design.** Unlike every component above it has no default parameter — it captures its default from the rendered `ChildContent` *after* first render and writes it back through the content **write** path, which carries no translations. Use `Quilt4Raw` (which does take `Translations`) for HTML content that must ship translations from code, or author the other languages in the content admin UI.
+
+**Passing `Translations` to a component that does not declare it is not a compile error.** Blazor binds component parameters by name at render time, so it builds cleanly and then throws `does not have a property matching the name 'Translations'` when the component renders — which, behind an error boundary, shows up as a blank page rather than an error.
+
+> **`Translations` applies only when the key is first created.** It is seed data, not an update mechanism. On a key that already exists on the server the dictionary is ignored — no error, no change. Retrofitting translations onto an app that has been running (so its keys are already materialized) therefore has no effect from code; author those in the content admin UI, or remove the key first so the next read re-creates it.
+
 For advanced scenarios (specific language, HTML format), inject `IContentService` directly:
 
 ```csharp


### PR DESCRIPTION
Closes #149.

Six content components already accept a name-keyed `Translations` dictionary. Two of the three that did not are the ones that matter: `Quilt4RadzenDataGridColumn` (91 usages measured in FortDocs) and `Quilt4Button` (37) — **128 of the 129** usages that could not carry a second language from code.

## Changes

**`Quilt4RadzenDataGridColumn`** — `Translations` added and threaded into its existing `GetContentAsync` call. Deliberately not refactored onto `PlaceholderResolver`; that would change behaviour for a null `TitleKey`.

**`Quilt4Button`** — **three** independent dictionaries, not one:

| Parameter | Surface |
|---|---|
| `Translations` | `TextKey` — the label |
| `BusyTextTranslations` | `BusyTextKey` |
| `TooltipTranslations` | `TooltipKey` |

The button resolves three separate content keys. A single shared dictionary could not distinguish "Spara" from "Sparar…" from "Spara dokumentet" — it would put the button's label into its tooltip. The issue asked for all three surfaces covered, and one test pins that they stay separate: supply only `Translations` and the other two forward `null`.

## `Quilt4Content` is excluded, by design

It has no default parameter — it captures its default from rendered `ChildContent` *after* first render and writes it back through the content **write** path, which carries no translations. A client-side workaround would have been silently wrong: writing the default enqueues AI translation for every enabled language, and `TranslationWorker` writes its result unconditionally, so any human translation written from the client would be overwritten the next time the worker ran.

Use `Quilt4Raw` (which does take `Translations`) for HTML content that must ship translations from code, or author the other languages in the admin UI.

## Note for consumers retrofitting an existing app

`Translations` is **seed data, applied only when a key is first created** — the server reaches it only in the not-found branch of `GetContentAsync`. On a key that already exists it is ignored silently, with no error.

So adding `Translations` to components in an app that has been running will not backfill anything: those keys are already materialized. They need the content admin UI, or the key removed so the next read re-creates it. Now documented in the README.

## Why this was worse than a missing feature

Blazor binds component parameters by name at render time, so passing `Translations` to a component that does not declare it **compiles cleanly** and then throws `does not have a property matching the name 'Translations'` on render — a blank page behind an error boundary. FortDocs only caught it because they keep a reflection test asserting every passed attribute is declared.

## Server

No server change. The wire contract has been in place since 0.10.3 (deployed 2026-07-13); these components forward the existing field.

## Tests

4 added to `ComponentTranslationsTests.cs`. Full suite **482 green** (160 Blazor + 217 Toolkit + 67 Health + 23 Api + 15 Mcp). No new warnings, so the ratchet is unaffected.
