### PR TITLE
feat(content): stable ISO code on Language + SelectByCode/SelectByName (#144)

### DIFF
--- a/Quilt4Net.Toolkit.Blazor.Tests/LanguageSelectByCodeTests.cs
+++ b/Quilt4Net.Toolkit.Blazor.Tests/LanguageSelectByCodeTests.cs
@@ -1,0 +1,111 @@
+using FluentAssertions;
+using Quilt4Net.Toolkit.Blazor;
+using Quilt4Net.Toolkit.Features.Content;
+using Xunit;
+
+namespace Quilt4Net.Toolkit.Blazor.Tests;
+
+/// <summary>
+/// #144: a host stores its own language identity as an ISO code and wants the content language to
+/// follow it. Before <see cref="Language.Code"/> it could only match on the display name (which a
+/// rename or localisation breaks) or hardcode the per-tenant <see cref="Language.Key"/> (which does
+/// not survive a move between teams or environments).
+/// </summary>
+public class LanguageSelectByCodeTests
+{
+    private static readonly Language English = new() { Key = Guid.Empty, Name = "English", Code = "en" };
+    private static readonly Language Swedish = new() { Key = Guid.NewGuid(), Name = "Svenska", Code = "sv" };
+    private static readonly Language Uncoded = new() { Key = Guid.NewGuid(), Name = "Klingon" };
+
+    [Fact]
+    public void SelectByCode_selects_the_matching_language()
+    {
+        var sut = State(English, Swedish);
+
+        sut.SelectByCode("sv").Should().BeTrue();
+
+        sut.Selected.Should().Be(Swedish);
+    }
+
+    [Theory]
+    [InlineData("SV")]
+    [InlineData("Sv")]
+    [InlineData(" sv ")]
+    public void SelectByCode_matches_case_insensitively_and_ignores_surrounding_space(string code)
+    {
+        // A host passing a culture string it got from elsewhere should not have to normalise first.
+        var sut = State(English, Swedish);
+
+        sut.SelectByCode(code).Should().BeTrue();
+
+        sut.Selected.Should().Be(Swedish);
+    }
+
+    [Fact]
+    public void A_miss_leaves_the_current_selection_untouched()
+    {
+        // The outcome that matters most: a team simply may not have the language the host asked
+        // for. Swapping the user's language on a miss would be worse than doing nothing.
+        var sut = State(English, Swedish);
+        sut.Selected = Swedish;
+
+        sut.SelectByCode("de").Should().BeFalse();
+
+        sut.Selected.Should().Be(Swedish);
+    }
+
+    [Fact]
+    public void A_language_with_no_code_is_never_matched()
+    {
+        // Null means "the server could not determine one", not "matches anything" — treating it
+        // loosely would reintroduce the guessing the code exists to remove.
+        var sut = State(English, Uncoded);
+
+        sut.SelectByCode("tlh").Should().BeFalse();
+
+        sut.Selected.Should().Be(English);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void An_empty_request_is_a_miss_not_a_crash(string code)
+    {
+        var sut = State(English, Swedish);
+
+        sut.SelectByCode(code).Should().BeFalse();
+        sut.SelectByName(code).Should().BeFalse();
+    }
+
+    [Fact]
+    public void SelectByName_still_works_for_a_host_that_only_has_a_name()
+    {
+        var sut = State(English, Swedish);
+
+        sut.SelectByName("svenska").Should().BeTrue();
+
+        sut.Selected.Should().Be(Swedish);
+    }
+
+    private static ILanguageStateService State(params Language[] languages)
+        => new StubLanguageState { Languages = languages, Selected = languages[0] };
+
+    /// <summary>
+    /// Deliberately implements only the members the default interface methods rely on — which is
+    /// also the proof that a host's own implementation keeps compiling without writing them.
+    /// </summary>
+    private sealed class StubLanguageState : ILanguageStateService
+    {
+        public Language Selected { get; set; }
+        public Language[] Languages { get; set; }
+        public bool DeveloperMode { get; set; }
+        public Task<Language[]> ReloadAsync() => Task.FromResult(Languages);
+
+#pragma warning disable CS0067
+        public event EventHandler<LanguageLoadedEventArgs> LanguageLoadedEvent;
+        public event EventHandler<LanguageChangedEventArgs> LanguageChangedEvent;
+        public event EventHandler<DeveloperModeEventArgs> DeveloperModeEvent;
+#pragma warning restore CS0067
+    }
+}

--- a/Quilt4Net.Toolkit.Blazor/ILanguageStateService.cs
+++ b/Quilt4Net.Toolkit.Blazor/ILanguageStateService.cs
@@ -11,4 +11,59 @@ public interface ILanguageStateService
     Language[] Languages { get; set; }
     bool DeveloperMode { get; set; }
     Task<Language[]> ReloadAsync();
+
+    /// <summary>
+    /// Select the language whose <see cref="Language.Code"/> matches <paramref name="code"/>
+    /// (case-insensitive). Returns <c>false</c> and leaves <see cref="Selected"/> untouched when the
+    /// team has no language with that code.
+    /// </summary>
+    /// <remarks>
+    /// The point of the code (issue #144): a host holding its own language identity — a team's
+    /// working language stored as <c>"sv"</c> — can follow it without matching on a display name or
+    /// hardcoding a per-tenant <see cref="Language.Key"/>. A miss is an ordinary outcome, not an
+    /// error: a team simply may not have the language the host asked for, and the caller decides
+    /// whether to fall back or offer to add it.
+    /// </remarks>
+    /// <remarks>
+    /// A <b>default interface member</b>, so a host with its own <see cref="ILanguageStateService"/>
+    /// keeps compiling — adding an abstract member to a shipped public interface would break every
+    /// implementor, including test stubs, for a convenience method.
+    /// </remarks>
+    bool SelectByCode(string code)
+    {
+        if (string.IsNullOrWhiteSpace(code)) return false;
+
+        // Languages with no code are skipped rather than compared: a null Code means "the server
+        // could not determine one", and matching those on anything would reintroduce the guessing
+        // this field exists to remove.
+        var match = Languages?.FirstOrDefault(x =>
+            !string.IsNullOrWhiteSpace(x?.Code) && string.Equals(x.Code, code.Trim(), StringComparison.OrdinalIgnoreCase));
+
+        if (match == null) return false;
+        Selected = match;
+        return true;
+    }
+
+    /// <summary>
+    /// Select the language whose <see cref="Language.Name"/> matches <paramref name="name"/>
+    /// (case-insensitive). Returns <c>false</c> and leaves <see cref="Selected"/> untouched on a miss.
+    /// </summary>
+    /// <remarks>
+    /// Prefer <see cref="SelectByCode"/>. The display name is what a code exists to stop hosts
+    /// matching on — it can be renamed or localised out from under the caller. This overload is here
+    /// for a host that genuinely has only a name to work from.
+    /// </remarks>
+    bool SelectByName(string name)
+    {
+        if (string.IsNullOrWhiteSpace(name)) return false;
+
+        var match = Languages?.FirstOrDefault(x =>
+            !string.IsNullOrWhiteSpace(x?.Name) && string.Equals(x.Name, name.Trim(), StringComparison.OrdinalIgnoreCase));
+
+        // A miss must leave the current selection alone — swapping the user's language because a
+        // host asked for one the team does not have is worse than doing nothing.
+        if (match == null) return false;
+        Selected = match;
+        return true;
+    }
 }

--- a/Quilt4Net.Toolkit.Blazor/LanguageStateService.cs
+++ b/Quilt4Net.Toolkit.Blazor/LanguageStateService.cs
@@ -164,5 +164,9 @@ internal class LanguageStateService : ILanguageStateService
         });
     }
 
