### PR TITLE
Handle 429 and honour Retry-After (#172)

### DIFF
--- a/Quilt4Net.Toolkit.Tests/ContentRateLimitedTests.cs
+++ b/Quilt4Net.Toolkit.Tests/ContentRateLimitedTests.cs
@@ -1,0 +1,230 @@
+using System.Net;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Quilt4Net.Toolkit.Features.Content;
+using Quilt4Net.Toolkit.Features.FeatureToggle;
+using Quilt4Net.Toolkit.Framework;
+using Xunit;
+
+namespace Quilt4Net.Toolkit.Tests;
+
+// The Quilt4Net server is gaining a per-caller concurrency limiter, which converts what used to be a
+// multi-minute hang into an immediate 429. That is only an improvement if the client understands it:
+// a 429 must degrade to cache-or-default quietly and must honour the server's Retry-After rather than
+// retrying straight back into the overload that produced it.
+//
+// Before this, a 429 fell into the generic non-2xx branch: logged at Error (one line per key per
+// render under load) and negative-cached the caller's *default*, discarding a good cached value.
+public class ContentRateLimitedTests
+{
+    [Fact]
+    public async Task Rate_Limited_429_Falls_Back_To_Default_Without_Throwing()
+    {
+        using var listener = StartListener(out var prefix, out _, HttpStatusCode.TooManyRequests, retryAfterSeconds: 30);
+        var service = BuildContentService(prefix, new RecordingLoggerProvider());
+
+        var (value, success) = await service.GetContentAsync("Any.Key", "the-default", Guid.NewGuid(), ContentFormat.String, application: "App");
+
+        value.Should().Be("the-default", "a rejected call must degrade to the caller's default, not surface an error");
+        success.Should().BeFalse("the value did not come from the server");
+    }
+
+    [Fact]
+    public async Task Rate_Limited_429_Is_Logged_At_Warning_Not_Error()
+    {
+        using var listener = StartListener(out var prefix, out _, HttpStatusCode.TooManyRequests, retryAfterSeconds: 30);
+        var recorder = new RecordingLoggerProvider();
+        var service = BuildContentService(prefix, recorder);
+
+        await service.GetContentAsync("Any.Key", "the-default", Guid.NewGuid(), ContentFormat.String, application: "App");
+
+        recorder.Entries.Should().NotContain(e => e.Level == LogLevel.Error,
+            "backpressure is designed behaviour on both sides — logging it at Error makes a healthy shed look like an outage");
+        recorder.Entries.Should().Contain(e => e.Level == LogLevel.Warning && e.Message.Contains("429"),
+            "a 429 is still worth seeing, at Warning");
+    }
+
+    [Fact]
+    public async Task Rate_Limited_429_Does_Not_Re_Request_Before_Retry_After_Elapses()
+    {
+        // The property that stops the client deepening the overload that rejected it.
+        using var listener = StartListener(out var prefix, out var requestCount, HttpStatusCode.TooManyRequests, retryAfterSeconds: 30);
+        var service = BuildContentService(prefix, new RecordingLoggerProvider());
+        var languageKey = Guid.NewGuid();
+
+        for (var i = 0; i < 5; i++)
+            await service.GetContentAsync("Any.Key", "the-default", languageKey, ContentFormat.String, application: "App");
+
+        requestCount().Should().Be(1,
+            "Retry-After said 30s, so five renders inside that window must produce exactly one call");
+    }
+
+    [Fact]
+    public async Task Rate_Limited_429_Keeps_A_Previously_Cached_Value_Instead_Of_The_Default()
+    {
+        // The user-visible half of Toolkit issue #172: overwriting a good Swedish value with the
+        // English default makes server backpressure look like a translation regression.
+        using var listener = StartSwitchableListener(out var prefix, out var mode);
+        // Stale-while-revalidate off, so an expired entry takes the *foreground* refresh — the path
+        // that used to overwrite it with the caller's default. With SWR on, the background path
+        // already preserved the stale value.
+        var service = BuildContentService(prefix, new RecordingLoggerProvider(), staleWhileRevalidate: false);
+        var languageKey = Guid.NewGuid();
+
+        // Already expired, so the very next resolve must go back to the server rather than be served
+        // from cache — no sleeping in the test.
+        mode.Serve("the-server-value", validFor: TimeSpan.FromSeconds(-1));
+        var (first, firstSuccess) = await service.GetContentAsync("Any.Key", "the-default", languageKey, ContentFormat.String, application: "App");
+        first.Should().Be("the-server-value");
+        firstSuccess.Should().BeTrue();
+
+        mode.RateLimit(retryAfterSeconds: 30);
+
+        var (second, _) = await service.GetContentAsync("Any.Key", "the-default", languageKey, ContentFormat.String, application: "App");
+
+        second.Should().Be("the-server-value",
+            "a 429 says nothing about the content, so a value already held must survive it");
+    }
+
+    private static IContentService BuildContentService(string baseAddress, ILoggerProvider loggerProvider, bool staleWhileRevalidate = true)
+    {
+        var host = Host.CreateDefaultBuilder()
+            .ConfigureServices(services =>
+            {
+                services.AddQuilt4NetContent(null, o =>
+                {
+                    o.Quilt4NetAddress = baseAddress;
+                    o.ApiKey = "test-key";
+                    o.WarmUpEnabled = false;
+                    o.StaleWhileRevalidate = staleWhileRevalidate;
+                });
+                services.AddLogging(b =>
+                {
+                    b.ClearProviders();
+                    b.SetMinimumLevel(LogLevel.Debug);
+                    b.AddProvider(loggerProvider);
+                });
+            })
+            .Build();
+
+        return host.Services.GetRequiredService<IContentService>();
+    }
+
+    private static HttpListener StartListener(out string prefix, out Func<int> requestCount, HttpStatusCode status, int? retryAfterSeconds = null)
+    {
+        var listener = Listen(out prefix);
+        var hits = 0;
+        requestCount = () => Volatile.Read(ref hits);
+
+        _ = Task.Run(async () =>
+        {
+            while (listener.IsListening)
+            {
+                HttpListenerContext ctx;
+                try { ctx = await listener.GetContextAsync(); }
+                catch { return; }
+
+                Interlocked.Increment(ref hits);
+                ctx.Response.StatusCode = (int)status;
+                if (retryAfterSeconds != null)
+                    ctx.Response.Headers["Retry-After"] = retryAfterSeconds.Value.ToString();
+                ctx.Response.Close();
+            }
+        });
+
+        return listener;
+    }
+
+    private static HttpListener StartSwitchableListener(out string prefix, out ResponseMode mode)
+    {
+        var listener = Listen(out prefix);
+        var state = new ResponseMode();
+        mode = state;
+
+        _ = Task.Run(async () =>
+        {
+            while (listener.IsListening)
+            {
+                HttpListenerContext ctx;
+                try { ctx = await listener.GetContextAsync(); }
+                catch { return; }
+
+                var (status, retryAfter, body, validFor) = state.Current;
+                ctx.Response.StatusCode = (int)status;
+                if (retryAfter != null) ctx.Response.Headers["Retry-After"] = retryAfter.Value.ToString();
+                if (body != null)
+                {
+                    var json = $"{{\"value\":\"{body}\",\"validTo\":\"{DateTime.UtcNow.Add(validFor):O}\"}}";
+                    var bytes = System.Text.Encoding.UTF8.GetBytes(json);
+                    ctx.Response.ContentType = "application/json";
+                    await ctx.Response.OutputStream.WriteAsync(bytes);
+                }
+                ctx.Response.Close();
+            }
+        });
+
+        return listener;
+    }
+
+    private static HttpListener Listen(out string prefix)
+    {
+        var port = GetFreePort();
+        prefix = $"http://127.0.0.1:{port}/";
+        var listener = new HttpListener();
+        listener.Prefixes.Add(prefix);
+        listener.Start();
+        return listener;
+    }
+
+    private static int GetFreePort()
+    {
+        using var l = new System.Net.Sockets.TcpListener(IPAddress.Loopback, 0);
+        l.Start();
+        var port = ((IPEndPoint)l.LocalEndpoint).Port;
+        l.Stop();
+        return port;
+    }
+
+    private sealed class ResponseMode
+    {
+        private volatile Tuple<HttpStatusCode, int?, string, TimeSpan> _current =
+            Tuple.Create(HttpStatusCode.OK, (int?)null, (string)null, TimeSpan.FromMinutes(10));
+
+        public (HttpStatusCode Status, int? RetryAfter, string Body, TimeSpan ValidFor) Current =>
+            (_current.Item1, _current.Item2, _current.Item3, _current.Item4);
+
+        public void Serve(string body, TimeSpan? validFor = null) =>
+            _current = Tuple.Create(HttpStatusCode.OK, (int?)null, body, validFor ?? TimeSpan.FromMinutes(10));
+
+        public void RateLimit(int retryAfterSeconds) =>
+            _current = Tuple.Create(HttpStatusCode.TooManyRequests, (int?)retryAfterSeconds, (string)null, TimeSpan.Zero);
+    }
+
+    private sealed class RecordingLoggerProvider : ILoggerProvider
+    {
+        public List<(LogLevel Level, string Message)> Entries { get; } = new();
+        public ILogger CreateLogger(string categoryName) => new RecordingLogger(Entries);
+        public void Dispose() { }
+
+        private sealed class RecordingLogger : ILogger
+        {
+            private readonly List<(LogLevel, string)> _entries;
+            public RecordingLogger(List<(LogLevel, string)> entries) => _entries = entries;
+            public IDisposable BeginScope<TState>(TState state) where TState : notnull => NullScope.Instance;
+            public bool IsEnabled(LogLevel logLevel) => true;
+            public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception,
+                Func<TState, Exception, string> formatter)
+            {
+                lock (_entries) _entries.Add((logLevel, formatter(state, exception)));
+            }
+        }
+
+        private sealed class NullScope : IDisposable
+        {
+            public static readonly NullScope Instance = new();
+            public void Dispose() { }
+        }
+    }
+}

