### PR TITLE
fix(blazor): LanguageSelector no longer spins on a connectivity probe (#156)

### DIFF
--- a/Quilt4Net.Toolkit.Blazor.Tests/ConnectionWrapperReadyTests.cs
+++ b/Quilt4Net.Toolkit.Blazor.Tests/ConnectionWrapperReadyTests.cs
@@ -1,0 +1,88 @@
+using Bunit;
+using FluentAssertions;
+using Microsoft.AspNetCore.Components;
+using Quilt4Net.Toolkit.Blazor.Framework;
+using Quilt4Net.Toolkit.Framework;
+using Xunit;
+
+namespace Quilt4Net.Toolkit.Blazor.Tests;
+
+/// <summary>
+/// #156: <c>ConnectionWrapper</c> put a connectivity probe in front of everything it wrapped, so the
+/// language selector — whose menu is built entirely from state it already holds — spun on an HTTP
+/// call to <c>Api/System/WhoAmI</c>, a request that answers a different question than "can this
+/// render".
+/// </summary>
+public class ConnectionWrapperReadyTests : BunitContext
+{
+    private readonly SlowConnectionService _connectionService = new();
+
+    public ConnectionWrapperReadyTests()
+    {
+        JSInterop.Mode = JSRuntimeMode.Loose;
+        Services.AddSingleton<IConnectionService>(_connectionService);
+    }
+
+    [Fact]
+    public void Ready_renders_the_child_without_waiting_for_the_probe()
+    {
+        var cut = Render<ConnectionWrapper>(p => p
+            .Add(c => c.Service, Service.Content)
+            .Add(c => c.Ready, true)
+            .Add(c => c.ChildContent, (RenderFragment)(b => b.AddMarkupContent(0, "<span id=\"menu\">menu</span>"))));
+
+        cut.Find("#menu").Should().NotBeNull();
+    }
+
+    [Fact]
+    public void Ready_does_not_issue_the_probe_at_all()
+    {
+        Render<ConnectionWrapper>(p => p
+            .Add(c => c.Service, Service.Content)
+            .Add(c => c.Ready, true)
+            .Add(c => c.ChildContent, (RenderFragment)(b => b.AddMarkupContent(0, "<span id=\"menu\">menu</span>"))));
+
+        _connectionService.Probes.Should().Be(0);
+    }
+
+    [Fact]
+    public void Not_ready_still_waits_on_the_probe()
+    {
+        // The probe is what distinguishes "nothing to show" from "not connected", so a component
+        // with nothing of its own to render must still wait for it.
+        var cut = Render<ConnectionWrapper>(p => p
+            .Add(c => c.Service, Service.Content)
+            .Add(c => c.Ready, false)
+            .Add(c => c.ChildContent, (RenderFragment)(b => b.AddMarkupContent(0, "<span id=\"menu\">menu</span>"))));
+
+        cut.FindAll("#menu").Should().BeEmpty();
+        _connectionService.Probes.Should().Be(1);
+    }
+
+    [Fact]
+    public void Becoming_ready_replaces_the_spinner_with_the_child()
+    {
+        // The language selector's real sequence: nothing to draw on the first render, then the
+        // languages arrive and the menu must appear without the probe having answered.
+        var cut = Render<ConnectionWrapper>(p => p
+            .Add(c => c.Service, Service.Content)
+            .Add(c => c.Ready, false)
+            .Add(c => c.ChildContent, (RenderFragment)(b => b.AddMarkupContent(0, "<span id=\"menu\">menu</span>"))));
+
+        cut.Render(p => p.Add(c => c.Ready, true));
+
+        cut.Find("#menu").Should().NotBeNull();
+    }
+
+    /// <summary>Never completes, standing in for a probe still in flight.</summary>
+    private sealed class SlowConnectionService : IConnectionService
+    {
+        public int Probes { get; private set; }
+
+        public Task<ConnectionResult> CanConnectAsync(Service service)
+        {
+            Probes++;
+            return new TaskCompletionSource<ConnectionResult>().Task;
+        }
+    }
+}

--- a/Quilt4Net.Toolkit.Blazor.Tests/ContentWarmupTests.cs
+++ b/Quilt4Net.Toolkit.Blazor.Tests/ContentWarmupTests.cs
@@ -7,6 +7,7 @@ using Quilt4Net.Toolkit;
 using Quilt4Net.Toolkit.Blazor;
 using Quilt4Net.Toolkit.Features.Content;
 using Quilt4Net.Toolkit.Features.FeatureToggle;
+using Quilt4Net.Toolkit.Framework;
 using Xunit;
 
 namespace Quilt4Net.Toolkit.Blazor.Tests;
@@ -17,7 +18,7 @@ public class ContentWarmupTests
     public async Task HostedService_warms_the_default_language_on_start_when_enabled()
     {
         var call = new RecordingRemoteCallService();
-        var sut = new ContentWarmupHostedService(call, Options.Create(new ContentOptions { WarmUpEnabled = true }),
+        var sut = new ContentWarmupHostedService(call, new RecordingConnectionService(), Options.Create(new ContentOptions { WarmUpEnabled = true }),
             NullLogger<ContentWarmupHostedService>.Instance);
 
         await sut.StartAsync(CancellationToken.None);
@@ -27,16 +28,45 @@ public class ContentWarmupTests
     }
 
     [Fact]
+    public async Task HostedService_warms_the_connection_probe_on_start()
+    {
+        // #156: the probe is shared process-wide, so paying for it here keeps it off the render
+        // path of the first circuit — where a spinner is actually seen.
+        var probe = new RecordingConnectionService();
+        var sut = new ContentWarmupHostedService(new RecordingRemoteCallService(), probe, Options.Create(new ContentOptions { WarmUpEnabled = true }),
+            NullLogger<ContentWarmupHostedService>.Instance);
+
+        await sut.StartAsync(CancellationToken.None);
+
+        (await WaitUntil(() => probe.Probed.Contains(Service.Content))).Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task A_failing_content_warm_up_does_not_skip_the_probe()
+    {
+        // The two warm-ups are independent; one failing must not silently cost the other.
+        var probe = new RecordingConnectionService();
+        var sut = new ContentWarmupHostedService(new ThrowingRemoteCallService(), probe, Options.Create(new ContentOptions { WarmUpEnabled = true }),
+            NullLogger<ContentWarmupHostedService>.Instance);
+
+        await sut.StartAsync(CancellationToken.None);
+
+        (await WaitUntil(() => probe.Probed.Contains(Service.Content))).Should().BeTrue();
+    }
+
+    [Fact]
     public async Task HostedService_does_not_warm_when_disabled()
     {
         var call = new RecordingRemoteCallService();
-        var sut = new ContentWarmupHostedService(call, Options.Create(new ContentOptions { WarmUpEnabled = false }),
+        var probe = new RecordingConnectionService();
+        var sut = new ContentWarmupHostedService(call, probe, Options.Create(new ContentOptions { WarmUpEnabled = false }),
             NullLogger<ContentWarmupHostedService>.Instance);
 
         await sut.StartAsync(CancellationToken.None);
 
         await Task.Delay(150);
         call.Calls.Should().BeEmpty();
+        probe.Probed.Should().BeEmpty("WarmUpEnabled turns the whole startup warm-up off");
     }
 
     [Fact]
@@ -65,7 +95,7 @@ public class ContentWarmupTests
         return condition();
     }
 
-    private sealed class RecordingRemoteCallService : IRemoteContentCallService
+    private class RecordingRemoteCallService : IRemoteContentCallService
     {
         public ConcurrentBag<Guid> Calls { get; } = [];
 
@@ -76,7 +106,7 @@ public class ContentWarmupTests
         }
 
         // Mirrors the real service with no WarmUpLanguages configured: warm the default language.
-        public Task WarmConfiguredLanguagesAsync(string application = null) => WarmCacheAsync(Guid.Empty, application);
+        public virtual Task WarmConfiguredLanguagesAsync(string application = null) => WarmCacheAsync(Guid.Empty, application);
 
         public Task<(string Value, bool Success)> GetContentAsync(string key, string defaultValue, Guid languageKey, ContentFormat? contentType, string application = null, IReadOnlyDictionary<string, string> translations = null)
             => Task.FromResult((defaultValue, true));
@@ -86,6 +116,22 @@ public class ContentWarmupTests
         public Task<Language[]> GetLanguagesAsync(bool forceReload) => Task.FromResult(Array.Empty<Language>());
         public Task ClearContentCacheAsync() => Task.CompletedTask;
         public IReadOnlyDictionary<Guid, int> GetCacheCountsByLanguage() => new Dictionary<Guid, int>();
+    }
+
+    private sealed class ThrowingRemoteCallService : RecordingRemoteCallService
+    {
+        public override Task WarmConfiguredLanguagesAsync(string application = null) => throw new HttpRequestException("server unreachable");
+    }
+
+    private sealed class RecordingConnectionService : IConnectionService
+    {
+        public ConcurrentBag<Service> Probed { get; } = [];
+
+        public Task<ConnectionResult> CanConnectAsync(Service service)
+        {
+            Probed.Add(service);
+            return Task.FromResult(new ConnectionResult { Success = true });
+        }
     }
 
     private sealed class FakeLanguageService(Language[] languages) : ILanguageService

--- a/Quilt4Net.Toolkit.Blazor/ContentWarmupHostedService.cs
+++ b/Quilt4Net.Toolkit.Blazor/ContentWarmupHostedService.cs
@@ -2,6 +2,7 @@ using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Quilt4Net.Toolkit.Features.Content;
+using Quilt4Net.Toolkit.Framework;
 
 namespace Quilt4Net.Toolkit.Blazor;
 
@@ -16,12 +17,14 @@ namespace Quilt4Net.Toolkit.Blazor;
 internal sealed class ContentWarmupHostedService : IHostedService
 {
     private readonly IRemoteContentCallService _callService;
+    private readonly IConnectionService _connectionService;
     private readonly ContentOptions _options;
     private readonly ILogger<ContentWarmupHostedService> _logger;
 
-    public ContentWarmupHostedService(IRemoteContentCallService callService, IOptions<ContentOptions> options, ILogger<ContentWarmupHostedService> logger)
+    public ContentWarmupHostedService(IRemoteContentCallService callService, IConnectionService connectionService, IOptions<ContentOptions> options, ILogger<ContentWarmupHostedService> logger)
     {
         _callService = callService;
+        _connectionService = connectionService;
         _options = options.Value;
         _logger = logger;
     }
@@ -41,6 +44,18 @@ internal sealed class ContentWarmupHostedService : IHostedService
             catch (Exception e)
             {
                 _logger.LogError(e, "Content startup warm-up failed: {Message}", e.Message);
+            }
+
+            // The connectivity probe is warmed here too (#156). Its result is now shared
+            // process-wide, so paying for it once at startup keeps it off the render path of the
+            // first circuit — which is the one where a user actually notices it.
+            try
+            {
+                await _connectionService.CanConnectAsync(Service.Content);
+            }
+            catch (Exception e)
+            {
+                _logger.LogError(e, "Connection probe warm-up failed: {Message}", e.Message);
             }
         }, CancellationToken.None);
 

--- a/Quilt4Net.Toolkit.Blazor/Features/Language/LanguageSelector.razor
+++ b/Quilt4Net.Toolkit.Blazor/Features/Language/LanguageSelector.razor
@@ -9,7 +9,11 @@
 @inject IContentAdminService ContentAdminService
 @inject NavigationManager NavigationManager
 
-<ConnectionWrapper Service="Service.Content">
+@* Ready as soon as there is a menu to draw. The languages come from LanguageStateService and the
+   admin flag from the auth state — neither is what the connectivity probe answers, so waiting on
+   it only ever delayed a menu that was already complete (#156). The probe still decides what an
+   empty selector shows: nothing, or "not connected". *@
+<ConnectionWrapper Service="Service.Content" Ready="@(LanguageStateService.Languages.Length > 1 || _isAdmin)">
     @if (LanguageStateService.Languages.Length > 1 || _isAdmin)
     {
         <RadzenMenu>

--- a/Quilt4Net.Toolkit.Blazor/Framework/ConnectionWrapper.razor
+++ b/Quilt4Net.Toolkit.Blazor/Framework/ConnectionWrapper.razor
@@ -1,7 +1,16 @@
-﻿@using Quilt4Net.Toolkit.Framework
+@using Quilt4Net.Toolkit.Framework
 @inject IConnectionService ConnectionService
 
-@if (_result == null)
+@if (Ready)
+{
+    @* The child already has the state it renders, so there is nothing to wait for. Capabilities
+       cascade as null unless a probe happened to complete earlier — a component opting in here is
+       declaring it does not read them. *@
+    <CascadingValue Value="@_result?.Capabilities">
+        @ChildContent
+    </CascadingValue>
+}
+else if (_result == null)
 {
     <Loading Size="ProgressBarCircularSize.Small" />
 }
@@ -23,6 +32,15 @@ else
     [Parameter]
     public Service? Service { get; set; }
 
+    /// <summary>
+    /// Set by a host component that already holds everything it renders. The connectivity probe is
+    /// then neither awaited nor issued: it answers a different question than "can this render", and
+    /// making it a precondition put a network round trip in front of content that was already in
+    /// hand (#156).
+    /// </summary>
+    [Parameter]
+    public bool Ready { get; set; }
+
     [Parameter]
     public RenderFragment ChildContent { get; set; }
 
@@ -30,7 +48,12 @@ else
     {
         if (!Service.HasValue) throw new InvalidOperationException($"No {nameof(Service)} parameter provided to {nameof(ConnectionWrapper)} component.");
 
-        _result = await ConnectionService.CanConnectAsync(Service.Value);
+        // The probe only decides between "nothing to show" and "not connected", and Ready has
+        // already settled that.
+        if (!Ready)
+        {
+            _result = await ConnectionService.CanConnectAsync(Service.Value);
+        }
 
         await base.OnParametersSetAsync();
     }

--- a/Quilt4Net.Toolkit.Blazor/README.md
+++ b/Quilt4Net.Toolkit.Blazor/README.md
@@ -689,6 +689,13 @@ Add the `LanguageSelector` component to let users switch languages.
 
 The selected language is persisted to browser local storage. All content components update automatically when the language changes.
 
+The selector renders as soon as it has a menu to draw — it does **not** wait on a connectivity check
+first. The connectivity probe (`GET Api/System/WhoAmI`) still runs, but only to decide what an
+*empty* selector shows: nothing, or "Not connected to Quilt4Net". Its result is cached for the whole
+process and warmed at startup alongside the content warm-up, so it is not re-issued per component or
+per circuit. An unsuccessful probe is cached briefly rather than permanently, so a server that comes
+back is picked up without a restart.
+
 ### Language state
 
 Inject `ILanguageStateService` to manage language state from code.

--- a/Quilt4Net.Toolkit.Tests/ConnectionServiceUnconfiguredTests.cs
+++ b/Quilt4Net.Toolkit.Tests/ConnectionServiceUnconfiguredTests.cs
@@ -1,3 +1,4 @@
+using System.Net;
 using FluentAssertions;
 using Microsoft.Extensions.Options;
 using Quilt4Net.Toolkit.Framework;
@@ -77,10 +78,70 @@ public class ConnectionServiceUnconfiguredTests
         second.Should().BeSameAs(first);
     }
 
-    private static ConnectionService CreateSut(string contentAddress, string configurationAddress)
+    // -------- Probe caching (#156) -----------------------------------------------------------
+
+    [Fact]
+    public async Task An_unreachable_server_is_probed_once_not_once_per_call()
+    {
+        // The catch used to return without caching, so every later probe re-paid the full timeout.
+        var handler = new CountingHandler(() => throw new HttpRequestException("unreachable"));
+        var sut = CreateSut("https://example.com/", "https://example.com/", handler);
+
+        await sut.CanConnectAsync(Service.Content);
+        await sut.CanConnectAsync(Service.Content);
+
+        handler.Calls.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task A_cached_failure_expires_so_the_server_coming_back_is_noticed()
+    {
+        // The cache is process-wide now. Caching a failure forever would leave a permanently
+        // "Not connected" UI after one blip at startup.
+        var handler = new CountingHandler(() => throw new HttpRequestException("unreachable"));
+        var sut = CreateSut("https://example.com/", "https://example.com/", handler);
+        sut.FailureCacheDuration = TimeSpan.Zero; // expired the moment it is written
+
+        await sut.CanConnectAsync(Service.Content);
+        await sut.CanConnectAsync(Service.Content);
+
+        handler.Calls.Should().Be(2);
+    }
+
+    [Fact]
+    public async Task A_successful_probe_is_not_re_issued()
+    {
+        var handler = new CountingHandler(() => new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent("{}") });
+        var sut = CreateSut("https://example.com/", "https://example.com/", handler);
+
+        await sut.CanConnectAsync(Service.Content);
+        await sut.CanConnectAsync(Service.Content);
+
+        handler.Calls.Should().Be(1);
+    }
+
+    private static ConnectionService CreateSut(string contentAddress, string configurationAddress, HttpMessageHandler handler = null)
     {
         var content = Options.Create(new ContentOptions { Quilt4NetAddress = contentAddress });
         var configuration = Options.Create(new RemoteConfigurationOptions { Quilt4NetAddress = configurationAddress });
-        return new ConnectionService(content, configuration);
+        return new ConnectionService(content, configuration, new StubHttpClientFactory(handler ?? new CountingHandler(() => new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent("{}") })));
+    }
+
+    private sealed class CountingHandler(Func<HttpResponseMessage> respond) : HttpMessageHandler
+    {
+        public int Calls { get; private set; }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            Calls++;
+            return Task.FromResult(respond());
+        }
+    }
+
+    private sealed class StubHttpClientFactory(HttpMessageHandler handler) : IHttpClientFactory
+    {
+        // No BaseAddress, mirroring a host that registered the other feature only — the service
+        // fills it in from options, which is the path worth exercising here.
+        public HttpClient CreateClient(string name) => new(handler, disposeHandler: false);
     }
 }

