### PR TITLE
Content fallback metadata: tell the caller why the language is wrong

### DIFF
--- a/Quilt4Net.Toolkit.Blazor.Tests/ContentFallbackDecorationTests.cs
+++ b/Quilt4Net.Toolkit.Blazor.Tests/ContentFallbackDecorationTests.cs
@@ -1,0 +1,84 @@
+using FluentAssertions;
+using Quilt4Net.Toolkit.Features.Content;
+using Xunit;
+
+namespace Quilt4Net.Toolkit.Blazor.Tests;
+
+/// <summary>
+/// How the debug overlay renders a language fallback. Shown only while
+/// <c>IContentSourceService.Enabled</c> — the components already gate on that.
+/// </summary>
+public class ContentFallbackDecorationTests
+{
+    private static ContentResult Result(ContentFallbackReason reason, ContentSource source = ContentSource.Server) => new()
+    {
+        Value = "v", Success = true, Source = source, Stale = false, FallbackReason = reason,
+    };
+
+    [Fact]
+    public void A_language_fallback_is_dashed_so_the_source_colour_keeps_its_meaning()
+    {
+        // The value can be a perfectly fresh server hit and still be the wrong language — two
+        // independent dimensions, so the second one must not repaint the first.
+        var style = ContentSourceDecoration.Style(Result(ContentFallbackReason.TranslationPending));
+
+        style.Should().Contain("dashed");
+        style.Should().Contain("#2e7d32", "it is still a fresh server value");
+    }
+
+    [Fact]
+    public void No_fallback_stays_solid()
+    {
+        ContentSourceDecoration.Style(Result(ContentFallbackReason.None)).Should().Contain("solid");
+    }
+
+    [Fact]
+    public void An_older_server_does_not_make_everything_look_like_a_fallback()
+    {
+        // Unknown means the server said nothing. Decorating on that would light up every value in
+        // the app against a server that predates the field.
+        ContentSourceDecoration.Style(Result(ContentFallbackReason.Unknown)).Should().Contain("solid");
+        ContentSourceDecoration.Tooltip(Result(ContentFallbackReason.Unknown)).Should().NotContain("Language:");
+    }
+
+    [Fact]
+    public void A_pending_translation_says_a_later_load_may_show_it()
+    {
+        ContentSourceDecoration.Tooltip(Result(ContentFallbackReason.TranslationPending))
+            .Should().Contain("later load may show it");
+    }
+
+    [Fact]
+    public void A_dead_end_says_waiting_will_not_help()
+    {
+        ContentSourceDecoration.Tooltip(Result(ContentFallbackReason.TranslationFailed))
+            .Should().Contain("Waiting will not help");
+    }
+
+    [Theory]
+    [InlineData(ContentFallbackReason.TranslationDisabled)]
+    [InlineData(ContentFallbackReason.NoContent)]
+    public void Every_language_fallback_explains_itself(ContentFallbackReason reason)
+    {
+        ContentSourceDecoration.Tooltip(Result(reason)).Should().Contain("Language:");
+    }
+
+    [Fact]
+    public void Stage_fallback_is_reported_alongside_the_language_reason()
+    {
+        var tooltip = ContentSourceDecoration.Tooltip(
+            Result(ContentFallbackReason.TranslationPending) with { IsStageFallback = true });
+
+        tooltip.Should().Contain("Stage:");
+        tooltip.Should().Contain("Language:");
+    }
+
+    [Fact]
+    public void The_source_line_is_always_kept()
+    {
+        // The fallback lines are additive — the existing "where did this come from" answer must not
+        // be displaced by the new "what is it" answer.
+        ContentSourceDecoration.Tooltip(Result(ContentFallbackReason.NoContent, ContentSource.Cache))
+            .Should().StartWith("Source: local cache");
+    }
+}

--- a/Quilt4Net.Toolkit.Blazor/ContentSourceDecoration.cs
+++ b/Quilt4Net.Toolkit.Blazor/ContentSourceDecoration.cs
@@ -7,10 +7,17 @@ namespace Quilt4Net.Toolkit.Blazor;
 /// <see cref="ContentSource"/> the same way.
 /// </summary>
 /// <remarks>