--- a/Quilt4Net.Toolkit/Features/Content/RemoteContentCallService.cs
+++ b/Quilt4Net.Toolkit/Features/Content/RemoteContentCallService.cs
@@ -423,15 +423,33 @@ internal class RemoteContentCallService : IRemoteContentCallService
                     // Warning: falling back to the caller's Default is the designed behaviour.
                     _logger.LogInformation("No content override for key '{Key}' (404). Using default value.", key);
                 }
+                else if (response.StatusCode == HttpStatusCode.TooManyRequests)
+                {
+                    // Warning, not Error: a 429 is the server applying backpressure, which is designed
+                    // behaviour on both sides — not a fault to page someone about. Logging it at Error
+                    // would make a healthy shed look like an outage, and under load it is the single
+                    // most repeated line there is.
+                    _logger.LogWarning("Rate limited (429) getting content for key '{Key}'. Backing off for {RetryAfter}.",
+                        key, RetryAfterOf(response)?.ToString() ?? "the default failure duration");
+                }
                 else
                 {
                     _logger.LogError("Unable to get content for key '{Key}'. Response was {StatusCode} {ReasonPhrase}.",
                         key, response.StatusCode, response.ReasonPhrase);
                 }
+
+                // Prefer a value already cached over the caller's default. A 429 says nothing about the
+                // content, so overwriting a good Swedish value with the English default would make
+                // backpressure look like a translation regression — the half-translated page in
+                // Toolkit issue #172. The other failure branches keep the same preference.
+                var fallbackValue = _localCache.TryGetValue(cacheKey, out var cachedOnFailure)
+                    ? cachedOnFailure.Value
+                    : defaultValue;
+
                 // Negative-cache either way so the key isn't re-requested (and re-logged) every render.
