### PR TITLE
Scope columns + environment filter on RemoteConfigurationAdmin

### DIFF
--- a/Quilt4Net.Toolkit.Blazor.Tests/ConfigurationScopeTests.cs
+++ b/Quilt4Net.Toolkit.Blazor.Tests/ConfigurationScopeTests.cs
@@ -1,0 +1,144 @@
+using FluentAssertions;
+using Quilt4Net.Toolkit.Blazor.Features.Configuration;
+using Quilt4Net.Toolkit.Features.FeatureToggle;
+using Xunit;
+
+namespace Quilt4Net.Toolkit.Blazor.Tests;
+
+/// <summary>
+/// The admin grid lists every configuration entry the team's API key can read, so the same key
+/// appears once per application × environment × instance. These are the rules that make those rows
+/// distinguishable — and, critically, that stop the environment filter from hiding the shared
+/// entries that apply everywhere.
+/// </summary>
+public class ConfigurationScopeTests
+{
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    public void A_shared_scope_value_renders_as_an_explicit_marker_not_a_blank(string value)
+    {
+        // Application/Environment/Instance are declared `required string` but a shared entry
+        // legitimately arrives null. A blank cell reads as missing data rather than "applies to all".
+        ConfigurationScope.Label(value).Should().Be("(all)");
+    }
+
+    [Fact]
+    public void A_scoped_value_renders_as_itself()
+    {
+        ConfigurationScope.Label("Production").Should().Be("Production");
+    }
+
+    [Fact]
+    public void Available_environments_are_distinct_sorted_and_exclude_the_shared_ones()
+    {
+        var entries = new[]
+        {
+            Entry(environment: "Production"),
+            Entry(environment: "Development"),
+            Entry(environment: "production"),
+            Entry(environment: null),
+            Entry(environment: ""),
+        };
+
+        ConfigurationScope.AvailableEnvironments(entries)
+            .Should().Equal("Development", "Production");
+    }
+
+    [Fact]
+    public void The_default_selection_is_the_host_environment()
+    {
+        ConfigurationScope.DefaultEnvironment(["Development", "Production"], "Production")
+            .Should().Be("Production");
+    }
+
+    [Fact]
+    public void The_default_selection_matches_the_host_environment_case_insensitively()
+    {
+        ConfigurationScope.DefaultEnvironment(["Development", "Production"], "PRODUCTION")
+            .Should().Be("Production");
+    }
+
+    [Fact]
+    public void No_entries_for_the_host_environment_means_no_filter_rather_than_an_arbitrary_one()
+    {
+        // LogEnvironmentSelector falls back to the first option, but that view is read-only. Picking
+        // an arbitrary environment here would hide configuration the operator can edit — the exact
+        // failure this grid exists to fix.
+        ConfigurationScope.DefaultEnvironment(["Development", "Production"], "Staging")
+            .Should().BeNull();
+    }
+
+    [Fact]
+    public void No_host_environment_at_all_means_no_filter()
+    {
+        // A Blazor WebAssembly host has no IHostEnvironment to resolve.
+        ConfigurationScope.DefaultEnvironment(["Development"], null).Should().BeNull();
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    public void No_selection_matches_everything(string selected)
+    {
+        ConfigurationScope.MatchesEnvironment("Production", selected).Should().BeTrue();
+        ConfigurationScope.MatchesEnvironment(null, selected).Should().BeTrue();
+    }
+
+    [Fact]
+    public void A_selection_keeps_its_own_environment_and_drops_the_others()
+    {
+        ConfigurationScope.MatchesEnvironment("Production", "Production").Should().BeTrue();
+        ConfigurationScope.MatchesEnvironment("Development", "Production").Should().BeFalse();
+    }
+
+    [Fact]
+    public void Environment_matching_is_case_insensitive()
+    {
+        ConfigurationScope.MatchesEnvironment("production", "Production").Should().BeTrue();
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    public void A_shared_entry_survives_every_environment_filter(string entryEnvironment)
+    {
+        // The whole complaint is that scope was invisible. A filter that also hid the entries
+        // applying to *every* environment would conceal more than the missing columns ever did.
+        ConfigurationScope.MatchesEnvironment(entryEnvironment, "Production").Should().BeTrue();
+    }
+
+    [Fact]
+    public void The_instance_column_stays_hidden_when_nothing_carries_an_instance()
+    {
+        // Instance is a level slated for removal, so it earns no permanent column.
+        var entries = new[] { Entry(instance: null), Entry(instance: "") };
+
+        ConfigurationScope.ShowInstance(entries).Should().BeFalse();
+    }
+
+    [Fact]
+    public void The_instance_column_appears_as_soon_as_one_entry_carries_an_instance()
+    {
+        // Otherwise two entries differing only by instance are indistinguishable again.
+        var entries = new[] { Entry(instance: null), Entry(instance: "worker-1") };
+
+        ConfigurationScope.ShowInstance(entries).Should().BeTrue();
+    }
+
+    private static ConfigurationResponse Entry(string environment = null, string instance = null)
+    {
+        return new ConfigurationResponse
+        {
+            Key = "SomeKey",
+            Application = null,
+            Environment = environment,
+            Instance = instance,
+            Value = "true",
+            DefaultValue = "true",
+            ValueType = "Boolean",
+            LastUsed = null,
+            Ttl = null,
+        };
+    }
+}

--- a/Quilt4Net.Toolkit.Blazor.Tests/RemoteConfigurationAdminScopeTests.cs
+++ b/Quilt4Net.Toolkit.Blazor.Tests/RemoteConfigurationAdminScopeTests.cs
@@ -1,0 +1,199 @@
+using Bunit;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Quilt4Net.Toolkit.Blazor.Features.Configuration;
+using Quilt4Net.Toolkit.Features.FeatureToggle;
+using Quilt4Net.Toolkit.Framework;
+using Radzen;
+using Xunit;
+
+namespace Quilt4Net.Toolkit.Blazor.Tests;
+
+/// <summary>
+/// <c>RemoteConfigurationAdmin</c> rendered only Key, Value, Default, Ttl and LastUsed, while
+/// <c>GetAllAsync</c> deliberately returns every entry the team key can read. One key therefore
+/// appeared once per application × environment × instance as apparent duplicate rows, with nothing
+/// on screen saying which scope each was — and the row's own edit/reset/delete passed
+/// <c>context.Application/Environment/Instance</c>, so the operator acted on a scope the UI never
+/// showed them.
+/// </summary>
+public class RemoteConfigurationAdminScopeTests : BunitContext
+{
+    private readonly StubConfigurationService _configuration = new();
+
+    public RemoteConfigurationAdminScopeTests()
+    {
+        JSInterop.Mode = JSRuntimeMode.Loose;
+        Services.AddSingleton<IRemoteConfigurationService>(_configuration);
+        Services.AddSingleton<IConnectionService>(new ConnectedService());
+        // RadzenDataGrid and the ActionButton in the delete column property-inject Radzen's
+        // DialogService / NotificationService / TooltipService — register the family rather than
+        // chase them one at a time.
+        Services.AddRadzenComponents();
+    }
+
+    [Fact]
+    public void The_grid_names_the_scope_of_every_row()
+    {
+        _configuration.Entries =
+        [
+            Entry("Feature.A", application: "Quilt4Net.Server", environment: "Production"),
+        ];
+
+        var cut = RenderAdmin("Production");
+
+        var headers = cut.FindAll("th").Select(x => x.TextContent).ToArray();
+        headers.Should().Contain(x => x.Contains("Application"));
+        headers.Should().Contain(x => x.Contains("Environment"));
+
+        cut.Markup.Should().Contain("Quilt4Net.Server");
+    }
+
+    [Fact]
+    public void A_shared_entry_is_labelled_rather_than_left_blank()
+    {
+        _configuration.Entries = [Entry("Feature.Shared", application: null, environment: null)];
+
+        var cut = RenderAdmin("Production");
+
+        cut.Markup.Should().Contain("(all)");
+    }
+
+    [Fact]
+    public void The_environment_filter_defaults_to_the_host_environment()
+    {
+        _configuration.Entries =
+        [
+            Entry("Feature.A", environment: "Production"),
+            Entry("Feature.B", environment: "Development"),
+        ];
+
+        var cut = RenderAdmin("Production");
+
+        cut.Markup.Should().Contain("Feature.A");
+        cut.Markup.Should().NotContain("Feature.B");
+    }
+
+    [Fact]
+    public void The_filter_never_hides_a_shared_entry()
+    {
+        // The failure this guards: a shared entry has no environment, so a naive equality filter
+        // drops it and the operator loses configuration that applies to the environment they picked.
+        _configuration.Entries =
+        [
+            Entry("Feature.Scoped", environment: "Production"),
+            Entry("Feature.Shared", environment: null),
+        ];
+
+        var cut = RenderAdmin("Production");
+
+        cut.Markup.Should().Contain("Feature.Shared");
+    }
+
+    [Fact]
+    public void An_unrepresented_host_environment_shows_everything_instead_of_an_arbitrary_slice()
+    {
+        _configuration.Entries =
+        [
+            Entry("Feature.A", environment: "Production"),
+            Entry("Feature.B", environment: "Development"),
+        ];
+
+        var cut = RenderAdmin("Staging");
+
+        cut.Markup.Should().Contain("Feature.A");
+        cut.Markup.Should().Contain("Feature.B");
+    }
+
+    [Fact]
+    public void There_is_no_environment_filter_when_every_entry_is_shared()
+    {
+        _configuration.Entries = [Entry("Feature.Shared", environment: null)];
+
+        var cut = RenderAdmin("Production");
+
+        cut.FindAll(".rz-dropdown").Should().BeEmpty();
+    }
+
+    [Fact]
+    public void The_instance_column_is_absent_until_an_entry_carries_an_instance()
+    {
+        _configuration.Entries = [Entry("Feature.A", environment: "Production")];
+
+        var cut = RenderAdmin("Production");
+
+        cut.FindAll("th").Select(x => x.TextContent).Should().NotContain(x => x.Contains("Instance"));
+    }
+
+    [Fact]
+    public void The_instance_column_appears_when_an_entry_carries_an_instance()
+    {
+        _configuration.Entries =
+        [
+            Entry("Feature.A", environment: "Production", instance: "worker-1"),
+        ];
+
+        var cut = RenderAdmin("Production");
+
+        cut.FindAll("th").Select(x => x.TextContent).Should().Contain(x => x.Contains("Instance"));
+        cut.Markup.Should().Contain("worker-1");
+    }
+
+    private IRenderedComponent<RemoteConfigurationAdmin> RenderAdmin(string hostEnvironment)
+    {
+        Services.AddSingleton<IHostEnvironment>(new StubHostEnvironment { EnvironmentName = hostEnvironment });
+
+        return Render<RemoteConfigurationAdmin>();
+    }
+
+    private static ConfigurationResponse Entry(string key, string application = null, string environment = null, string instance = null)
+    {
+        return new ConfigurationResponse
+        {
+            Key = key,
+            Application = application,
+            Environment = environment,
+            Instance = instance,
+            Value = "true",
+            DefaultValue = "true",
+            ValueType = "Boolean",
+            LastUsed = null,
+            Ttl = null,
+        };
+    }
+
+    private sealed class StubConfigurationService : IRemoteConfigurationService
+    {
+        public ConfigurationResponse[] Entries { get; set; } = [];
+
+        public Task<ConfigurationResponse[]> GetAsync() => Task.FromResult(Entries);
+
+        public ValueTask<T> GetAsync<T>(string key, T fallback = default, TimeSpan? ttl = null, string application = "") => new(fallback);
+        public ValueTask<bool> GetToggleAsync(string key, bool fallback = default, TimeSpan? ttl = null, string application = "") => new(fallback);
+        public Task DeleteAsync(string key, string application, string environment, string instance) => Task.CompletedTask;
+        public Task SetAsync(string key, string application, string environment, string instance, string value) => Task.CompletedTask;
+    }
+
+    /// <summary>A probe that has already succeeded, so <c>ConnectionWrapper</c> renders its child.</summary>
+    private sealed class ConnectedService : IConnectionService
+    {
+        public Task<ConnectionResult> CanConnectAsync(Service service)
+        {
+            return Task.FromResult(new ConnectionResult
+            {
+                Success = true,
+                Address = new Uri("https://quilt4net.com"),
+                Capabilities = new WhoAmIResponse { Scopes = ["config:write"] },
+            });
+        }
+    }
+
+    private sealed class StubHostEnvironment : IHostEnvironment
+    {
+        public string EnvironmentName { get; set; }
+        public string ApplicationName { get; set; } = "Tests";
+        public string ContentRootPath { get; set; } = string.Empty;
+        public Microsoft.Extensions.FileProviders.IFileProvider ContentRootFileProvider { get; set; }
+    }
+}

--- a/Quilt4Net.Toolkit.Blazor/Features/Configuration/ConfigurationScope.cs
+++ b/Quilt4Net.Toolkit.Blazor/Features/Configuration/ConfigurationScope.cs
@@ -1,0 +1,98 @@
+using Quilt4Net.Toolkit.Features.FeatureToggle;
+
+namespace Quilt4Net.Toolkit.Blazor.Features.Configuration;
+
+/// <summary>
+/// Scope presentation and filtering for <c>RemoteConfigurationAdmin</c>.
+/// <para>
+/// A configuration entry is scoped by application, environment and instance, and the admin grid lists
+/// every entry the team's API key can read — so the same key legitimately appears once per
+/// application × environment × instance. Without the scope on screen those read as duplicate rows,
+/// while the row's own edit/reset/delete act on a scope the operator was never shown.
+/// </para>
+/// <para>
+/// <see cref="ConfigurationResponse"/> declares <c>Application</c>, <c>Environment</c> and
+/// <c>Instance</c> as <c>required string</c>, but a <b>shared</b> entry legitimately arrives with them
+/// null — which is why <c>RemoteConfigCallService.GetAllAsync</c> does no filtering of its own. Every
+/// member here treats null and empty alike.
+/// </para>
+/// </summary>
+internal static class ConfigurationScope
+{
+    /// <summary>
+    /// Shown in place of a null/empty application or environment, so a shared entry reads as
+    /// deliberately unscoped rather than as a blank cell.
+    /// </summary>
+    public const string SharedLabel = "(all)";
+
+    /// <summary>Label for the dropdown option that applies no environment filter.</summary>
+    public const string AllEnvironmentsLabel = "All environments";
+
+    /// <summary>Renders a scope value for display, marking the shared case explicitly.</summary>
+    public static string Label(string value) => string.IsNullOrEmpty(value) ? SharedLabel : value;
+
+    /// <summary>
+    /// The environments available to filter on, in display order — every distinct environment present
+    /// in <paramref name="entries"/>. Shared entries contribute nothing: they are not an environment,
+    /// and they are never filtered out (see <see cref="MatchesEnvironment"/>).
+    /// </summary>
+    public static string[] AvailableEnvironments(IEnumerable<ConfigurationResponse> entries)
+    {
+        return entries
+            .Select(x => x.Environment)
+            .Where(x => !string.IsNullOrEmpty(x))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .OrderBy(x => x, StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+    }
+
+    /// <summary>
+    /// The environment to select on first load: the host's own environment when it has entries,
+    /// otherwise no filter at all.
+    /// </summary>
+    /// <remarks>
+    /// <c>LogEnvironmentSelector</c> falls back to the first available option, but that view is
+    /// read-only. Here an arbitrary first-option default would hide configuration the operator can
+    /// edit — the precise failure this grid exists to fix — so the fallback is "show everything".
+    /// </remarks>
+    public static string DefaultEnvironment(IEnumerable<string> available, string hostEnvironment)
+    {
+        if (string.IsNullOrEmpty(hostEnvironment)) return null;
+
+        return available.FirstOrDefault(x => string.Equals(x, hostEnvironment, StringComparison.OrdinalIgnoreCase));
+    }
+
+    /// <summary>
+    /// Whether an entry survives the environment filter.
+    /// </summary>
+    /// <param name="entryEnvironment">The entry's environment; null/empty means shared.</param>
+    /// <param name="selectedEnvironment">The selected environment; null means no filter.</param>
+    /// <remarks>
+    /// A shared entry applies to <i>every</i> environment, so it always passes. Filtering it out would
+    /// make the filter conceal more configuration than the missing columns ever did.
+    /// </remarks>
+    public static bool MatchesEnvironment(string entryEnvironment, string selectedEnvironment)
+    {
+        if (string.IsNullOrEmpty(selectedEnvironment)) return true;
+        if (string.IsNullOrEmpty(entryEnvironment)) return true;
+
+        return string.Equals(entryEnvironment, selectedEnvironment, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// Whether the Instance column is worth rendering — true when any entry carries an instance.
+    /// </summary>
+    /// <remarks>
+    /// Instance is a level slated for removal (<c>configuration-content-ui-spec.md</c>; the Server's
+    /// own grid already has it commented out), so it gets no permanent column. It must still be
+    /// visible when set, or two entries differing only by instance are indistinguishable again.
+    /// <para>
+    /// Computed over the full loaded set rather than the filtered rows, so the column does not appear
+    /// and vanish as the operator changes the filter.
+    /// </para>
+    /// </remarks>
+    public static bool ShowInstance(IEnumerable<ConfigurationResponse> entries)
+    {
+        return entries.Any(x => !string.IsNullOrEmpty(x.Instance));
+    }
+}

--- a/Quilt4Net.Toolkit.Blazor/Features/Configuration/RemoteConfigurationAdmin.razor
+++ b/Quilt4Net.Toolkit.Blazor/Features/Configuration/RemoteConfigurationAdmin.razor
@@ -1,8 +1,11 @@
-﻿@using Microsoft.Extensions.Logging
+﻿@using Microsoft.Extensions.DependencyInjection
+@using Microsoft.Extensions.Hosting
+@using Microsoft.Extensions.Logging
 @using Quilt4Net.Toolkit.Blazor.Framework
 @using Quilt4Net.Toolkit.Features.FeatureToggle
 @using Quilt4Net.Toolkit.Framework
 @inject IRemoteConfigurationService RemoteConfigurationService
+@inject IServiceProvider ServiceProvider
 @inject DialogService DialogService
 @inject ILogger<RemoteConfigurationAdmin> Logger
 
@@ -13,9 +16,43 @@
     }
     else
     {
-        <RadzenDataGrid Data="@_model" TItem="ConfigurationResponse">
+        @if (_environments.Length > 0)
+        {
+            <RadzenRow Style="margin-bottom: 1rem;">
+                <RadzenColumn Size="4">
+                    <RadzenText Text="Environment" TextStyle="TextStyle.Caption"/>
+                    <div title="Entries shared across every environment are always listed, whichever environment is selected.">
+                        <RadzenDropDown Data="@_environments"
+                                        TValue="string"
+                                        @bind-Value="_selectedEnvironment"
+                                        AllowClear="true"
+                                        Placeholder="@ConfigurationScope.AllEnvironmentsLabel"
+                                        Change="@(_ => ApplyFilter())"/>
+                    </div>
+                </RadzenColumn>
+            </RadzenRow>
+        }
+        <RadzenDataGrid Data="@_filtered" TItem="ConfigurationResponse">
             <Columns>
                 <RadzenDataGridColumn Title="Key" Property="@nameof(ConfigurationResponse.Key)"/>
+                <RadzenDataGridColumn Title="Application" Property="@nameof(ConfigurationResponse.Application)">
+                    <Template>
+                        @ConfigurationScope.Label(context.Application)
+                    </Template>
+                </RadzenDataGridColumn>
+                <RadzenDataGridColumn Title="Environment" Property="@nameof(ConfigurationResponse.Environment)">
+                    <Template>
+                        @ConfigurationScope.Label(context.Environment)
+                    </Template>
+                </RadzenDataGridColumn>
+                @if (_showInstance)
+                {
+                    <RadzenDataGridColumn Title="Instance" Property="@nameof(ConfigurationResponse.Instance)">
+                        <Template>
+                            @ConfigurationScope.Label(context.Instance)
+                        </Template>
+                    </RadzenDataGridColumn>
+                }
                 <RadzenDataGridColumn Title="Value" Property="@nameof(ConfigurationResponse.Value)">
                     <Template>
                         @if (_canWrite)
@@ -80,6 +117,12 @@
 
 @code {
     private ConfigurationResponse[] _model;
+    private ConfigurationResponse[] _filtered = [];
+    private string[] _environments = [];
+    private string _selectedEnvironment;
+    private bool _environmentDefaulted;
+    private bool _showInstance;
+    private string _hostEnvironmentName;
     private bool _canWrite;
 
     [CascadingParameter]
@@ -87,6 +130,15 @@
 
     [Parameter]
     public bool TogglesOnly { get; set; }
+
+    protected override void OnInitialized()
+    {
+        // Resolved rather than @inject'ed. A Blazor WebAssembly host has no IHostEnvironment at all,
+        // and an @inject on an unregistered service fails at *render* time — the same trap the
+        // toolkit's own EnvironmentName record carries (it is built inline in each registration
+        // factory, never registered). No host environment simply means no default filter.
+        _hostEnvironmentName = ServiceProvider.GetService<IHostEnvironment>()?.EnvironmentName;
+    }
 
     protected override async Task OnParametersSetAsync()
     {
@@ -108,6 +160,29 @@
     {
         var model = await RemoteConfigurationService.GetAsync();
         _model = model.Where(x => !TogglesOnly || x.ValueType == "Boolean").ToArray();
+        _environments = ConfigurationScope.AvailableEnvironments(_model);
+        _showInstance = ConfigurationScope.ShowInstance(_model);
+
+        if (!_environmentDefaulted)
+        {
+            _environmentDefaulted = true;
+            _selectedEnvironment = ConfigurationScope.DefaultEnvironment(_environments, _hostEnvironmentName);
+        }
+        else if (_selectedEnvironment != null && !_environments.Contains(_selectedEnvironment, StringComparer.OrdinalIgnoreCase))
+        {
+            // The selected environment's last entry was just deleted, so the dropdown no longer offers
+            // it. Keeping it selected would leave an empty grid filtered by an invisible criterion.
+            _selectedEnvironment = null;
+        }
+
+        ApplyFilter();
+    }
+
+    private void ApplyFilter()
+    {
+        _filtered = _model
+            .Where(x => ConfigurationScope.MatchesEnvironment(x.Environment, _selectedEnvironment))
+            .ToArray();
         StateHasChanged();
     }
 

--- a/Quilt4Net.Toolkit.Blazor/README.md
+++ b/Quilt4Net.Toolkit.Blazor/README.md
@@ -775,6 +775,27 @@ Set `TogglesOnly="true"` to show only boolean toggles.
 
 The component displays a data grid with editors for boolean, integer, and string values. Changes are saved to [Quilt4Net Web](https://quilt4net.com).
 
+### Scope columns and the environment filter
+
+A configuration entry is scoped by **application**, **environment** and **instance**, and the grid lists every entry the team's API key can read — so the same key legitimately appears once per application × environment × instance. Those three are shown as their own columns, sortable like the rest:
+
+| Column | Shown |
+|---|---|
+| Application | Always |
+| Environment | Always |
+| Instance | Only when at least one loaded entry carries an instance |
+
+An entry that applies everywhere is stored with no application or environment, and renders as **`(all)`** rather than an empty cell — a blank reads as missing data rather than as a deliberate "not scoped".
+
+Above the grid, an **environment** dropdown filters the rows. It defaults to the host's own environment (`IHostEnvironment.EnvironmentName`), and clearing it shows every environment again. Two behaviours are deliberate:
+
+- **Shared entries are never filtered out.** They apply to every environment, so they stay listed whichever environment is selected — a filter that hid them would conceal more configuration than having no columns did.
+- **When the host's environment has no entries, no filter is applied.** Selecting an arbitrary environment instead would hide values the operator can edit.
+
+The dropdown is not rendered at all when every entry is shared, since there would be nothing to filter on.
+
+> The row actions (edit, reset, delete) have always acted on the row's own application/environment/instance. The columns exist so the operator can see which scope that is before acting on it.
+
 ## Log viewer
 
 View and search Application Insights logs with the `LogView` component. Requires the Application Insights client to be configured in one of two modes (mutually exclusive):


### PR DESCRIPTION
## The problem

`RemoteConfigurationAdmin` rendered only Key, Value, Default, Ttl and LastUsed, while
`RemoteConfigCallService.GetAllAsync` deliberately does no client-side filtering — it returns every
entry the team's API key can read. One key therefore appears once per application × environment ×
instance as **apparent duplicate rows**, with nothing on screen saying which scope each is.

The sharp edge: the row's own edit/reset/delete already pass
`context.Application/Environment/Instance`, so the operator was acting on a scope the UI never
showed them.

Reported against the Server page `/developer/configuration`, but the grid is the Toolkit's.

## What this adds

- **Application** and **Environment** columns, sortable like the rest.
- An **Instance** column, rendered only when at least one loaded entry carries an instance.
- An **environment dropdown** above the grid, defaulting to the host's environment. Not rendered at
  all when every entry is shared, since there would be nothing to filter on.
- A shared scope renders as **`(all)`** rather than a blank cell — `Application`/`Environment`/
  `Instance` are declared `required string`, but a shared entry legitimately arrives null, and a
  blank reads as missing data rather than as a deliberate "not scoped".

Filter and label rules live in a new internal static `ConfigurationScope`, testable without bUnit —
same shape as `TtlFormat` in the same folder.

## Two behaviours that are deliberate

Both are tested, because getting either wrong makes the filter hide *more* configuration than the
missing columns did — which would be worse than the bug being fixed.

1. **Shared entries always pass the filter.** They have no environment and apply to every one of
   them, so a naive equality predicate would drop exactly the entries that are in force everywhere.
2. **An unrepresented host environment applies no filter**, rather than falling back to the first
   available option. `LogEnvironmentSelector` does fall back that way, but it is a read-only log
   view; here an arbitrary default would hide values the operator can edit.

`Instance` deliberately gets no permanent column: `configuration-content-ui-spec.md` asks for the
Instance and Version *levels* to be removed as unused, and the Server's own grid already has both
commented out. It still has to be visible when set, or two entries differing only by instance are
indistinguishable again.

## One deviation worth review

`IHostEnvironment` is resolved via `IServiceProvider.GetService<IHostEnvironment>()` rather than
`@inject`ed. A Blazor **WebAssembly** host has no `IHostEnvironment` at all, and an `@inject` on an
unregistered service fails at *render* time — the same trap the toolkit's `EnvironmentName` record
carries (it is constructed inline in each registration factory, never registered). No host
environment simply means no default filter.

`LogEnvironmentSelector` has the same latent problem; left alone as out of scope here.

## Verification

- Clean Release build, 0 errors.
- **553 tests green**, 24 of them new — 16 unit (`ConfigurationScopeTests`) + 8 bUnit
  (`RemoteConfigurationAdminScopeTests`).
- Warning ratchet: 134 against a baseline of 248; none from the new files.

## Follow-ups (recorded in the backlog, not in this PR)

- The Server's own `/configuration` page needs the same filter — spec'd but unstarted in
  `04-configuration-ui-improvements.md` §3. It already has the columns.
- **Wording split:** this grid says `(all)`; the Server page already ships `(shared)` for the same
  concept. One operator reads both pages, so they should be aligned.