+/// <para>
 /// Colour carries meaning here: red marks a fallback default — the case you are usually hunting,
 /// because it means the server has no value for that key. Green is a fresh server value, blue a
 /// cache hit, amber a stale one. The outline shape matches the existing edit-mode decoration so the
 /// two modes look related.
+/// </para>
+/// <para>
+/// A <b>language</b> fallback is a second, independent dimension: the value can be a perfectly fresh
+/// server hit and still be the wrong language. That is drawn as a <b>dashed</b> outline rather than
+/// its own colour, so the source colour keeps meaning what it always did and the two read together.
+/// </para>
 /// </remarks>
 internal static class ContentSourceDecoration
 {
@@ -29,6 +36,18 @@ internal static class ContentSourceDecoration
         return $"outline: 2px solid {colour}; outline-offset: -4px;";
     }
 
+    /// <summary>
+    /// As <see cref="Style(ContentSource)"/>, but dashes the outline when the value is not in the
+    /// requested language. Falls through to the source-only style when the server reported nothing
+    /// (<see cref="ContentFallbackReason.Unknown"/>) — an older server must not make every value
+    /// look like a fallback.
+    /// </summary>
+    public static string Style(ContentResult result)
+    {
+        var style = Style(result.Source);
+        return IsLanguageFallback(result) ? style.Replace("solid", "dashed") : style;
+    }
+
     public static string Tooltip(ContentSource source)
     {
         return source switch
@@ -42,4 +61,40 @@ internal static class ContentSourceDecoration
             _ => "Source: not reported by this IContentService implementation"
         };
     }
+
+    /// <summary>
+    /// As <see cref="Tooltip(ContentSource)"/>, plus a line explaining the language fallback and —
+    /// the point of the whole thing — whether asking again later could do better.
+    /// </summary>
+    public static string Tooltip(ContentResult result)
+    {
+        var tooltip = Tooltip(result.Source);
+
+        if (result.IsStageFallback) tooltip += "\nStage: served from a lower stage than this environment maps to.";
+        if (!IsLanguageFallback(result)) return tooltip;
+
+        var reason = result.FallbackReason switch
+        {
+            // The only reason for which waiting is the right move.
+            ContentFallbackReason.TranslationPending =>
+                "Language: not translated yet — a translation is queued, so a later load may show it.",
+            ContentFallbackReason.TranslationFailed =>
+                "Language: translation failed and gave up. Waiting will not help — requeue it or write the text.",
+            ContentFallbackReason.TranslationDisabled =>
+                "Language: machine translation is off for this language. It has to be authored.",
+            ContentFallbackReason.NoContent =>
+                "Language: the key has no stored content at all — this is the caller's own default.",
+            _ => null,
+        };
+
+        return reason == null ? tooltip : $"{tooltip}\n{reason}";
+    }
+
+    /// <summary>
+    /// Whether the value is in a language other than the one asked for. <c>Unknown</c> and
+    /// <c>None</c> both mean "do not decorate" — the first because the server said nothing, the
+    /// second because there is nothing to say.
+    /// </summary>
+    private static bool IsLanguageFallback(ContentResult result)
+        => result.FallbackReason is not (ContentFallbackReason.Unknown or ContentFallbackReason.None);
 }

--- a/Quilt4Net.Toolkit.Blazor/Quilt4Content.razor
+++ b/Quilt4Net.Toolkit.Blazor/Quilt4Content.razor
@@ -35,11 +35,11 @@
     private string GetStyle()
     {
         if (EditContentService.Enabled) return _edit;
-        if (_showSource && _response != null) return $"{_edit} {ContentSourceDecoration.Style(_response.Source)}";
+        if (_showSource && _response != null) return $"{_edit} {ContentSourceDecoration.Style(_response)}";
         return _edit;
     }
 
-    private string GetTitle() => _showSource && _response != null ? ContentSourceDecoration.Tooltip(_response.Source) : null;
+    private string GetTitle() => _showSource && _response != null ? ContentSourceDecoration.Tooltip(_response) : null;
 
     [Parameter]
     public string Key { get; set; }