-                CacheFailure(cacheKey, defaultValue);
+                CacheFailure(cacheKey, fallbackValue, RetryAfterOf(response));
                 LogResolved(key, languageKey, effectiveApplication, sw.ElapsedMilliseconds, ContentSource.Default, stale: true);
-                return Result(defaultValue, false, ContentSource.Default, true);
+                return Result(fallbackValue, false, ContentSource.Default, true);
             }
 
             var result = await response.Content.ReadFromJsonAsync<GetContentResponse>(cancellationToken: cts.Token);
@@ -504,13 +522,18 @@ internal class RemoteContentCallService : IRemoteContentCallService
                         // negative cache to once per key per refresh cycle.
                         _logger.LogInformation("Background refresh for content '{Key}': no override (404). Keeping default value.", key);
                     }
+                    else if (response.StatusCode == HttpStatusCode.TooManyRequests)
+                    {
+                        _logger.LogWarning("Background refresh for content '{Key}' was rate limited (429). Backing off for {RetryAfter}.",
+                            key, RetryAfterOf(response)?.ToString() ?? "the default failure duration");
+                    }
                     else
                     {
                         _logger.LogError("Background refresh for content '{Key}' failed. Response was {StatusCode} {ReasonPhrase}.",
                             key, response.StatusCode, response.ReasonPhrase);
                     }
                     var staleValue = _localCache.TryGetValue(cacheKey, out var s) ? s.Value : defaultValue;
-                    CacheFailure(cacheKey, staleValue);
+                    CacheFailure(cacheKey, staleValue, RetryAfterOf(response));
                     return;
                 }
 
@@ -577,9 +600,44 @@ internal class RemoteContentCallService : IRemoteContentCallService
 
     // Negative cache. IsDefault marks the entry as a fallback rather than server content, so a later
     // hit reports ContentSource.Default instead of masquerading as a cache hit.
