### PR TITLE
fix(content): warm-up failure logs name the application, language and reason (#155)

### DIFF
--- a/Quilt4Net.Toolkit.Tests/ContentWarmUpTests.cs
+++ b/Quilt4Net.Toolkit.Tests/ContentWarmUpTests.cs
@@ -1,7 +1,9 @@
+using System.Collections.Concurrent;
 using System.Net;
 using FluentAssertions;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
 using Quilt4Net.Toolkit.Features.Content;
 using Quilt4Net.Toolkit.Features.FeatureToggle;
 using Xunit;
@@ -47,6 +49,39 @@ public class ContentWarmUpTests
         r.Success.Should().BeTrue();
         r.Value.Should().Be("single-value");
         state.SingleKeyCalls.Should().Be(1, "an old server without the bulk endpoint must leave the per-key path working");
+    }
+
+    // #155: warm-up runs once per configured language, so a failure line naming neither the
+    // application nor the language cannot say which of them dropped to per-key fetching — which is
+    // exactly what FortDocs saw when the Swedish warm-up 500'd and the English one succeeded. The
+    // success line has always named them; the failure line was the odd one out.
+
+    [Fact]
+    public async Task A_failed_warm_up_names_the_application_and_language_it_was_warming()
+    {
+        var swedish = Guid.NewGuid();
+        using var listener = StartListener(out var prefix, out _, bulkItems: null, bulkStatus: 500);
+        var logs = new CapturingLoggerProvider();
+
+        var (warm, _) = Build(prefix, loggerProvider: logs);
+        await warm.WarmCacheAsync(swedish, App);
+
+        var entry = logs.Entries.Should().ContainSingle(x => x.Contains("Content warm-up failed")).Subject;
+        entry.Should().Contain(App).And.Contain(swedish.ToString());
+    }
+
+    [Fact]
+    public async Task A_failed_warm_up_reports_the_response_body_as_the_reason()
+    {
+        // "The 500 should say something." Without the body the only signal is the status code,
+        // which says a request failed but never why.
+        using var listener = StartListener(out var prefix, out _, bulkItems: null, bulkStatus: 500);
+        var logs = new CapturingLoggerProvider();
+
+        var (warm, _) = Build(prefix, loggerProvider: logs);
+        await warm.WarmCacheAsync(Guid.NewGuid(), App);
+
+        logs.Entries.Should().ContainSingle(x => x.Contains("Content warm-up failed") && x.Contains("Body:"));
     }
 
     [Fact]
@@ -137,11 +172,12 @@ public class ContentWarmUpTests
         after.Value.Should().Be("real-value", "a placeholder default must never outrank confirmed server content");
     }
 