--- a/Quilt4Net.Toolkit.Blazor/Quilt4Raw.razor
+++ b/Quilt4Net.Toolkit.Blazor/Quilt4Raw.razor
@@ -9,7 +9,7 @@
 {
     @* Source mode needs an element to carry the outline + tooltip. Off, this component renders the
        value bare exactly as before — no wrapper, no markup change. *@
-    <span style="@ContentSourceDecoration.Style(_response.Source)" title="@ContentSourceDecoration.Tooltip(_response.Source)">@_content</span>
+    <span style="@ContentSourceDecoration.Style(_response)" title="@ContentSourceDecoration.Tooltip(_response)">@_content</span>
 }
 else
 {

--- a/Quilt4Net.Toolkit.Blazor/Quilt4Span.razor
+++ b/Quilt4Net.Toolkit.Blazor/Quilt4Span.razor
@@ -12,9 +12,9 @@
     private bool _showSource;
     private ContentResult _response;
 
-    private string GetStyle() => _showSource && _response != null ? ContentSourceDecoration.Style(_response.Source) : null;
+    private string GetStyle() => _showSource && _response != null ? ContentSourceDecoration.Style(_response) : null;
 
-    private string GetTitle() => _showSource && _response != null ? ContentSourceDecoration.Tooltip(_response.Source) : null;
+    private string GetTitle() => _showSource && _response != null ? ContentSourceDecoration.Tooltip(_response) : null;
 
     [Parameter]
     public string Key { get; set; }

--- a/Quilt4Net.Toolkit.Blazor/Quilt4Text.razor
+++ b/Quilt4Net.Toolkit.Blazor/Quilt4Text.razor
@@ -57,7 +57,7 @@
         if (_edit != null) return _edit;
         // _response is null until the first load completes, so fall back to Unknown rather than
         // faulting on an early render.
-        if (_showSource && _response != null) return $"{Style}{(string.IsNullOrEmpty(Style) ? "" : " ")}{ContentSourceDecoration.Style(_response.Source)}";
+        if (_showSource && _response != null) return $"{Style}{(string.IsNullOrEmpty(Style) ? "" : " ")}{ContentSourceDecoration.Style(_response)}";
         return Style;
     }
 
@@ -67,7 +67,7 @@
         {
             { "onclick", EventCallback.Factory.Create<MouseEventArgs>(this, OpenDialog) }
         };
-        if (_showSource && _response != null) attributes["title"] = ContentSourceDecoration.Tooltip(_response.Source);
+        if (_showSource && _response != null) attributes["title"] = ContentSourceDecoration.Tooltip(_response);
         return attributes;
     }
 

--- a/Quilt4Net.Toolkit.Blazor/README.md
+++ b/Quilt4Net.Toolkit.Blazor/README.md
@@ -591,6 +591,35 @@ Red is the one to look for: it means the text you are seeing is not managed by Q
 Supported on `Quilt4Text`, `Quilt4Span`, `Quilt4Raw` and `Quilt4Content`. `Quilt4PageTitle` is not
 included — it renders into `<PageTitle>`, which has no on-page surface to annotate.
 
+### Wrong language: the dashed outline
+
+Source colour answers *where the value came from*. Whether it is in the **language you asked for** is
+a separate question — a value can be a perfectly fresh server hit and still be the wrong language. So
+a language fallback **dashes** the outline instead of recolouring it, and the two read together.
+
+The tooltip then says why, and — the part that matters — whether loading again could do better:
+
+| `FallbackReason` | Tooltip says | Will retrying help? |
+|---|---|---|
+| `TranslationPending` | a translation is queued | **yes**, a later load may show it |
+| `TranslationFailed` | translation gave up | no — requeue it or write the text |
+| `TranslationDisabled` | machine translation is off for this language | no — it must be authored |
+| `NoContent` | the key has no stored content at all | no — this is your own default |
+| `None` | *(solid outline, no extra line)* | nothing is wrong |
+| `Unknown` | *(solid outline, no extra line)* | the server did not say |
+
+In code, `ContentResult.CanImprove` collapses that to the single question — `true`, `false`, or
+**`null` when the server did not report**. It is deliberately three-valued: an older server says
+nothing, and reporting that as a confident `false` would be indistinguishable from a translation
+that has genuinely given up.
+
+`ContentResult.ServedLanguageKey` carries the language the value is actually in, and
+`IsStageFallback` reports the stage dimension independently — a value can be both from a lower stage
+and in the wrong language.
+
+> Requires a server that populates the metadata. Against an older one every value reports `Unknown`
+> and the overlay behaves exactly as before — nothing is dashed, no extra tooltip lines.
+
 Notes:
 
 - **Edit mode wins.** With both enabled, the edit outline is shown, since it carries the