+    // SelectByCode / SelectByName are default interface members on ILanguageStateService — they need
+    // nothing this class has beyond Languages and Selected, so there is one implementation rather
+    // than one per implementor.
+
     public Language[] Languages { get; set; }
 }

--- a/Quilt4Net.Toolkit.Blazor/README.md
+++ b/Quilt4Net.Toolkit.Blazor/README.md
@@ -706,12 +706,40 @@ Inject `ILanguageStateService` to manage language state from code.
 // Get available languages
 var languages = LanguageState.Languages;
 
-// Change language
-LanguageState.Selected = languages.First(l => l.Key == "sv");
+// Change language by ISO code — the recommended way
+LanguageState.SelectByCode("sv");
 
 // Reload languages from server
 await LanguageState.ReloadAsync();
 ```
+
+#### Selecting by ISO code
+
+Each `Language` carries a stable, tenant-independent **`Code`** (ISO-639: `"sv"`, `"en"`, `"es"`), so
+a host that already stores its own language identity can make the content language follow it:
+
+```csharp
+// The team's working language, held by the host as an ISO code
+if (!LanguageState.SelectByCode(team.LanguageCode))
+{
+    // This team has no such language configured — keep the current one, or offer to add it.
+}
+```
+
+Both `SelectByCode(code)` and `SelectByName(name)` match case-insensitively, return `bool`, and
+**leave the current selection untouched on a miss** — a team simply may not have the language asked
+for, and silently swapping the user's language would be worse than doing nothing.
+
+Prefer `Code` over the alternatives:
+
+| Identifier | Why not |
+|---|---|
+| `Name` (`"Svenska"`) | A display string. Spelling, localisation or a rename breaks the match. |
+| `Key` (GUID) | Registered **per team**, so a hardcoded value does not survive a move between tenants or environments. |
+
+`Code` is **nullable — expect nulls.** A server older than this field never sends one, and a language
+whose code could not be determined keeps it `null` rather than being given a guess. `SelectByCode`
+never matches a language with no code.
 
 ### Developer mode
 

--- a/Quilt4Net.Toolkit.Tests/LanguageWireContractTests.cs
+++ b/Quilt4Net.Toolkit.Tests/LanguageWireContractTests.cs
@@ -1,0 +1,71 @@
+using System.Text.Json;
+using FluentAssertions;
+using Quilt4Net.Toolkit.Features.Content;
+using Quilt4Net.Toolkit.Features.FeatureToggle;
+using Xunit;
+
+namespace Quilt4Net.Toolkit.Tests;
+
+/// <summary>
+/// #144 adds <see cref="Language.Code"/> to a wire model that a *server* also serializes, and the
+/// two sides upgrade independently — the Server consumes the Toolkit as a published package, so
+/// there is always a window where one end knows about the field and the other does not.
+/// </summary>
+public class LanguageWireContractTests
+{
+    // Matches how the client reads it: ReadFromJsonAsync uses JsonSerializerDefaults.Web.
+    private static readonly JsonSerializerOptions WebOptions = new(JsonSerializerDefaults.Web);
+
+    [Fact]
+    public void Code_is_read_from_the_language_payload()
+    {
+        var json = """{"key":"e088a31e-c415-4f78-a00b-eb09a77c78d0","name":"Svenska","developer":false,"code":"sv"}""";
+
+        var language = JsonSerializer.Deserialize<Language>(json, WebOptions);
+
+        language.Code.Should().Be("sv");
+        language.Name.Should().Be("Svenska");
+    }
+
+    [Fact]
+    public void A_server_that_does_not_send_a_code_yields_null_rather_than_failing()
+    {
+        // The upgrade window that actually happens: this field ships in the Toolkit first, so every
+        // server predates it until the Server bumps its package reference.
+        var json = """{"key":"00000000-0000-0000-0000-000000000000","name":"English","developer":false}""";
+
+        var language = JsonSerializer.Deserialize<Language>(json, WebOptions);
+
+        language.Should().NotBeNull();
+        language.Code.Should().BeNull();
+    }
+
+    [Fact]
+    public void An_explicit_null_code_is_accepted()
+    {
+        // A server that knows the field but could not determine a code sends null rather than
+        // guessing — that is the documented contract, so it must deserialize as cleanly as absence.
+        var json = """{"key":"00000000-0000-0000-0000-000000000000","name":"English","code":null}""";
+
+        var language = JsonSerializer.Deserialize<Language>(json, WebOptions);
+
+        language.Code.Should().BeNull();
+    }
+
+    [Fact]
+    public void A_full_language_response_round_trips()
+    {
+        var json = """
+            {"languages":[
+              {"key":"00000000-0000-0000-0000-000000000000","name":"English","developer":false,"code":"en"},
+              {"key":"e088a31e-c415-4f78-a00b-eb09a77c78d0","name":"Svenska","developer":false,"code":"sv"},
+              {"key":"24368a7b-a720-4115-8b4e-de1d2dd618cc","name":"Español","developer":false}
+            ],"validTo":"2030-01-01T00:00:00Z"}
+            """;
+
+        var response = JsonSerializer.Deserialize<LanguageResponse>(json, WebOptions);
+
+        response.Languages.Should().HaveCount(3);
+        response.Languages.Select(x => x.Code).Should().Equal("en", "sv", null);
+    }
+}

--- a/Quilt4Net.Toolkit/Features/Content/Language.cs
+++ b/Quilt4Net.Toolkit/Features/Content/Language.cs
@@ -1,4 +1,4 @@
-﻿namespace Quilt4Net.Toolkit.Features.Content;
+namespace Quilt4Net.Toolkit.Features.Content;
 
 public record Language
 {
@@ -8,4 +8,24 @@ public record Language
     public Guid Key { get; set; }
     public string Name { get; set; }
     public bool Developer { get; set; }
+
+    /// <summary>
+    /// Stable ISO-639 code for this language — <c>"sv"</c>, <c>"en"</c>, <c>"es"</c> — or
+    /// <c>null</c> when the server has not been given one.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The identifier a host can map <b>its own</b> language identity onto. <see cref="Key"/> is
+    /// per-tenant, so hardcoding it does not survive a move between teams or environments, and
+    /// <see cref="Name"/> is a display string that spelling, localisation or a rename can change
+    /// underneath a match. Neither is safe to key off; this is (issue #144).
+    /// </para>
+    /// <para>
+    /// <b>Nullable on purpose, and expect nulls.</b> A server older than this field never sends one,
+    /// and a language whose code could not be determined keeps it null rather than being given a
+    /// guess — a wrong code silently routes a host to the wrong language, which is the exact bug
+    /// this field exists to prevent. Treat null as "cannot be matched by code", not as an error.
+    /// </para>
+    /// </remarks>
+    public string Code { get; set; }
 }


### PR DESCRIPTION
Part 1 of #144 — the **wire contract and client DX**. The Server populates `Code` once it takes this release (it consumes the Toolkit as a published package, so the contract has to ship first — same two-PR sequence as #135).

## Problem

A host cannot map *its own* language identity onto a Quilt4Net content language. `Language` exposed only a per-tenant `Key` (GUID) and a display `Name`, so a host had to either match on the display name — brittle to spelling, localisation and renames — or hardcode the GUID, which does not survive a move between teams or environments.

## Changes

- **`Language.Code`** — nullable ISO-639 code (`"sv"`, `"en"`, `"es"`).

  Nullable **on purpose**, and callers must expect nulls: a server older than this field never sends one, and a language whose code cannot be determined keeps `null` rather than being handed a guess. A wrong code silently routes a host to the wrong language, which is precisely the bug this field exists to prevent — so "unknown" has to be representable.

- **`SelectByCode(code)` / `SelectByName(name)`** on `ILanguageStateService`, both **default interface members**. Adding abstract members to a shipped public interface would break every implementor — including hosts' own stubs — for what is a convenience method; the same reason `IsConfigured` is a default member on `IUserDirectoryService`. Case-insensitive, trim-tolerant, return `bool`, and **leave the current selection untouched on a miss**: a team simply may not have the language asked for, and silently swapping the user's language would be worse than doing nothing. A language with no `Code` is never matched.

- **README** — the existing language-state example did not merely omit this, it **could not compile**: it compared the `Guid` `Key` against the string `"sv"`. That is the exact confusion this issue reports, sitting in our own docs. Rewritten around `Code`, with a table on why `Name` and `Key` are the wrong things to key off.

## Tests

14 new. `SelectByCode` matching (case, whitespace, miss-leaves-selection, never matches a null code, empty input is a miss not a crash), and wire-contract tests for the upgrade window that will actually happen — a server that omits `code`, and one that sends an explicit `null`. The test stub implements only `Languages`/`Selected`, which doubles as proof that a host's own implementation keeps compiling.

Full suite: 527 pass.

## Not in this PR

The session extension — a client asking for **any** ISO code, with the server creating the language and starting background translation under a server-side setting — is Part B. It needs the server endpoint, so it follows the Server PR. Scoped in `plan/`, including the guardrails: creating a language fans out one metered AI call per existing key (~1,268 for FortDocs), so ISO validation, a per-team cap and a default-off setting are part of that feature rather than a follow-up.