-    private static (IRemoteContentCallService warm, IContentService content) Build(string baseAddress, string apiKey = "test-key")
+    private static (IRemoteContentCallService warm, IContentService content) Build(string baseAddress, string apiKey = "test-key", ILoggerProvider loggerProvider = null)
     {
         var host = Host.CreateDefaultBuilder()
             .ConfigureServices(services =>
             {
+                if (loggerProvider != null) services.AddLogging(b => b.AddProvider(loggerProvider).SetMinimumLevel(LogLevel.Debug));
                 services.AddQuilt4NetContent(null, o =>
                 {
                     o.Quilt4NetAddress = baseAddress;
@@ -158,6 +194,21 @@ public class ContentWarmUpTests
     {
         public int BulkCalls;
         public int SingleKeyCalls;
+    }
+
+    private sealed class CapturingLoggerProvider : ILoggerProvider
+    {
+        public ConcurrentBag<string> Entries { get; } = [];
+        public ILogger CreateLogger(string categoryName) => new Capturing(Entries);
+        public void Dispose() { }
+
+        private sealed class Capturing(ConcurrentBag<string> entries) : ILogger
+        {
+            public IDisposable BeginScope<TState>(TState state) where TState : notnull => null;
+            public bool IsEnabled(LogLevel logLevel) => true;
+            public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter)
+                => entries.Add(formatter(state, exception));
+        }
     }
 
     private static HttpListener StartListener(out string prefix, out ListenerState state,

--- a/Quilt4Net.Toolkit/Features/Content/RemoteContentCallService.cs
+++ b/Quilt4Net.Toolkit/Features/Content/RemoteContentCallService.cs
@@ -251,14 +251,20 @@ internal class RemoteContentCallService : IRemoteContentCallService
 
             if (response.StatusCode == HttpStatusCode.NotFound)
             {
-                _logger.LogInformation("Content warm-up endpoint unavailable (404). Server predates bulk content; falling back to per-key fetching.");
+                _logger.LogInformation("Content warm-up endpoint unavailable (404) for application '{Application}' in environment '{Environment}', language '{LanguageKey}'. Server predates bulk content; falling back to per-key fetching.",
+                    effectiveApplication, _environmentName.Name, languageKey);
                 return;
             }
 
             if (!response.IsSuccessStatusCode)
             {
-                _logger.LogWarning("Content warm-up failed. Response was {StatusCode} {ReasonPhrase}. Falling back to per-key fetching.",
-                    response.StatusCode, response.ReasonPhrase);
+                // Coordinates and body, because warm-up is per language: without them a host warming
+                // two languages sees one failure line that cannot say which one dropped to per-key
+                // fetching, and no reason at all (#155). The success line above has always named
+                // them, so a failure naming nothing was the odd one out.
+                var body = await ReadErrorBodyAsync(response, cts.Token);
+                _logger.LogWarning("Content warm-up failed for application '{Application}' in environment '{Environment}', language '{LanguageKey}'. Response was {StatusCode} {ReasonPhrase}. {Body}Falling back to per-key fetching.",
+                    effectiveApplication, _environmentName.Name, languageKey, response.StatusCode, response.ReasonPhrase, body);
                 return;
             }
 
@@ -292,12 +298,39 @@ internal class RemoteContentCallService : IRemoteContentCallService
         }
         catch (OperationCanceledException)
         {
-            _logger.LogWarning("Content warm-up timed out after {Timeout}ms. Falling back to per-key fetching.",
-                _contentOptions.HttpTimeout.TotalMilliseconds);
+            _logger.LogWarning("Content warm-up timed out after {Timeout}ms for application '{Application}' in environment '{Environment}', language '{LanguageKey}'. Falling back to per-key fetching.",
+                _contentOptions.HttpTimeout.TotalMilliseconds, effectiveApplication, _environmentName.Name, languageKey);
         }
         catch (Exception e)
         {
-            _logger.LogError(e, "Content warm-up failed: {Message} Falling back to per-key fetching.", e.Message);
+            _logger.LogError(e, "Content warm-up failed for application '{Application}' in environment '{Environment}', language '{LanguageKey}': {Message} Falling back to per-key fetching.",
+                effectiveApplication, _environmentName.Name, languageKey, e.Message);
+        }
+    }
+
+    /// <summary>
+    /// The error response body, trimmed to one log line, or an empty string when there is nothing
+    /// useful to show. Bounded because the failing response is not always ours — a proxy or gateway
+    /// in front of the server answers with a full HTML page, and that does not belong in a log.
+    /// Never throws: this runs on a path that is already reporting a failure.
+    /// </summary>
+    private static async Task<string> ReadErrorBodyAsync(HttpResponseMessage response, CancellationToken cancellationToken)
+    {
+        const int maxLength = 200;
+        try
+        {
+            var body = await response.Content.ReadAsStringAsync(cancellationToken);
+            if (string.IsNullOrWhiteSpace(body)) return string.Empty;
+
+            // One line: a problem-detail payload is multi-line JSON, and a log entry that wraps is
+            // harder to scan than a truncated one.
+            body = body.ReplaceLineEndings(" ").Trim();
+            if (body.Length > maxLength) body = string.Concat(body.AsSpan(0, maxLength), "…");
+            return $"Body: {body}. ";
+        }
+        catch
+        {
+            return string.Empty;
         }
     }
 


### PR DESCRIPTION
The client half of #155. The server-side fix for the 500 itself lives in Quilt4Net.Server and needs no Toolkit release.

## Problem

Warm-up runs **once per configured language**, but every failure path named neither the application nor the language. FortDocs warmed English and Svenska; English succeeded, Svenska 500'd, and the only client signal was:

```
warn: Content warm-up failed. Response was InternalServerError Internal Server Error. Falling back to per-key fetching.
```

One line that cannot say *which* language lost its warm-up, and no reason beyond the status code — while the success line immediately above it has always named both application and language.

## Changes

- All four non-success paths — 404, non-success status, timeout, exception — now carry **application, environment and language**, matching the success line.
- The non-success path additionally logs the **response body**, so "why did it 500" is answerable from the client log rather than only from the server's. It is bounded: line endings collapsed, trimmed to 200 characters, and the read is wrapped so it can never throw on a path that is already reporting a failure. A proxy or gateway in front of the server answers with a full HTML page, and that does not belong in a log.

## Tests

2 new tests, both verified to fail against `master` before the change: one asserts the failure line names the application and the language key, the other that it reports the response body. Full suite: 513 pass.