--- a/Quilt4Net.Toolkit/ContentRegistration.cs
+++ b/Quilt4Net.Toolkit/ContentRegistration.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -50,6 +51,12 @@ public static class ContentRegistration
 
         services.AddTransient<ILanguageService, LanguageService>();
         services.AddTransient<IContentService, ContentService>();
+
+        // ConnectionWrapper (LanguageSelector, ContentAdmin) probes Service.Content, so a
+        // content-only host needs this too — it used to come solely from
+        // AddQuilt4NetRemoteConfiguration. Singleton so the probe cache is shared process-wide;
+        // TryAdd so registering both features stays a no-op the second time.
+        services.TryAddSingleton<IConnectionService, ConnectionService>();
 
         // Named factory client: BaseAddress + X-API-KEY configured once, correlation-id forwarded
         // to Quilt4Net.Server. Replaces the previous per-call `new HttpClient()` (socket-pooling +

--- a/Quilt4Net.Toolkit/Framework/ConnectionService.cs
+++ b/Quilt4Net.Toolkit/Framework/ConnectionService.cs
@@ -1,4 +1,5 @@
-﻿using System.Text.Json;
+using System.Collections.Concurrent;
+using System.Text.Json;
 using Microsoft.Extensions.Options;
 
 namespace Quilt4Net.Toolkit.Framework;