--- a/Quilt4Net.Toolkit.Tests/ContentFallbackMetadataTests.cs
+++ b/Quilt4Net.Toolkit.Tests/ContentFallbackMetadataTests.cs
@@ -1,0 +1,73 @@
+using FluentAssertions;
+using Quilt4Net.Toolkit.Features.Content;
+using Xunit;
+
+namespace Quilt4Net.Toolkit.Tests;
+
+/// <summary>
+/// The fallback metadata contract, and specifically the three-valued <c>CanImprove</c>.
+/// <para>
+/// The question a caller actually has is "will asking again later do better?". Getting that wrong in
+/// the safe-looking direction is the trap: a plain <c>bool</c> would report an older server — which
+/// says nothing at all — as a confident "no", which is indistinguishable from a translation that has
+/// genuinely given up.
+/// </para>
+/// </summary>
+public class ContentFallbackMetadataTests
+{
+    private static ContentResult Result(ContentFallbackReason reason) => new()
+    {
+        Value = "v", Success = true, Source = ContentSource.Server, Stale = false, FallbackReason = reason,
+    };
+
+    [Fact]
+    public void A_queued_translation_is_the_only_reason_that_may_improve()
+    {
+        Result(ContentFallbackReason.TranslationPending).CanImprove.Should().BeTrue();
+    }
+
+    [Theory]
+    [InlineData(ContentFallbackReason.TranslationFailed)]
+    [InlineData(ContentFallbackReason.TranslationDisabled)]
+    [InlineData(ContentFallbackReason.NoContent)]
+    [InlineData(ContentFallbackReason.None)]
+    public void Every_other_known_reason_is_a_dead_end(ContentFallbackReason reason)
+    {
+        Result(reason).CanImprove.Should().BeFalse();
+    }
+
+    [Fact]
+    public void An_unreported_reason_is_null_not_false()
+    {
+        // "I don't know" is a different claim from "no better result is coming". An older server
+        // omits the field, and reporting that as a confident false would make a pending translation
+        // look like one that had given up.
+        Result(ContentFallbackReason.Unknown).CanImprove.Should().BeNull();
+    }
+
+    [Fact]
+    public void Unknown_is_the_zero_value_so_an_absent_field_deserializes_to_it()
+    {
+        // The whole back-compat story rests on this: a server that predates the field sends no
+        // property, System.Text.Json leaves the enum at default, and default must mean "not known".
+        ((int)ContentFallbackReason.Unknown).Should().Be(0);
+
+        var fromOlderServer = new ContentResult { Value = "v", Success = true, Source = ContentSource.Server, Stale = false };
+        fromOlderServer.FallbackReason.Should().Be(ContentFallbackReason.Unknown);
+        fromOlderServer.ServedLanguageKey.Should().BeNull();
+        fromOlderServer.IsStageFallback.Should().BeFalse();
+        fromOlderServer.CanImprove.Should().BeNull();
+    }
+
+    [Fact]
+    public void Stage_fallback_is_independent_of_the_language_reason()
+    {
+        // A value can be both from a lower stage and in the wrong language, which is why these are
+        // two fields rather than one enum.
+        var both = Result(ContentFallbackReason.TranslationPending) with { IsStageFallback = true };
+
+        both.IsStageFallback.Should().BeTrue();
+        both.FallbackReason.Should().Be(ContentFallbackReason.TranslationPending);
+        both.CanImprove.Should().BeTrue();
+    }
+}

