### PR TITLE
Warm-up must not overwrite a newer cached value

### DIFF
--- a/Quilt4Net.Toolkit.Blazor/README.md
+++ b/Quilt4Net.Toolkit.Blazor/README.md
@@ -625,6 +625,25 @@ builder.AddQuilt4NetBlazorContent(o =>
 
 `WarmUpLanguages` names must match the languages configured on the Quilt4Net server; an unmatched
 name is skipped with a `Warning`. See the
+
+### Warm-up never overwrites a newer cached value
+
+A bulk response is a **snapshot** taken when the request was issued, and warm-up is fire-and-forget:
+selecting a language starts the bulk call and raises `LanguageChangedEvent` in the same breath, so
+components take the per-key path concurrently. Warm-up therefore keeps an existing cache entry when
+that entry is newer than its own response, rather than overwriting it.
+
+This matters when a per-key read causes the server to *produce* a value — for example a translation
+the server backfills the first time a language is requested for a key that already existed. Without
+the guard, the slower bulk response would put the pre-backfill fallback back over it, and the user
+would see the old language for the rest of the TTL, intermittently, depending on which response
+landed last.
+
+A **negative** cache entry (a default standing in after a 404, timeout or error) is always replaced
+by real warm-up content — its expiry comes from `FailureCacheDuration` rather than a real response,
+so it can otherwise outlast a genuine value.
+
+See the
 [ContentOptions reference](https://github.com/Quilt4/Quilt4Net.Toolkit/blob/master/Quilt4Net.Toolkit/README.md#contentoptions).
 
 ## Languages

--- a/Quilt4Net.Toolkit.Tests/ContentWarmUpTests.cs
+++ b/Quilt4Net.Toolkit.Tests/ContentWarmUpTests.cs
@@ -75,6 +75,68 @@ public class ContentWarmUpTests
         state.BulkCalls.Should().Be(0, "no API key means no calls are made at all");
     }
 
+    // Warm-up is fire-and-forget and runs concurrently with the per-key reads a language switch
+    // triggers, so a slower bulk response could overwrite what those reads cached — including a
+    // value the server produced *because* of them, such as a translation backfilled on first
+    // request (Quilt4Net.Server, Toolkit #152). The user then saw the old language for the rest of
+    // the TTL, intermittently, depending on which response landed last.
+
+    [Fact]
+    public async Task Warm_up_does_not_overwrite_a_newer_cached_value()
+    {
+        // Bulk response is deliberately older than the per-key entry already in the cache: it is a
+        // snapshot from before that read happened.
+        using var listener = StartListener(out var prefix, out _,
+            bulkItems: [("k1", "stale-from-bulk")], bulkTtl: TimeSpan.FromMinutes(30));
+
+        var (warm, content) = Build(prefix);
+
+        // Per-key read first — caches "single-value" with the longer TTL.
+        await content.GetContentAsync("k1", "def", Guid.Empty, ContentFormat.String, App);
+
+        await warm.WarmCacheAsync(Guid.Empty, App);
+
+        var after = await content.GetContentAsync("k1", "def", Guid.Empty, ContentFormat.String, App);
+        after.Value.Should().Be("single-value", "the bulk snapshot predates the per-key read and must not undo it");
+    }
+
+    [Fact]
+    public async Task Warm_up_does_replace_an_older_cached_value()
+    {
+        // The converse — the guard must not freeze the cache. A warm-up newer than what is cached
+        // is a legitimate refresh.
+        using var listener = StartListener(out var prefix, out _,
+            bulkItems: [("k1", "fresh-from-bulk")], bulkTtl: TimeSpan.FromHours(2));
+
+        var (warm, content) = Build(prefix);
+        await content.GetContentAsync("k1", "def", Guid.Empty, ContentFormat.String, App);
+
+        await warm.WarmCacheAsync(Guid.Empty, App);
+
+        var after = await content.GetContentAsync("k1", "def", Guid.Empty, ContentFormat.String, App);
+        after.Value.Should().Be("fresh-from-bulk");
+    }
+
+    [Fact]
+    public async Task Warm_up_replaces_a_negative_cache_entry_whatever_its_timestamp()
+    {
+        // A negative entry's ValidTo comes from FailureCacheDuration, not a real response, so it can
+        // outlast a genuine warm-up value. Real content must still win.
+        using var listener = StartListener(out var prefix, out _,
+            bulkItems: [("k1", "real-value")], bulkTtl: TimeSpan.FromMinutes(1), singleKeyStatus: 500);
+
+        var (warm, content) = Build(prefix);
+
+        // Fails -> negative-cached with the caller's default and a 10-minute FailureCacheDuration.
+        var failed = await content.GetContentAsync("k1", "def", Guid.Empty, ContentFormat.String, App);
+        failed.Value.Should().Be("def");
+
+        await warm.WarmCacheAsync(Guid.Empty, App);
+
+        var after = await content.GetContentAsync("k1", "def", Guid.Empty, ContentFormat.String, App);
+        after.Value.Should().Be("real-value", "a placeholder default must never outrank confirmed server content");
+    }
+
     private static (IRemoteContentCallService warm, IContentService content) Build(string baseAddress, string apiKey = "test-key")
     {
         var host = Host.CreateDefaultBuilder()
@@ -99,7 +161,7 @@ public class ContentWarmUpTests
     }
 
     private static HttpListener StartListener(out string prefix, out ListenerState state,
-        (string Key, string Value)[] bulkItems, int bulkStatus = 200)
+        (string Key, string Value)[] bulkItems, int bulkStatus = 200, TimeSpan? bulkTtl = null, int singleKeyStatus = 200)
     {
         var port = GetFreePort();
         prefix = $"http://127.0.0.1:{port}/";
@@ -132,12 +194,14 @@ public class ContentWarmUpTests
                     ctx.Response.StatusCode = bulkStatus;
                     var items = string.Join(",", (bulkItems ?? []).Select(i =>
                         $$"""{"key":"{{i.Key}}","value":"{{i.Value}}"}"""));
-                    body = $$"""{"items":[{{items}}],"validTo":"{{DateTime.UtcNow.AddHours(1):o}}"}""";
+                    // The bulk TTL is adjustable so a test can make the warm-up response older than
+                    // an entry already in the cache — the snapshot-vs-per-key race this guards.
+                    body = $$"""{"items":[{{items}}],"validTo":"{{DateTime.UtcNow.Add(bulkTtl ?? TimeSpan.FromHours(1)):o}}"}""";
                 }
                 else
                 {
                     lock (sync) s.SingleKeyCalls++;
-                    ctx.Response.StatusCode = 200;
+                    ctx.Response.StatusCode = singleKeyStatus;
                     body = $$"""{"value":"single-value","validTo":"{{DateTime.UtcNow.AddHours(1):o}}"}""";
                 }
 