@@ -7,39 +8,54 @@ internal class ConnectionService : IConnectionService
 {
     private static readonly JsonSerializerOptions JsonOptions = new() { PropertyNameCaseInsensitive = true };
 
+    /// <summary>
+    /// How long an unsuccessful probe is trusted before it is worth asking again.
+    /// <para>
+    /// A failure used to be either cached for the lifetime of one short-lived service instance or
+    /// (in the exception case) not cached at all. Now that the cache is shared process-wide, caching
+    /// "forever" would turn one blip during startup into a permanently disconnected UI, while caching
+    /// nothing means every probe after a failure re-pays the full round trip (#156). A minute kills
+    /// the burst and still recovers on its own.
+    /// </para>
+    /// </summary>
+    internal TimeSpan FailureCacheDuration { get; set; } = TimeSpan.FromMinutes(1);
+
     private readonly ContentOptions _contentOptions;
     private readonly RemoteConfigurationOptions _configurationOptions;
-    private readonly Dictionary<Service, ConnectionResult> _cache = new();
+    private readonly IHttpClientFactory _httpClientFactory;
 
-    public ConnectionService(IOptions<ContentOptions> contentOptions, IOptions<RemoteConfigurationOptions> configurationOptions)
+    /// <summary>
+    /// Probe results, shared by every caller in the process. This service used to be transient, so
+    /// the cache lived and died with a single component's injected copy: the "cached" probe was in
+    /// practice re-issued per component, per circuit (#156).
+    /// </summary>
+    private readonly ConcurrentDictionary<Service, CacheEntry> _cache = new();
+
+    public ConnectionService(IOptions<ContentOptions> contentOptions, IOptions<RemoteConfigurationOptions> configurationOptions, IHttpClientFactory httpClientFactory)
     {
         _contentOptions = contentOptions.Value;
         _configurationOptions = configurationOptions.Value;
+        _httpClientFactory = httpClientFactory;
     }
 
     public async Task<ConnectionResult> CanConnectAsync(Service service)
     {
-        if (_cache.TryGetValue(service, out var cached))
-            return cached;
+        if (_cache.TryGetValue(service, out var cached) && !cached.HasExpired(DateTime.UtcNow))
+            return cached.Result;
 
         if (!TryGetConfiguration(service, out var config, out var configError))
         {
             // Cache the unconfigured result so subsequent probes return immediately
-            // instead of paying the upstream HealthService timeout per call.
+            // instead of paying the upstream HealthService timeout per call. No expiry:
+            // missing configuration cannot fix itself while the process runs.
             var unconfigured = new ConnectionResult { Success = false, Message = configError };
-            _cache[service] = unconfigured;
+            _cache[service] = CacheEntry.Permanent(unconfigured);
             return unconfigured;
         }
 
         try
         {
-            using var client = new HttpClient();
-
-            client.BaseAddress = config.BaseAddress;
-            if (!string.IsNullOrEmpty(config.ApiKey))
-            {
-                client.DefaultRequestHeaders.Add("X-API-KEY", config.ApiKey);
-            }
+            var client = GetHttpClient(service, config);
 
             var response = await client.GetAsync("Api/System/WhoAmI");
 
@@ -58,7 +74,9 @@ internal class ConnectionService : IConnectionService
                 Capabilities = capabilities
             };
 
-            _cache[service] = result;
+            _cache[service] = result.Success
+                ? CacheEntry.Permanent(result)
+                : CacheEntry.Expiring(result, DateTime.UtcNow.Add(FailureCacheDuration));
             return result;
         }
         catch (Exception e)
@@ -69,8 +87,45 @@ internal class ConnectionService : IConnectionService
                 Message = e.Message,
                 Address = config.BaseAddress
             };