-    private void CacheFailure(string cacheKey, string value)
+    /// <summary>
+    /// How long to hold off after a <c>429 Too Many Requests</c>, from the server's own
+    /// <c>Retry-After</c> header. Returns null when the response is not a 429 or carries no usable
+    /// header, in which case the caller's normal negative-cache duration applies.
+    /// </summary>
+    /// <remarks>
+    /// The server is telling us when it will be ready. Ignoring that and falling back to the last
+    /// successful TTL — which is a *content freshness* interval and has nothing to do with
+    /// backpressure — either retries far too early and deepens the overload that caused the 429, or
+    /// sits out a multi-minute TTL when the server asked for a few seconds.
+    /// <para>
+    /// RFC 9110 allows either delta-seconds or an HTTP-date; <see cref="HttpResponseHeaders.RetryAfter"/>
+    /// surfaces both, so both are handled. A date in the past yields <see cref="TimeSpan.Zero"/>, which
+    /// is treated as "no advice" rather than "retry immediately".
+    /// </para>
+    /// </remarks>
+    private static TimeSpan? RetryAfterOf(HttpResponseMessage response)
     {
-        var duration = _lastKnownTtl.GetValueOrDefault(cacheKey, _contentOptions.FailureCacheDuration);
+        if (response.StatusCode != HttpStatusCode.TooManyRequests) return null;
+
+        var retryAfter = response.Headers.RetryAfter;
+        if (retryAfter == null) return null;
+
+        if (retryAfter.Delta is { } delta && delta > TimeSpan.Zero) return delta;
+
+        if (retryAfter.Date is { } date)
+        {
+            var wait = date - DateTimeOffset.UtcNow;
+            if (wait > TimeSpan.Zero) return wait;
+        }
+
+        return null;
+    }
+
+    private void CacheFailure(string cacheKey, string value, TimeSpan? overrideDuration = null)
+    {
+        var duration = overrideDuration
+                       ?? _lastKnownTtl.GetValueOrDefault(cacheKey, _contentOptions.FailureCacheDuration);
         var failureResponse = new CachedContent
         {
             Value = value,


### PR DESCRIPTION
Part of #172.

The Quilt4Net server is gaining a per-caller concurrency limiter, which turns what used to be a multi-minute hang into an immediate `429`. That is only an improvement if the client understands one — and a grep found **no handling of 429 or `Retry-After` anywhere** in the toolkit.

### What a 429 used to do

It fell into the generic non-2xx branch, which:

- logged at **Error** — one line per key per render under load, making designed backpressure look like an outage; and
- negative-cached the **caller's default**, discarding a good cached value. That is the user-visible half of #172: a page half-rendered in English because the server was busy, indistinguishable on screen from a missing translation.

### What it does now

- logs at **Warning**, not Error;
- takes the negative-cache duration from the server's **`Retry-After`** (delta-seconds or HTTP-date, per RFC 9110) instead of the last successful content TTL — that TTL is a *freshness* interval and says nothing about backpressure, so the old behaviour either retried straight back into the overload or sat out a multi-minute wait when the server asked for seconds;
- keeps a value **already cached** rather than replacing it with the caller's default.

Applies to both the foreground resolve and the background refresh.

### Context from production

Measured in App Insights on 2026-08-29, `Eplicta.FortDocs.Web` against `quilt4net.com` in one burst hour:

| Env | Calls | Failed | p50 | p95 |
|---|---|---|---|---|
| Test | 277 | 244 (88%) | 49 s | 212 s |
| Production | 16 | **16 (100%)** | **154 s** | 180 s |
| CI | 10 | 10 (100%) | 154 s | 201 s |

Test and CI were 95% of tagged traffic and starved Production to a 100% failure rate. The server-side fix (per-caller partitioning plus a concurrency limiter) is ready on its own branch.

### Note on `HttpTimeout`

Worth saying explicitly for #172: `ContentOptions.HttpTimeout` is already configurable and defaults to **5 seconds**. FortDocs sets it *up* to 15 s in its own `appsettings.json`. Lowering that is a consumer-side change, not a toolkit one.

### Tests

Four new tests covering fall-back-to-default, Warning-not-Error, no re-request inside the `Retry-After` window, and cache preservation. **563 toolkit tests green.**

### Ordering

⚠️ This must be released to NuGet **and picked up by consumers** before the server's concurrency limiter is enabled in production. Enabling the server first converts hangs into errors the deployed client does not understand.