--- a/Quilt4Net.Toolkit/Features/Content/RemoteContentCallService.cs
+++ b/Quilt4Net.Toolkit/Features/Content/RemoteContentCallService.cs
@@ -253,16 +253,22 @@ internal class RemoteContentCallService : IRemoteContentCallService
             if (result?.Items == null) return;
 
             var ttl = result.ValidTo - DateTime.UtcNow;
+            var kept = 0;
             foreach (var item in result.Items)
             {
                 var cacheKey = BuildCacheKey(item.Key, languageKey, effectiveApplication);
                 var cached = new CachedContent { Value = item.Value, ValidTo = result.ValidTo };
-                _localCache.AddOrUpdate(cacheKey, cached, (_, _) => cached);
+                _localCache.AddOrUpdate(cacheKey, cached, (_, existing) =>
+                {
+                    if (!ShouldKeepExisting(existing, cached)) return cached;
+                    Interlocked.Increment(ref kept);
+                    return existing;
+                });
                 if (ttl > TimeSpan.Zero) _lastKnownTtl[cacheKey] = ttl;
             }
 
-            _logger.LogInformation("Content warm-up loaded {Count} item(s) in {Elapsed}ms for application '{Application}', language '{LanguageKey}'. ValidTo: {ValidTo}.",
-                result.Items.Length, sw.ElapsedMilliseconds, effectiveApplication, languageKey, result.ValidTo);
+            _logger.LogInformation("Content warm-up loaded {Count} item(s) in {Elapsed}ms for application '{Application}', language '{LanguageKey}'. ValidTo: {ValidTo}. Kept {Kept} newer cached value(s).",
+                result.Items.Length, sw.ElapsedMilliseconds, effectiveApplication, languageKey, result.ValidTo, kept);
         }
         catch (OperationCanceledException)
         {
@@ -273,6 +279,34 @@ internal class RemoteContentCallService : IRemoteContentCallService
         {
             _logger.LogError(e, "Content warm-up failed: {Message} Falling back to per-key fetching.", e.Message);
         }
+    }
+
+    /// <summary>
+    /// Whether a bulk warm-up result must leave an existing cache entry alone.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// A bulk response is a <b>snapshot</b> taken when the request was issued, and warm-up is
+    /// fire-and-forget: <c>LanguageStateService</c> starts it and raises
+    /// <c>LanguageChangedEvent</c> in the same breath, so components take the per-key path
+    /// concurrently. Without this guard the slower bulk response overwrites whatever those reads
+    /// cached — including a value the server only produced <i>because</i> of them, such as a
+    /// translation backfilled on first request. The user then sees the old language for the rest of
+    /// the TTL, intermittently, depending on which response happened to land last.
+    /// </para>
+    /// <para>
+    /// <see cref="CachedContent.ValidTo"/> doubles as a written-at stamp: the TTL is a server
+    /// constant, so a later <c>ValidTo</c> means the entry was written later.
+    /// </para>
+    /// </remarks>
+    private static bool ShouldKeepExisting(CachedContent existing, CachedContent incoming)
+    {
+        // A negative entry stands in for a value the server never confirmed, and its ValidTo comes
+        // from FailureCacheDuration rather than a real response — so it can easily outlast a
+        // genuine warm-up value. Real content always wins over it, timestamps notwithstanding.
+        if (existing.IsDefault) return false;
+
+        return existing.ValidTo > incoming.ValidTo;
     }
 
     public async Task WarmConfiguredLanguagesAsync(string application = null)