--- a/Quilt4Net.Toolkit/Features/Content/CachedContent.cs
+++ b/Quilt4Net.Toolkit/Features/Content/CachedContent.cs
@@ -21,4 +21,17 @@ internal record CachedContent
 
     /// <summary>True when this entry holds a fallback default rather than a value from the server.</summary>
     public bool IsDefault { get; init; }
+
+    /// <summary>
+    /// Fallback metadata as reported by the server for this value, carried so a <b>cache hit</b>
+    /// reports the same provenance as the fetch that filled it. Without this the indicator would
+    /// flicker between informative and blank as entries moved in and out of cache.
+    /// </summary>
+    public Guid? ServedLanguageKey { get; init; }
+
+    /// <inheritdoc cref="ServedLanguageKey"/>
+    public ContentFallbackReason FallbackReason { get; init; }
+
+    /// <inheritdoc cref="ServedLanguageKey"/>
+    public bool IsStageFallback { get; init; }
 }

--- a/Quilt4Net.Toolkit/Features/Content/ContentFallbackReason.cs
+++ b/Quilt4Net.Toolkit/Features/Content/ContentFallbackReason.cs
@@ -1,0 +1,50 @@
+namespace Quilt4Net.Toolkit.Features.Content;
+
+/// <summary>
+/// Why a content value is not in the language that was asked for.
+/// <para>
+/// Distinct from <see cref="ContentSource"/>, which says where the value was fetched from (server,
+/// cache, fallback default). This says <i>what the value is</i>: a request can be a fresh server hit
+/// and still be the wrong language.
+/// </para>
+/// <para>
+/// The question this exists to answer is whether calling again later could do better. Use
+/// <c>ContentResult.CanImprove</c> rather than switching on this directly when that is all you need.
+/// </para>
+/// </summary>
+public enum ContentFallbackReason
+{
+    /// <summary>
+    /// The server did not report a reason. Means "not known", <b>not</b> "no fallback" — an older
+    /// server omits the field entirely, so this is what every value from one deserializes to.
+    /// Deliberately the zero value so that absence and ignorance read the same.
+    /// </summary>
+    Unknown = 0,
+
+    /// <summary>The value is in the requested language. No language fallback happened.</summary>
+    None,
+
+    /// <summary>
+    /// No value in the requested language yet, and a translation is queued. **Trying again later may
+    /// succeed** — this is the only reason for which that is true.
+    /// </summary>
+    TranslationPending,
+
+    /// <summary>
+    /// A translation was attempted and gave up (its retry budget is spent). Waiting will not help;
+    /// somebody has to requeue it or write the text.
+    /// </summary>
+    TranslationFailed,
+
+    /// <summary>
+    /// The language is not machine-translated (AI translation is off for it), so nothing will ever
+    /// produce this value automatically. It must be authored.
+    /// </summary>
+    TranslationDisabled,
+
+    /// <summary>
+    /// The key has no stored content at all — the value being rendered is the caller's own default,
+    /// echoed back. Nothing is queued because there is no source text to translate.
+    /// </summary>
+    NoContent,
+}

--- a/Quilt4Net.Toolkit/Features/Content/ContentResult.cs
+++ b/Quilt4Net.Toolkit/Features/Content/ContentResult.cs
@@ -28,4 +28,39 @@ public record ContentResult
     /// in for a value the server never confirmed.
     /// </summary>
     public required bool Stale { get; init; }
