### PR TITLE
fix(content): "Reload Content" in ContentAdmin re-warms instead of only flushing

### DIFF
--- a/Quilt4Net.Toolkit.Blazor.Tests/ContentWarmupTests.cs
+++ b/Quilt4Net.Toolkit.Blazor.Tests/ContentWarmupTests.cs
@@ -84,6 +84,40 @@ public class ContentWarmupTests
         call.Calls.Should().NotContain(Guid.Empty, "the default language is warmed at startup, not by the selector");
     }
 
+    [Fact]
+    public async Task Reload_content_clears_the_cache_and_then_re_warms_the_configured_languages()
+    {
+        // The re-warm is the whole point of "Reload Content": nothing else refills the singleton
+        // cache after a clear (the hosted service only runs at startup), so without it the button is
+        // a flush and content trickles back one key at a time as pages render.
+        var call = new RecordingRemoteCallService();
+        var state = NewLanguageState(call);
+
+        await ContentReloader.ReloadAsync(state, new DelegatingContentService(call), call);
+
+        call.Events.Should().ContainInOrder("clear", $"warm:{Guid.Empty}");
+    }
+
+    [Fact]
+    public async Task Reload_content_survives_a_failing_warm_up()
+    {
+        // Best-effort: the forced page reload must still happen, falling back to per-key fetching.
+        var call = new ThrowingRemoteCallService();
+        var state = NewLanguageState(call);
+
+        var act = async () => await ContentReloader.ReloadAsync(state, new DelegatingContentService(call), call);
+
+        await act.Should().NotThrowAsync();
+        call.Events.Should().Contain("clear");
+    }
+
+    private static LanguageStateService NewLanguageState(IRemoteContentCallService call)
+    {
+        var languages = new[] { new Language { Key = Guid.Empty, Name = "Default" } };
+        return new LanguageStateService(new FakeLanguageService(languages), new NoopLocalStorage(), call,
+            NullLogger<LanguageStateService>.Instance);
+    }
+
     private static async Task<bool> WaitUntil(Func<bool> condition, int timeoutMs = 2000)
     {
         var deadline = Environment.TickCount64 + timeoutMs;
@@ -99,9 +133,13 @@ public class ContentWarmupTests
     {
         public ConcurrentBag<Guid> Calls { get; } = [];
 
+        /// <summary>Ordered log — Calls is a bag, and "clear before warm" is an ordering claim.</summary>
+        public ConcurrentQueue<string> Events { get; } = new();
+
         public Task WarmCacheAsync(Guid languageKey, string application = null)
         {
             Calls.Add(languageKey);
+            Events.Enqueue($"warm:{languageKey}");
             return Task.CompletedTask;
         }
 
@@ -114,13 +152,30 @@ public class ContentWarmupTests
             => Task.FromResult(new ContentResult { Value = defaultValue, Success = true, Source = ContentSource.Default, Stale = false });
         public Task SetContentAsync(string key, string defaultValue, Guid languageKey, ContentFormat contentType, string application = null) => Task.CompletedTask;
         public Task<Language[]> GetLanguagesAsync(bool forceReload) => Task.FromResult(Array.Empty<Language>());
-        public Task ClearContentCacheAsync() => Task.CompletedTask;
+
+        public Task ClearContentCacheAsync()
+        {
+            Events.Enqueue("clear");
+            return Task.CompletedTask;
+        }
+
         public IReadOnlyDictionary<Guid, int> GetCacheCountsByLanguage() => new Dictionary<Guid, int>();
     }
 
     private sealed class ThrowingRemoteCallService : RecordingRemoteCallService
     {
         public override Task WarmConfiguredLanguagesAsync(string application = null) => throw new HttpRequestException("server unreachable");
+    }
+
+    // The real ContentService is a thin pass-through to the call service, so the reload sequence can
+    // be observed on one recorder.
+    private sealed class DelegatingContentService(IRemoteContentCallService remote) : IContentService
+    {
+        public Task<(string Value, bool Success)> GetContentAsync(string key, string defaultValue, Guid languageKey, ContentFormat? contentType, string application = null, IReadOnlyDictionary<string, string> translations = null)
+            => remote.GetContentAsync(key, defaultValue, languageKey, contentType, application, translations);
+        public Task SetContentAsync(string key, string value, Guid languageKey, ContentFormat contentType, string application = null)
+            => remote.SetContentAsync(key, value, languageKey, contentType, application);
+        public Task ClearCacheAsync() => remote.ClearContentCacheAsync();
     }
 
     private sealed class RecordingConnectionService : IConnectionService

--- a/Quilt4Net.Toolkit.Blazor/ContentReloader.cs
+++ b/Quilt4Net.Toolkit.Blazor/ContentReloader.cs
@@ -1,0 +1,36 @@
+using Quilt4Net.Toolkit.Features.Content;
+
+namespace Quilt4Net.Toolkit.Blazor;
+
+/// <summary>
+/// The admin "Reload Content" sequence, shared by <c>LanguageSelector</c> and <c>ContentAdmin</c>:
+/// reload the language list, flush the content cache, then re-warm the configured languages. The
+/// caller forces the page reload afterwards.
+/// </summary>
+/// <remarks>
+/// The re-warm is what makes this a hot-load rather than a cache flush — the cache lives in the
+/// singleton <see cref="IRemoteContentCallService"/> and the startup
+/// <see cref="ContentWarmupHostedService"/> only runs once per process, so nothing refills it after
+/// a clear. Without the re-warm the cleared cache repopulates lazily, one key at a time, as pages
+/// render. Both entry points go through here so they cannot drift apart again.
+/// </remarks>
+internal static class ContentReloader
+{
+    public static async Task ReloadAsync(ILanguageStateService languageStateService, IContentService contentService, IRemoteContentCallService remoteContentCallService)
+    {
+        await languageStateService.ReloadAsync();
+        await contentService.ClearCacheAsync();
+
+        // Re-warm before the caller's forced reload so the new circuit renders from a warm cache (the
+        // singleton cache persists across circuits). Best-effort — a warm failure must not block the
+        // reload.
+        try
+        {
+            await remoteContentCallService.WarmConfiguredLanguagesAsync();
+        }
+        catch
+        {
+            // Ignored: the per-key path still serves content on the reload.
+        }
+    }
+}

--- a/Quilt4Net.Toolkit.Blazor/Features/Language/ContentAdmin.razor
+++ b/Quilt4Net.Toolkit.Blazor/Features/Language/ContentAdmin.razor
@@ -85,8 +85,7 @@
 
     private async Task ReloadContent()
     {
-        await LanguageStateService.ReloadAsync();
-        await ContentService.ClearCacheAsync();
+        await ContentReloader.ReloadAsync(LanguageStateService, ContentService, RemoteContentCallService);
         NavigationManager.NavigateTo(NavigationManager.Uri, true);
     }
 }