+
+            // Cached like any other failure. Leaving this path uncached was the one asymmetry in
+            // the original three: an unreachable server made every later probe pay the full timeout.
+            _cache[service] = CacheEntry.Expiring(result, DateTime.UtcNow.Add(FailureCacheDuration));
             return result;
         }
+    }
+
+    /// <summary>
+    /// The pooled client for the probed service. The named clients registered by
+    /// <c>AddQuilt4NetContent</c> / <c>AddQuilt4NetRemoteConfiguration</c> already carry the same
+    /// base address, API key and correlation-id handler, so the probe reuses one rather than
+    /// constructing (and discarding) an <see cref="HttpClient"/> of its own per call.
+    /// </summary>
+    /// <remarks>
+    /// A host that registered only one of the two features still has the *other* service's named
+    /// client resolvable — the factory hands back an unconfigured client for any name. That is what
+    /// the <c>BaseAddress</c> check covers. Nothing is added on top of an already-configured client:
+    /// re-adding X-API-KEY would send it twice, which the server rejects as an invalid key.
+    /// </remarks>
+    private HttpClient GetHttpClient(Service service, (Uri BaseAddress, string ApiKey) config)
+    {
+        var name = service switch
+        {
+            Service.Content => Features.Content.RemoteContentCallService.HttpClientName,
+            Service.Configuration => Features.FeatureToggle.RemoteConfigCallService.HttpClientName,
+            _ => throw new ArgumentOutOfRangeException(nameof(service), service, null)
+        };
+
+        var client = _httpClientFactory.CreateClient(name);
+        if (client.BaseAddress != null) return client;
+
+        client.BaseAddress = config.BaseAddress;
+        if (!string.IsNullOrEmpty(config.ApiKey))
+        {
+            client.DefaultRequestHeaders.Remove("X-API-KEY");
+            client.DefaultRequestHeaders.Add("X-API-KEY", config.ApiKey);
+        }
+        return client;
     }
 
     /// <summary>