### PR DESCRIPTION
Relates to #152 — this is the client-side half of the limitation documented there.

## The problem

A bulk warm-up response is a **snapshot** taken when the request was issued, and warm-up is fire-and-forget: `LanguageStateService.Selected` starts `WarmSelected` and raises `LanguageChangedEvent` in the same breath, so components take the per-key path concurrently. `WarmCacheAsync` then did an unconditional `AddOrUpdate` over every key in its response, overwriting whatever those reads had cached.

That is not merely a lost refresh. It can undo a value the server produced *because* of the per-key read: Quilt4Net.Server now backfills a supplied translation the first time a language is requested for an already-existing key (#152). The bulk snapshot predates that write, so it put the pre-backfill fallback straight back over the correct value — and the user saw the old language for the rest of the TTL, **intermittently**, depending on which response landed last.

## The fix

Warm-up keeps an existing cache entry when it is newer than the incoming one. `ValidTo` doubles as a written-at stamp because the TTL is a server constant.

A **negative** entry is still always replaced: its expiry comes from `FailureCacheDuration` rather than a real response, so a placeholder default could otherwise outrank confirmed server content.

## What this does not fix

While bulk-cached fallback values are still fresh, the backfilling per-key path is **not reached at all** — so a language switch can still show the old language until the TTL lapses. Fixing that properly needs fallback metadata on the bulk items so the client can tell a real value from an inherited one, rather than caching both as if they were equivalent. Tracked on the backlog.

## Tests

485 green (was 482). Three added: a newer per-key value survives an older bulk response, an older cached value is still replaced by a newer one (the guard must not freeze the cache), and a negative entry is replaced whatever its timestamp. The test listener gained control over the bulk TTL and the per-key status code to make the race expressible.