--- a/Quilt4Net.Toolkit.Blazor/Features/Language/LanguageSelector.razor
+++ b/Quilt4Net.Toolkit.Blazor/Features/Language/LanguageSelector.razor
@@ -55,18 +55,7 @@
 
     private async Task ReloadContent()
     {
-        await LanguageStateService.ReloadAsync();
-        await ContentService.ClearCacheAsync();
-        // Re-warm before the forced reload so the new circuit renders from a warm cache (the singleton
-        // cache persists across circuits). Best-effort — a warm failure must not block the reload.
-        try
-        {
-            await RemoteContentCallService.WarmConfiguredLanguagesAsync();
-        }
-        catch
-        {
-            // Ignored: the per-key path still serves content on the reload.
-        }
+        await ContentReloader.ReloadAsync(LanguageStateService, ContentService, RemoteContentCallService);
         NavigationManager.NavigateTo(NavigationManager.Uri, true);
     }
 }

--- a/Quilt4Net.Toolkit.Blazor/README.md
+++ b/Quilt4Net.Toolkit.Blazor/README.md
@@ -639,8 +639,8 @@ the cache with a **single bulk call per language**, so the first render serves w
 - List **additional languages** to warm at startup — by name — via `ContentOptions.WarmUpLanguages`.
   Without this, non-default languages warm lazily on first selection, so the first render in that
   language pays a per-key fan-out.
-- **Reload Content** (in `LanguageSelector`, admin) clears the cache and then **re-warms** the same
-  set — a true hot-load, not just a flush.
+- **Reload Content** (in `LanguageSelector` and `ContentAdmin`, admin) clears the cache and then
+  **re-warms** the same set — a true hot-load, not just a flush.
 - Best-effort: against a server without the bulk endpoint, or on any failure, it falls back to lazy
   per-key fetching.
 

--- a/docs/articles/content-components.md
+++ b/docs/articles/content-components.md
@@ -327,8 +327,8 @@ builder.AddQuilt4NetBlazorContent(o =>
 
 Each named language is resolved against the server's language list and warmed with its own bulk
 call; a name with no match is skipped with a `Warning`. The default language is always warmed
-regardless. The admin **Reload Content** action (in `LanguageSelector`) clears the cache and then
-re-warms this same set, so it is a true hot-load rather than just a cache flush.
+regardless. The admin **Reload Content** action (in `LanguageSelector` and `ContentAdmin`) clears
+the cache and then re-warms this same set, so it is a true hot-load rather than just a cache flush.
 
 Disable warm-up entirely to rely purely on lazy per-key loading:
 


### PR DESCRIPTION
## Problem

The **Reload Content** button in `ContentAdmin` cleared the content cache and forced a page reload, but never re-warmed:

```csharp
await LanguageStateService.ReloadAsync();
await ContentService.ClearCacheAsync();
NavigationManager.NavigateTo(NavigationManager.Uri, true);
```

The cache lives in the singleton `RemoteContentCallService`, and `ContentWarmupHostedService` only runs once per process at startup — so nothing refilled it after the clear. Content trickled back one key at a time via the lazy per-key path as pages rendered, rather than hot-loading in bulk.

The equivalent menu item in `LanguageSelector` *did* call `WarmConfiguredLanguagesAsync`. The two had drifted apart, and the documented behaviour ("a true hot-load, not just a flush") only held for one of them.

## Change

Extracted the sequence — reload languages → clear cache → re-warm configured languages — into `ContentReloader`, and routed both entry points through it so they cannot desync again. `ContentAdmin` already injected `IRemoteContentCallService` for its per-language cache counts, so no wiring changed.

Docs in `Quilt4Net.Toolkit.Blazor/README.md` and `docs/articles/content-components.md` now name `ContentAdmin` alongside `LanguageSelector`.

## Tests

Two added to `ContentWarmupTests`: the reload clears *then* re-warms, in that order; and a failing warm-up still lets the reload through (best-effort, falls back to per-key fetching).

Full Blazor suite: 187 passed, 0 failed.

## Known gaps, unchanged by this PR

- A non-default **selected** language is still not re-warmed by the button unless listed in `ContentOptions.WarmUpLanguages` — `WarmConfiguredLanguagesAsync` warms the default plus configured names only. After the forced reload the new circuit's `LanguageStateService` re-warms the restored selection fire-and-forget, racing the first render.
- `WarmUpEnabled = false` does not suppress the button's warm-up. This was `LanguageSelector`'s existing behaviour and is preserved — arguably correct for an explicit admin action, but it is an inconsistency.