@@ -105,5 +160,12 @@ internal class ConnectionService : IConnectionService
         config = (uri, apiKey);
         error = null;
         return true;
+    }
+
+    private readonly record struct CacheEntry(ConnectionResult Result, DateTime? ExpiresUtc)
+    {
+        public static CacheEntry Permanent(ConnectionResult result) => new(result, null);
+        public static CacheEntry Expiring(ConnectionResult result, DateTime expiresUtc) => new(result, expiresUtc);
+        public bool HasExpired(DateTime nowUtc) => ExpiresUtc.HasValue && ExpiresUtc.Value <= nowUtc;
     }
 }

--- a/Quilt4Net.Toolkit/RemoteConfigurationRegistration.cs
+++ b/Quilt4Net.Toolkit/RemoteConfigurationRegistration.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -73,6 +74,10 @@ public static class RemoteConfigurationRegistration
         });
         services.AddTransient<IFeatureToggleService, FeatureToggleService>();
         services.AddTransient<IRemoteConfigurationService, RemoteConfigurationService>();
-        services.AddTransient<IConnectionService, ConnectionService>();
+        // Singleton, and TryAdd because AddQuilt4NetContent registers the same service: the probe
+        // cache is only worth having if every caller shares it (#156). As a transient the cache
+        // died with each injected copy, so the connectivity probe ran once per component per
+        // circuit rather than once per process.
+        services.TryAddSingleton<IConnectionService, ConnectionService>();
     }
 }