+
+    /// <summary>
+    /// The language <see cref="Value"/> is actually in. <c>Guid.Empty</c> is the default language;
+    /// <c>null</c> when the server did not report it.
+    /// </summary>
+    public Guid? ServedLanguageKey { get; init; }
+
+    /// <summary>
+    /// Why <see cref="Value"/> is not in the requested language, when it is not.
+    /// <see cref="ContentFallbackReason.Unknown"/> against a server that predates the field.
+    /// </summary>
+    public ContentFallbackReason FallbackReason { get; init; }
+
+    /// <summary>
+    /// True when the value came from a lower stage than this environment maps to. Orthogonal to
+    /// <see cref="FallbackReason"/> — a value can be both.
+    /// </summary>
+    public bool IsStageFallback { get; init; }
+
+    /// <summary>
+    /// Whether asking again later could yield a better answer: <c>true</c> only while a translation
+    /// is queued, <c>false</c> for a dead end, and <c>null</c> when the server did not say.
+    /// </summary>
+    /// <remarks>
+    /// Derived rather than carried on the wire, so it can never disagree with
+    /// <see cref="FallbackReason"/>. Three-valued on purpose — an older server reports nothing, and
+    /// "no better result is coming" is a meaningfully different claim from "I don't know", which a
+    /// plain <c>bool</c> would quietly conflate.
+    /// </remarks>
+    public bool? CanImprove => FallbackReason switch
+    {
+        ContentFallbackReason.Unknown => null,
+        ContentFallbackReason.TranslationPending => true,
+        _ => false,
+    };
 }

--- a/Quilt4Net.Toolkit/Features/Content/RemoteContentCallService.cs
+++ b/Quilt4Net.Toolkit/Features/Content/RemoteContentCallService.cs
@@ -79,7 +79,7 @@ internal class RemoteContentCallService : IRemoteContentCallService
                 // render onwards. Success stays true either way — unchanged from the legacy tuple.
                 var source = cached.IsDefault ? ContentSource.Default : ContentSource.Cache;
                 LogResolved(key, languageKey, effectiveApplication, sw.ElapsedMilliseconds, source, stale: cached.IsDefault);
-                return Result(cached.Value ?? defaultValue, true, source, cached.IsDefault);
+                return Result(cached.Value ?? defaultValue, true, source, cached.IsDefault, cached);
             }
 
             // Stale-while-revalidate: return stale value immediately, refresh in background.
@@ -89,7 +89,7 @@ internal class RemoteContentCallService : IRemoteContentCallService
                 StartBackgroundRefresh(key, cacheKey, defaultValue, languageKey, contentType, effectiveApplication, translations);
                 var source = cached.IsDefault ? ContentSource.Default : ContentSource.StaleCache;
                 LogResolved(key, languageKey, effectiveApplication, sw.ElapsedMilliseconds, source, stale: true);
-                return Result(cached.Value ?? defaultValue, true, source, true);
+                return Result(cached.Value ?? defaultValue, true, source, true, cached);
             }
 
             // No cache (or stale-while-revalidate disabled) — fetch with timeout; the catch below
@@ -108,9 +108,22 @@ internal class RemoteContentCallService : IRemoteContentCallService
         }
     }
 
-    private static ContentResult Result(string value, bool success, ContentSource source, bool stale)
+    private static ContentResult Result(string value, bool success, ContentSource source, bool stale, CachedContent metadata = null)
     {
-        return new ContentResult { Value = value, Success = success, Source = source, Stale = stale };
+        return new ContentResult
+        {
+            Value = value,
+            Success = success,
+            Source = source,
+            Stale = stale,
+            // Carried from the cache entry (or the fetch that just filled it) so a cache hit reports
+            // the same fallback provenance as the server call did. Absent for the paths that never
+            // reached the server — no API key, developer language, a hard failure — where "unknown"
+            // is the honest answer rather than "no fallback".
+            ServedLanguageKey = metadata?.ServedLanguageKey,
+            FallbackReason = metadata?.FallbackReason ?? ContentFallbackReason.Unknown,
+            IsStageFallback = metadata?.IsStageFallback ?? false,
+        };
     }
 
     // Content was registered but cannot reach the server, so every value silently falls back to its