### PR DESCRIPTION
Closes #156.

`LanguageSelector` showed a spinner on every fresh session while it waited for `ConnectionService.CanConnectAsync(Service.Content)` — an HTTP `GET Api/System/WhoAmI`. The language menu is built entirely from state the component already holds (`LanguageStateService.Languages` plus the admin flag), so the probe answers a different question than "can this render".

One cause the issue did not catch: `IConnectionService` was registered **transient**, so its cache died with each injected copy. The probe was therefore re-issued per component, not merely per circuit as reported.

## Changes

- **`ConnectionWrapper` takes a `Ready` parameter.** When the host component already has what it renders, the probe is neither awaited nor issued. `LanguageSelector` is ready as soon as it has languages or the user is a content admin. The probe still decides what an *empty* selector shows — nothing, or "Not connected to Quilt4Net".
- **`IConnectionService` is a singleton**, so one probe serves the whole process. It is now registered by `AddQuilt4NetContent` as well: a content-only host previously had to pull it in via `AddQuilt4NetRemoteConfiguration` for `ConnectionWrapper` to resolve at all.
- **The startup warm-up warms the probe** alongside the content, keeping it off the first circuit's render path.
- **Failures are cached** like the other two outcomes — but with a short expiry rather than permanently. Uncached meant every later probe re-paid the full timeout; cached forever would leave a now process-wide UI stuck on "Not connected" after one blip at startup.
- **The probe uses the pooled named `IHttpClientFactory` client** instead of constructing an `HttpClient` per call.

## Deviation from the ask worth flagging

The issue asks to cache the failure result "as the other two paths already do", i.e. indefinitely. Combined with the singleton change that would make a transient blip permanent for the process lifetime, so failures expire after a minute instead. Successes are still cached indefinitely.

## Tests

8 new tests — 4 bUnit tests for the `Ready` render paths, 3 for probe caching (unreachable server probed once; a cached failure expiring; a success not re-issued), 1 for probe warm-up surviving a failed content warm-up. Full suite: 507 pass, no new warnings.