@@ -257,7 +270,14 @@ internal class RemoteContentCallService : IRemoteContentCallService
             foreach (var item in result.Items)
             {
                 var cacheKey = BuildCacheKey(item.Key, languageKey, effectiveApplication);
-                var cached = new CachedContent { Value = item.Value, ValidTo = result.ValidTo };
+                var cached = new CachedContent
+                {
+                    Value = item.Value,
+                    ValidTo = result.ValidTo,
+                    ServedLanguageKey = item.ServedLanguageKey,
+                    FallbackReason = item.FallbackReason,
+                    IsStageFallback = item.IsStageFallback,
+                };
                 _localCache.AddOrUpdate(cacheKey, cached, (_, existing) =>
                 {
                     if (!ShouldKeepExisting(existing, cached)) return cached;
@@ -387,11 +407,18 @@ internal class RemoteContentCallService : IRemoteContentCallService
             if (interval > TimeSpan.Zero)
                 _lastKnownTtl[cacheKey] = interval;
 
-            var cached = new CachedContent { Value = result.Value, ValidTo = result.ValidTo };
+            var cached = new CachedContent
+            {
+                Value = result.Value,
+                ValidTo = result.ValidTo,
+                ServedLanguageKey = result.ServedLanguageKey,
+                FallbackReason = result.FallbackReason,
+                IsStageFallback = result.IsStageFallback,
+            };
             _localCache.AddOrUpdate(cacheKey, cached, (_, _) => cached);
 
             LogResolved(key, languageKey, effectiveApplication, sw.ElapsedMilliseconds, ContentSource.Server, stale: false);
-            return Result(result.Value ?? defaultValue, true, ContentSource.Server, false);
+            return Result(result.Value ?? defaultValue, true, ContentSource.Server, false, cached);
         }
         catch (OperationCanceledException)
         {
@@ -460,7 +487,14 @@ internal class RemoteContentCallService : IRemoteContentCallService
                 if (interval > TimeSpan.Zero)
                     _lastKnownTtl[cacheKey] = interval;
 
-                var refreshed = new CachedContent { Value = result.Value, ValidTo = result.ValidTo };
+                var refreshed = new CachedContent
+                {
+                    Value = result.Value,
+                    ValidTo = result.ValidTo,
+                    ServedLanguageKey = result.ServedLanguageKey,
+                    FallbackReason = result.FallbackReason,
+                    IsStageFallback = result.IsStageFallback,
+                };
                 _localCache.AddOrUpdate(cacheKey, refreshed, (_, _) => refreshed);
                 _logger.LogInformation("Background refresh for content '{Key}' completed. ValidTo: {ValidTo}.",
                     key, result.ValidTo);

--- a/Quilt4Net.Toolkit/Features/FeatureToggle/ContentItem.cs
+++ b/Quilt4Net.Toolkit/Features/FeatureToggle/ContentItem.cs
@@ -1,3 +1,5 @@
+using Quilt4Net.Toolkit.Features.Content;
+
 namespace Quilt4Net.Toolkit.Features.FeatureToggle;
 
 /// <summary>A single resolved content entry (key and rendered value) within a <see cref="GetAllContentResponse"/>.</summary>
@@ -8,4 +10,21 @@ public record ContentItem
 
     /// <summary>Rendered content value for the requested language (server-rendered, same as the single-key path).</summary>
     public required string Value { get; init; }
+
+    /// <summary>
+    /// The language <see cref="Value"/> is actually in. <c>Guid.Empty</c> is the default language;
+    /// <c>null</c> means the server did not report it.
+    /// </summary>
+    /// <remarks>
+    /// The bulk path carries the same metadata as the single-key path deliberately. Warm-up is on by
+    /// default, so most rendered content arrives through here — omit it and the fallback indicator
+    /// would be blank for nearly everything, appearing only after a cache entry expired.
+    /// </remarks>
+    public Guid? ServedLanguageKey { get; init; }
+
+    /// <summary>Why <see cref="Value"/> is not in the requested language, when it is not.</summary>
+    public ContentFallbackReason FallbackReason { get; init; }
+
+    /// <summary>True when the value came from a lower stage than the caller's environment maps to.</summary>
+    public bool IsStageFallback { get; init; }
 }

--- a/Quilt4Net.Toolkit/Features/FeatureToggle/GetContentResponse.cs
+++ b/Quilt4Net.Toolkit/Features/FeatureToggle/GetContentResponse.cs
@@ -1,7 +1,33 @@
-﻿namespace Quilt4Net.Toolkit.Features.FeatureToggle;
+using Quilt4Net.Toolkit.Features.Content;
+
+namespace Quilt4Net.Toolkit.Features.FeatureToggle;
 
 public record GetContentResponse
 {
     public required string Value { get; init; }
     public required DateTime ValidTo { get; init; }
+
+    /// <summary>
+    /// The language <see cref="Value"/> is actually in, which is not necessarily the one requested.
+    /// <c>Guid.Empty</c> is the default language; <c>null</c> means the server did not report it
+    /// (older server).
+    /// </summary>
+    /// <remarks>
+    /// Optional on purpose — every metadata field here is. The server populates them only from the
+    /// release that added them, and a client on an older server must degrade to "unknown" rather
+    /// than to a confident wrong answer. That is also why
+    /// <see cref="ContentFallbackReason.Unknown"/> is the enum's zero value.
+    /// </remarks>
+    public Guid? ServedLanguageKey { get; init; }
+
+    /// <summary>Why <see cref="Value"/> is not in the requested language, when it is not.</summary>
+    public ContentFallbackReason FallbackReason { get; init; }
+
+    /// <summary>
+    /// True when the value was served from a lower stage than the caller's environment maps to.
+    /// <b>Orthogonal</b> to <see cref="FallbackReason"/> — a value can be both from a lower stage
+    /// and in the wrong language, so the two dimensions are reported separately rather than
+    /// collapsed into one enum.
+    /// </summary>
+    public bool IsStageFallback { get; init; }
 }


### PR DESCRIPTION
Part 2 of #152, and the Toolkit half of the fallback-metadata design.

**Stacked on #153** — branched from `fix/warmup-must-not-clobber-fresher-cache` because both touch `RemoteContentCallService`. Merge #153 first.

## The problem

When the server serves the default language instead of the requested one, the caller cannot tell. `ContentSource` reports `Server` / `Cache` / `Default` whichever language came back, so *"your translation is on its way"* and *"there is no translation and none is coming"* look identical. That is what made FortDocs' 1,268 discarded translations invisible.

## Wire contract

Added to `GetContentResponse` **and** `ContentItem`:

| Field | Meaning |
|---|---|
| `ServedLanguageKey` | the language the value is actually in |
| `FallbackReason` | `None` / `TranslationPending` / `TranslationFailed` / `TranslationDisabled` / `NoContent` / `Unknown` |
| `IsStageFallback` | stage dimension, reported separately |

Three decisions worth reviewing:

- **`Unknown` is the enum's zero value**, so a server that predates the field deserializes to "not known" rather than "no fallback". Every field is optional for the same reason — a new client against an old server must degrade to unknown, not to a confident wrong answer.
- **`CanImprove` is derived on the client, not carried**, so it cannot disagree with `FallbackReason`. It is `bool?` — `null` when unreported. A plain `bool` would report an older server as a confident "no better result coming", which is indistinguishable from a translation that has genuinely given up.
- **Stage and language are separate fields, not one enum.** A value can be both from a lower stage and in the wrong language.

## Bulk endpoint too

`ContentItem` carries the same metadata. Warm-up is on by default, so most rendered content arrives that way — omit it there and the indicator would be blank for nearly everything, appearing only after a cache entry expired.

Metadata is stored on the cache entry, so a cache hit reports the same provenance as the fetch that filled it rather than flickering as entries move in and out of cache.

## Display

Rides the existing `IContentSourceService` overlay — no new UI plumbing, and still debug-mode only. A language fallback **dashes** the outline instead of recolouring it, so the source colour keeps meaning what it always did and the two dimensions read together. The tooltip gains a line saying whether retrying could help.

Against a server that does not populate the fields, every value reports `Unknown` and the overlay behaves exactly as today — nothing dashed, no extra lines.

## Not included

Server-side population. These are Toolkit types the server consumes as a NuGet package, so the contract has to ship first; the server change follows the release.

## Tests

502 green (was 485). 14 added across the contract (`CanImprove` three-valued, `Unknown` is zero, stage/language independence) and the decoration (dashed only on a real fallback, older server does not light up every value, each reason explains itself, the source line is never displaced).
